### PR TITLE
Fix draft release check on Windows PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable public changes will be recorded here.
 - Preserved the v0.1.0 layout on narrower and vertical displays.
 - Added an audited PowerShell release packager with optional draft GitHub
   Release creation.
+- Fixed the unused-version check under Windows PowerShell 5.1.
 
 ## v0.1.0 - Initial public test release
 

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -175,8 +175,12 @@ if ($CreateDraftRelease) {
 
     Invoke-CheckedCommand -Command 'gh' -Arguments @('auth', 'status', '--hostname', 'github.com')
 
-    & gh release view "v$Version" --repo $Repository *> $null
-    if ($LASTEXITCODE -eq 0) {
+    $releaseListJson = & gh release list --repo $Repository --limit 1000 --json tagName
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to check existing GitHub Releases.'
+    }
+    $existingReleaseTags = @($releaseListJson | ConvertFrom-Json | ForEach-Object { $_.tagName })
+    if ($existingReleaseTags -contains "v$Version") {
         throw "A GitHub Release for v$Version already exists."
     }
 


### PR DESCRIPTION
## What changed

- replaces the expected-failure `gh release view` probe with a successful `gh release list --json tagName` query
- still blocks creation when the requested release tag already exists
- records the Windows PowerShell 5.1 fix in the v0.1.1 changelog

## Why

On Windows PowerShell 5.1, `gh release view` writes `release not found` to stderr when a version is unused. With the script's stop-on-error setting, PowerShell terminated before the script could treat that result as the expected all-clear.

## Validation

- branch is based on the current `main` after PR #4
- change is limited to the release-existence check and changelog
- the replacement command exits successfully for an empty release list, avoiding the PowerShell stderr behavior