### PR TITLE
Fix current-stage consumables and prepare v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable public changes will be recorded here.
 
+## v0.1.3 - Current-stage consumables fix
+
+- Corrected current-stage resource tracking after pure decoupler, separator, or
+  fairing stages.
+- Walked through empty decouple-stage groups and included resources on parts
+  that remain attached through the final stage.
+- Avoided kRPC's cumulative decouple-stage behavior, which excludes the
+  never-decoupled stage `-1` resource group.
+
 ## v0.1.2 - KSP Recall consumables fix
 
 - Restored filtering for KSP Recall's internal `StealBackMyFunds`,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Woobie's Mission Control
 
-Current release: **v0.1.2**
+Current release: **v0.1.3**
 
 A modular mission dashboard and optional ESP32 control-pad bridge for Kerbal
 Space Program 1, powered by [kRPC](https://krpc.github.io/krpc/).
@@ -272,7 +272,7 @@ From a clean, up-to-date `main` checkout, first create and audit the package
 without changing anything on GitHub:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.2
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.3
 ```
 
 The script writes the ZIP, SHA-256 checksum, and generated release notes to the
@@ -292,7 +292,7 @@ Open a new PowerShell window after installation, authenticate once with
 `gh auth login`, and then rerun:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.2 -CreateDraftRelease
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.3 -CreateDraftRelease
 ```
 
 The release remains private as a draft until it is reviewed and published on

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -30,7 +30,7 @@ HERE = Path(__file__).resolve().parent
 DASHBOARD = HERE / "ksp_mission_dashboard.html"
 PYTHON = sys.executable
 APP_NAME = "Woobie's Mission Control"
-APP_VERSION = "0.1.2"
+APP_VERSION = "0.1.3"
 APP_AUTHOR = "SacredWoobie"
 PROJECT_URL = "https://github.com/SacredWoobie/woobies-mission-control"
 

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -763,7 +763,7 @@
 </div>
 
 <footer class="project-footer" aria-label="Project information">
-  <span>Woobie's Mission Control v0.1.2</span><span class="sep">·</span>
+  <span>Woobie's Mission Control v0.1.3</span><span class="sep">·</span>
   <span>by SacredWoobie</span><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control" target="_blank" rel="noopener noreferrer">GitHub</a><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -89,6 +89,37 @@ def _is_consumable_resource(name):
     return _normalized_resource_name(name) not in _HIDDEN_RESOURCE_NAMES
 
 
+def _current_stage_resource_values(vessel, current_stage):
+    """Return the first resource-bearing decouple group below the active stage."""
+    # resources_in_decouple_stage groups parts by when they are discarded, not
+    # by the stage that activated their engines. Pure separator/fairing stages
+    # can therefore be empty, and parts that are never discarded use stage -1.
+    # Walk downward through those gaps instead of assuming current_stage - 1 is
+    # always the resource-bearing group. cumulative=False is deliberate: kRPC's
+    # cumulative direction does not include the never-decoupled -1 group.
+    for decouple_stage in range(current_stage - 1, -2, -1):
+        try:
+            resources = vessel.resources_in_decouple_stage(
+                stage=decouple_stage,
+                cumulative=False,
+            )
+            values = {}
+            for name in resources.names:
+                if not _is_consumable_resource(name):
+                    continue
+                try:
+                    maximum = resources.max(name)
+                    if maximum > 0:
+                        values[name] = (resources.amount(name), maximum)
+                except Exception:
+                    pass
+            if values:
+                return decouple_stage, values
+        except Exception:
+            pass
+    return None, {}
+
+
 def _current_stage(vessel):
     """Current stage index, or None if this kRPC build doesn't expose it."""
     global _HAS_CURRENT_STAGE
@@ -132,20 +163,12 @@ def _gather_resources(vessel):
     # Distinguish an unavailable stage index from a valid stage with no resources.
     out["res.stageKnown"] = (stage is not None)
     if stage is not None:
-        try:
-            # cumulative=True represents resources available from the current
-            # stage through all later stages, including never-decoupled parts.
-            sres = vessel.resources_in_decouple_stage(stage=stage - 1, cumulative=True)
-            for n in sres.names:
-                if not _is_consumable_resource(n):
-                    continue
-                try:
-                    out[f"r.resourceCurrent[{n}]"] = sres.amount(n)
-                    out[f"r.resourceCurrentMax[{n}]"] = sres.max(n)
-                except Exception:
-                    pass
-        except Exception:
-            pass
+        resource_stage, stage_values = _current_stage_resource_values(vessel, stage)
+        if resource_stage is not None:
+            out["res.stageResourceStage"] = resource_stage
+        for name, (amount, maximum) in stage_values.items():
+            out[f"r.resourceCurrent[{name}]"] = amount
+            out[f"r.resourceCurrentMax[{name}]"] = maximum
 
     return out
 


### PR DESCRIPTION
## Summary

- fix current-stage consumables across empty decoupler, separator, and fairing stages
- fall through to kRPC's never-decoupled stage `-1` resource group
- stop relying on cumulative decouple-stage results
- prepare the complete repository metadata and changelog for v0.1.3

## Root cause

The telemetry server assumed `current_stage - 1` with `cumulative=True` included every resource available to the current and later stages. The captured live vessel data disproved that assumption:

- at current stage 4, the active booster resources were in decouple group 3
- after separation at current stage 2, groups 1 and 0 were empty
- the remaining upper-stage resources were in the never-decoupled group `-1`
- cumulative queries from groups 1 and 0 did not include group `-1`

The dashboard therefore received no `r.resourceCurrentMax[...]` values and rendered dashes.

## Fix

Walk downward from `current_stage - 1` through empty non-cumulative decouple groups, including `-1`, and use the first resource-bearing group. The selected group is also emitted as `res.stageResourceStage` for future diagnostics.

## Release preparation

- README current release and command examples: v0.1.3
- launcher version: 0.1.3
- dashboard footer: v0.1.3
- changelog: new v0.1.3 section

## Validation

- parsed the updated telemetry server with Python's AST parser
- reproduced the captured craft mapping with focused fakes:
  - current stage 4 selects decouple group 3
  - current stage 2 skips groups 1 and 0 and selects group -1
- verified hidden KSP Recall bookkeeping resources do not stop the scan
- verified all metadata checks required by `tools/Publish-Release.ps1`
- confirmed v0.1.2 and main were identical before branching

This is a Python-only correction; no C# service or DLL rebuild is required.