### PR TITLE
Filter KSP Recall bookkeeping resources

### DIFF
--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -31,6 +31,15 @@ RES_POLL_SECONDS = 0.5    # 2N calls for N resources aboard
 TGT_POLL_SECONDS = 0.5    # target + docking geometry
 STAGE_POLL_SECONDS = 0.5  # dv changes continuously during a burn; ~2 Hz readout
 
+# KSP Recall exposes these internal refund-bookkeeping resources through kRPC.
+# They are implementation details, not vessel consumables. Match normalized
+# names so case and punctuation differences across mod versions do not matter.
+_HIDDEN_RESOURCE_NAMES = frozenset({
+    "stealback",
+    "stealbackmyfunds",
+    "refundingforksp111x",
+})
+
 _sci_cache = {}
 _sci_last_poll = 0.0
 _heat_cache = {}
@@ -72,6 +81,14 @@ def _mag(v):
     return math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
 
 
+def _normalized_resource_name(name):
+    return "".join(ch for ch in str(name).casefold() if ch.isalnum())
+
+
+def _is_consumable_resource(name):
+    return _normalized_resource_name(name) not in _HIDDEN_RESOURCE_NAMES
+
+
 def _current_stage(vessel):
     """Current stage index, or None if this kRPC build doesn't expose it."""
     global _HAS_CURRENT_STAGE
@@ -99,12 +116,7 @@ def _gather_resources(vessel):
     out = {}
     try:
         res = vessel.resources
-        # KSP Recall uses StealBack as an internal bookkeeping resource. It is
-        # not a consumable and should never become a dashboard row.
-        names = [
-            name for name in res.names
-            if "".join(ch for ch in name.lower() if ch.isalnum()) != "stealback"
-        ]
+        names = [name for name in res.names if _is_consumable_resource(name)]
     except Exception:
         return {}
 
@@ -125,6 +137,8 @@ def _gather_resources(vessel):
             # stage through all later stages, including never-decoupled parts.
             sres = vessel.resources_in_decouple_stage(stage=stage - 1, cumulative=True)
             for n in sres.names:
+                if not _is_consumable_resource(n):
+                    continue
                 try:
                     out[f"r.resourceCurrent[{n}]"] = sres.amount(n)
                     out[f"r.resourceCurrentMax[{n}]"] = sres.max(n)


### PR DESCRIPTION
## Summary

- restore filtering for KSP Recall's `StealBackMyFunds` and `RefundingForKSP111x` bookkeeping resources
- retain compatibility with the shorter `StealBack` name
- normalize case and punctuation before matching
- apply the same filter to vessel-total and current-stage resource telemetry

## Root cause

The dashboard displays every name provided in `res.names`. The telemetry server only excluded the exact normalized name `stealback`, while KSP Recall reports `StealBackMyFunds`. That name therefore passed through and appeared in the narrow dashboard label as “STEAL BACK”.

## Impact

Internal KSP Recall refund bookkeeping will no longer appear as consumables. Normal vessel resources remain unchanged.

## Validation

- parsed the updated module with Python's AST parser
- verified the filter rejects `StealBack`, `StealBackMyFunds`, punctuation/case variants, and `RefundingForKSP111x`
- verified normal resources such as `ElectricCharge`, `LiquidFuel`, and `MonoPropellant` remain visible
- confirmed the branch is one commit ahead of `main` and changes only `telemetry_server.py`