### PR TITLE
Handle an unused release tag in Windows PowerShell

### DIFF
--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -184,12 +184,11 @@ if ($CreateDraftRelease) {
         throw "A GitHub Release for v$Version already exists."
     }
 
-    $remoteTag = [string](& git -C $repoRoot ls-remote --tags origin "refs/tags/v$Version")
-    $remoteTag = $remoteTag.Trim()
+    $remoteTag = @(& git -C $repoRoot ls-remote --tags origin "refs/tags/v$Version")
     if ($LASTEXITCODE -ne 0) {
         throw 'Unable to check the remote release tag.'
     }
-    if ($remoteTag) {
+    if ($remoteTag.Count -gt 0) {
         throw "The tag v$Version already exists on the remote."
     }
 }


### PR DESCRIPTION
## What changed

- stores `git ls-remote` output in an always-present array
- checks the array count instead of calling `.Trim()` on a possibly null result

## Why

An unused version correctly produces no output from `git ls-remote`. Windows PowerShell 5.1 represented that empty native-command result as null, causing the previous `.Trim()` call to terminate the script before packaging or draft creation.

## Validation

- change is limited to the empty-tag handling
- no-output now becomes an empty array and passes the unused-tag check
- one or more matching remote tag lines still block duplicate release creation