### PR TITLE
Prepare Woobie's Mission Control v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable public changes will be recorded here.
 
+## v0.1.2 - KSP Recall consumables fix
+
+- Restored filtering for KSP Recall's internal `StealBackMyFunds`,
+  `RefundingForKSP111x`, and shorter `StealBack` bookkeeping resources.
+- Normalized resource names before filtering so case and punctuation variations
+  do not expose internal resources in the Consumables panel.
+- Applied the filter consistently to vessel-total and current-stage telemetry.
+
 ## v0.1.1 - Widescreen layout
 
 - Added a responsive layout for horizontal displays at 1440 pixels and wider.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Woobie's Mission Control
 
-Current release: **v0.1.1**
+Current release: **v0.1.2**
 
 A modular mission dashboard and optional ESP32 control-pad bridge for Kerbal
 Space Program 1, powered by [kRPC](https://krpc.github.io/krpc/).
@@ -272,7 +272,7 @@ From a clean, up-to-date `main` checkout, first create and audit the package
 without changing anything on GitHub:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.2
 ```
 
 The script writes the ZIP, SHA-256 checksum, and generated release notes to the
@@ -292,7 +292,7 @@ Open a new PowerShell window after installation, authenticate once with
 `gh auth login`, and then rerun:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.1 -CreateDraftRelease
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.2 -CreateDraftRelease
 ```
 
 The release remains private as a draft until it is reviewed and published on

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -30,7 +30,7 @@ HERE = Path(__file__).resolve().parent
 DASHBOARD = HERE / "ksp_mission_dashboard.html"
 PYTHON = sys.executable
 APP_NAME = "Woobie's Mission Control"
-APP_VERSION = "0.1.1"
+APP_VERSION = "0.1.2"
 APP_AUTHOR = "SacredWoobie"
 PROJECT_URL = "https://github.com/SacredWoobie/woobies-mission-control"
 

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -763,7 +763,7 @@
 </div>
 
 <footer class="project-footer" aria-label="Project information">
-  <span>Woobie's Mission Control v0.1.1</span><span class="sep">·</span>
+  <span>Woobie's Mission Control v0.1.2</span><span class="sep">·</span>
   <span>by SacredWoobie</span><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control" target="_blank" rel="noopener noreferrer">GitHub</a><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>


### PR DESCRIPTION
## Summary

- mark v0.1.2 as the current release in the README
- update the launcher and dashboard display versions to 0.1.2
- update the README release-command examples to 0.1.2
- add v0.1.2 release notes for the KSP Recall consumables fix

## Release contents

The v0.1.1 tag is one commit behind current main. The only product change since v0.1.1 is the merged KSP Recall bookkeeping-resource fix from #7.

## Validation

Verified the exact release metadata required by `tools/Publish-Release.ps1`:

- `README.md` contains `Current release: **v0.1.2**`
- `ksp_dashboard_app.py` contains `APP_VERSION = "0.1.2"`
- `ksp_mission_dashboard.html` contains `Mission Control v0.1.2`
- `CHANGELOG.md` contains a `## v0.1.2` section

This PR changes only release metadata and documentation; no DLL rebuild is required for the Python-only hotfix.