### PR TITLE
Add project attribution to the interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@ All notable public changes will be recorded here.
   debounced inputs and safe fire-button startup behavior.
 - Clarified that complete-release Python setup must be run from its `Dashboard`
   folder so the launcher can use the project-local virtual environment.
+- Added project, version, author, GitHub, and license information to the
+  launcher and dashboard.

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -29,6 +29,10 @@ from tkinter import scrolledtext
 HERE = Path(__file__).resolve().parent
 DASHBOARD = HERE / "ksp_mission_dashboard.html"
 PYTHON = sys.executable
+APP_NAME = "Woobie's Mission Control"
+APP_VERSION = "0.1.0"
+APP_AUTHOR = "SacredWoobie"
+PROJECT_URL = "https://github.com/SacredWoobie/woobies-mission-control"
 
 # Add future optional programs here. The GUI will expose a component only when
 # its script is present beside this launcher.
@@ -140,9 +144,21 @@ class App:
         self.backends = []
         self.backend_rows = []
 
-        root.title("KSP Components")
+        root.title(f"{APP_NAME} v{APP_VERSION}")
         root.minsize(600, 360)
         root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        header = tk.Frame(root)
+        header.pack(fill="x", padx=10, pady=(10, 2))
+        tk.Label(
+            header,
+            text=f"{APP_NAME}  v{APP_VERSION}",
+            anchor="w",
+            font=("TkDefaultFont", 11, "bold"),
+        ).pack(side="left")
+        tk.Button(header, text="About", width=8, command=self._show_about).pack(
+            side="right"
+        )
 
         components = discover_components()
         if components:
@@ -254,6 +270,58 @@ class App:
             webbrowser.open(DASHBOARD.as_uri() + "?autoconnect=1")
         except Exception as exc:
             self._enqueue("launcher", f"couldn't open browser: {exc}")
+
+    def _open_project_page(self):
+        try:
+            webbrowser.open(PROJECT_URL)
+        except Exception as exc:
+            self._enqueue("launcher", f"couldn't open GitHub: {exc}")
+
+    def _show_about(self):
+        dialog = tk.Toplevel(self.root)
+        dialog.title(f"About {APP_NAME}")
+        dialog.transient(self.root)
+        dialog.resizable(False, False)
+
+        body = tk.Frame(dialog, padx=18, pady=16)
+        body.pack(fill="both", expand=True)
+        tk.Label(
+            body,
+            text=APP_NAME,
+            font=("TkDefaultFont", 13, "bold"),
+        ).pack(anchor="w")
+        tk.Label(body, text=f"Version {APP_VERSION}").pack(anchor="w", pady=(2, 10))
+        tk.Label(body, text=f"Created by {APP_AUTHOR}").pack(anchor="w")
+        tk.Label(body, text="Released under the MIT License").pack(anchor="w")
+
+        link = tk.Label(
+            body,
+            text=PROJECT_URL,
+            fg="#1a5fb4",
+            cursor="hand2",
+        )
+        link.pack(anchor="w", pady=(10, 12))
+        link.bind("<Button-1>", lambda _event: self._open_project_page())
+
+        buttons = tk.Frame(body)
+        buttons.pack(fill="x")
+        tk.Button(buttons, text="Open GitHub", command=self._open_project_page).pack(
+            side="left"
+        )
+        tk.Button(buttons, text="Close", width=8, command=dialog.destroy).pack(
+            side="right"
+        )
+
+        dialog.update_idletasks()
+        x = self.root.winfo_rootx() + max(
+            0, (self.root.winfo_width() - dialog.winfo_width()) // 2
+        )
+        y = self.root.winfo_rooty() + max(
+            0, (self.root.winfo_height() - dialog.winfo_height()) // 2
+        )
+        dialog.geometry(f"+{x}+{y}")
+        dialog.grab_set()
+        dialog.focus_set()
 
     def _refresh(self):
         for backend, status, button in self.backend_rows:

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -3,7 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MISSION CONTROL — kRPC</title>
+<meta name="author" content="SacredWoobie">
+<meta name="application-name" content="Woobie's Mission Control">
+<title>Woobie's Mission Control — kRPC</title>
 <style>
   /* =========================================================================
      ORBITAL TELEMETRY — flight-computer MFD aesthetic
@@ -49,6 +51,15 @@
   @media (prefers-reduced-motion: reduce){ *{animation:none !important; transition:none !important} }
 
   .wrap{max-width:1180px;margin:0 auto;display:flex;flex-direction:column;gap:12px}
+  .project-footer{
+    max-width:1180px;margin:12px auto 2px;padding:10px 4px 2px;
+    border-top:1px solid var(--rule);color:var(--slate-dim);
+    font-size:9px;letter-spacing:.08em;text-align:center;text-transform:uppercase;
+  }
+  .project-footer .sep{margin:0 7px;color:var(--rule-bright)}
+  .project-footer a{color:var(--slate);text-decoration:none}
+  .project-footer a:hover{color:var(--cyan);text-decoration:underline}
+  .project-footer a:focus-visible{outline:1px solid var(--cyan);outline-offset:2px}
   .deck > .panel{break-inside:avoid;margin-bottom:12px;width:100%}
   @media (min-width:980px){
     .deck{column-count:2;column-gap:12px}
@@ -649,6 +660,13 @@
 
   </div><!-- /deck -->
 </div>
+
+<footer class="project-footer" aria-label="Project information">
+  <span>Woobie's Mission Control v0.1.0</span><span class="sep">·</span>
+  <span>by SacredWoobie</span><span class="sep">·</span>
+  <a href="https://github.com/SacredWoobie/woobies-mission-control" target="_blank" rel="noopener noreferrer">GitHub</a><span class="sep">·</span>
+  <a href="https://github.com/SacredWoobie/woobies-mission-control/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
+</footer>
 
 <script>
 /* ==========================================================================


### PR DESCRIPTION
## What changed

- Adds Woobie's Mission Control name and version to the launcher title and header.
- Adds an About dialog with author, license, and GitHub links.
- Adds a compact non-sticky author/version/GitHub/license footer to the dashboard.
- Records the interface attribution in the v0.1.0 changelog.

## Why

This makes distributed copies easy to identify and gives users a direct path to the project, license, and issue tracker without cluttering the operational displays.

## Validation

- Python source compilation passed.
- Launcher metadata and optional-component discovery checks passed.
- Dashboard JavaScript syntax validation passed.
- HTML parsing and single-footer structure checks passed.
- Privacy and artifact scans passed.
- Final source and complete-release ZIP integrity checks passed.