### PR TITLE
Make staging analysis revert-safe for v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable public changes will be recorded here.
 
+## v0.1.5 - Revert-safe staging analysis
+
+- Invalidated the private `KRPC.StageStats` MechJeb-module cache when KSP
+  replaces the active vessel or `MechJebCore`, including after Revert to Launch.
+- Updated `KRPC.StageStats` to `0.1.2` and made the release tool reject older
+  DLLs so a v0.1.5 package cannot silently reuse the revert-unsafe service.
+- Rejected incomplete MechJeb stage arrays instead of relabeling the surviving
+  rows by engine activation stage, which had disguised missing stages as S0/S4.
+- Cleared the last staging snapshot when universal time rewinds and verified
+  the stage count again after each multi-call snapshot to avoid cross-flight or
+  mid-staging data mixes.
+
 ## v0.1.4 - Multi-burn consumables partition
 
 - Split current-stage resources when multiple engine stages remain permanently

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Woobie's Mission Control
 
-Current release: **v0.1.4**
+Current release: **v0.1.5**
 
 A modular mission dashboard and optional ESP32 control-pad bridge for Kerbal
 Space Program 1, powered by [kRPC](https://krpc.github.io/krpc/).
@@ -102,7 +102,7 @@ still need confirmation before release.
 | MechJeb 2 | `2.14.3.0` |
 | KRPC.MechJeb | `0.7.1` |
 | KRPC.SystemHeat service | `0.2.0` |
-| KRPC.StageStats service | `0.1.1` |
+| KRPC.StageStats service | `0.1.2` |
 | KRPC.VesselScience service | `0.1.0` |
 | System Heat | `0.9.1` |
 | Near Future Electrical | `2.0.8` |
@@ -272,7 +272,7 @@ From a clean, up-to-date `main` checkout, first create and audit the package
 without changing anything on GitHub:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.4
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.5
 ```
 
 The script writes the ZIP, SHA-256 checksum, and generated release notes to the
@@ -292,7 +292,7 @@ Open a new PowerShell window after installation, authenticate once with
 `gh auth login`, and then rerun:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.4 -CreateDraftRelease
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.5 -CreateDraftRelease
 ```
 
 The release remains private as a draft until it is reviewed and published on

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -30,7 +30,7 @@ HERE = Path(__file__).resolve().parent
 DASHBOARD = HERE / "ksp_mission_dashboard.html"
 PYTHON = sys.executable
 APP_NAME = "Woobie's Mission Control"
-APP_VERSION = "0.1.4"
+APP_VERSION = "0.1.5"
 APP_AUTHOR = "SacredWoobie"
 PROJECT_URL = "https://github.com/SacredWoobie/woobies-mission-control"
 

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -763,7 +763,7 @@
 </div>
 
 <footer class="project-footer" aria-label="Project information">
-  <span>Woobie's Mission Control v0.1.4</span><span class="sep">·</span>
+  <span>Woobie's Mission Control v0.1.5</span><span class="sep">·</span>
   <span>by SacredWoobie</span><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control" target="_blank" rel="noopener noreferrer">GitHub</a><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -53,6 +53,7 @@ _tgt_cache = {}
 _tgt_last_poll = 0.0
 _stage_cache = {}
 _stage_last_poll = 0.0
+_stage_last_ut = None
 
 # Current-stage resource ownership is inferred only when one decouple group
 # contains multiple engine stages. Cache the part assignment until the vessel
@@ -525,11 +526,11 @@ def _gather_target(conn, vessel):
 # Per-stage delta-V via the custom KRPC.StageStats service (MechJeb's sim).
 #
 # The service indexes stages by ARRAY INDEX: index 0 is the final/upper stage.
-# A complete MechJeb result includes the zero-thrust staging slots and maps
-# contiguously to KSP's countdown numbering. During an incomplete/older result,
-# however, MechJeb can expose only propulsive rows. In that case we map the rows
-# to the vessel's actual engine activation stages instead of inventing adjacent
-# stage numbers and losing S0.
+# A complete MechJeb result includes every KSP staging slot, including
+# zero-thrust decoupler/fairing stages. Therefore a vessel at currentStage N
+# must have N+1 result rows, indexed S0 through SN. A shorter result is an async
+# partial (or a stale module after a scene change), not a propulsive-only table.
+# Reject it so the dashboard never disguises missing stages as S0/S4, etc.
 #
 #   ksp_number(index) = current_ksp - ((count - 1) - index)
 #                     = index + (current_ksp - (count - 1))
@@ -538,26 +539,7 @@ def _gather_target(conn, vessel):
 # The custom service pumps MechJeb's async sim on every read. Prime it, allow
 # MechJeb's 100 ms flight refresh window to complete, then take one snapshot.
 # ---------------------------------------------------------------------------
-def _stage_ksp_numbers(vessel, current_ksp, count):
-    """Return KSP labels for a full or propulsive-only MechJeb result."""
-    offset = (current_ksp - (count - 1)) if count > 0 else 0
-    contiguous = [index + offset for index in range(count)]
-
-    try:
-        engine_stages = set()
-        for engine in vessel.parts.engines:
-            stage = int(engine.part.stage)
-            if 0 <= stage <= current_ksp:
-                engine_stages.add(stage)
-        engine_stages = sorted(engine_stages)
-        if len(engine_stages) == count:
-            return engine_stages, "engine-activation"
-    except Exception:
-        pass
-    return contiguous, "contiguous"
-
-
-def _gather_stages(conn, vessel):
+def _gather_stages(conn):
     try:
         ss = conn.stage_stats
     except Exception:
@@ -577,15 +559,27 @@ def _gather_stages(conn, vessel):
         # its individual fields.
         ss.stage_count()
         time.sleep(STAGE_SETTLE_SECONDS)
-        count = ss.stage_count()
-        current_ksp = ss.current_stage()
+        count = int(ss.stage_count())
+        current_ksp = int(ss.current_stage())
+
+        # The MechJeb table is indexed S0..S(current). A smaller table is a
+        # transient/incomplete simulation. Publish an explicitly empty snapshot
+        # rather than relabeling two surviving rows as non-contiguous stages or
+        # continuing to show rows from the previous staging state.
+        expected_count = max(0, current_ksp + 1)
+        if count != expected_count:
+            return {
+                "stage.available": True,
+                "stage.complete": False,
+                "stage.count": count,
+                "stage.currentKsp": current_ksp,
+                "stage.stages": [],
+            }
+
         out["stage.count"] = count
         out["stage.currentKsp"] = current_ksp
-
-        ksp_numbers, mapping = _stage_ksp_numbers(
-            vessel, current_ksp, count
-        )
-        out["stage.mapping"] = mapping
+        out["stage.complete"] = True
+        out["stage.mapping"] = "complete"
         stages = []
         total_atmo = total_vac = 0.0
         for i in range(count):
@@ -595,7 +589,7 @@ def _gather_stages(conn, vessel):
             total_vac += dv_vac
             stages.append({
                 "index": i,
-                "ksp": ksp_numbers[i],
+                "ksp": i,
                 "dvAtmo": round(dv_atmo, 1),
                 "dvVac": round(dv_vac, 1),
                 "twr": round(ss.stage_twr(i, False), 2),
@@ -604,6 +598,15 @@ def _gather_stages(conn, vessel):
         out["stage.stages"] = stages
         out["stage.totalDvAtmo"] = round(total_atmo, 1)
         out["stage.totalDvVac"] = round(total_vac, 1)
+
+        # If staging or a scene change happened while the individual RPCs were
+        # being read, discard the mixed snapshot and retry on the next poll.
+        if int(ss.stage_count()) != count or int(ss.current_stage()) != current_ksp:
+            return {
+                "stage.available": True,
+                "stage.complete": False,
+                "stage.stages": [],
+            }
     except Exception:
         return {}  # mid-scene-change / sim not ready; retain last good cache
 
@@ -721,6 +724,7 @@ def _gather_science(conn, vessel):
 # Telemetry gathering
 # ---------------------------------------------------------------------------
 def gather_telemetry(conn):
+    global _stage_cache, _stage_last_poll, _stage_last_ut
     d = {}
 
     # The game scene is the authoritative signal. A vessel handle may remain
@@ -745,8 +749,10 @@ def gather_telemetry(conn):
     now = time.time()
 
     # ---- clocks (every tick) ----
+    universal_time = None
     try:
-        d["t.universalTime"] = sc.ut
+        universal_time = sc.ut
+        d["t.universalTime"] = universal_time
         d["v.missionTime"] = vessel.met
     except Exception:
         pass
@@ -840,11 +846,19 @@ def gather_telemetry(conn):
     d.update(_tgt_cache)
 
     # ---- per-stage delta-V (KRPC.StageStats / MechJeb) ----
-    global _stage_cache, _stage_last_poll
+    # Revert-to-launch rewinds universal time while the process and kRPC
+    # connection can remain alive. Never carry the previous flight's last good
+    # stage snapshot across that boundary.
+    if universal_time is not None:
+        if _stage_last_ut is not None and universal_time < _stage_last_ut:
+            _stage_cache = {}
+            _stage_last_poll = 0.0
+        _stage_last_ut = universal_time
+
     if now - _stage_last_poll >= STAGE_POLL_SECONDS:
         _stage_last_poll = now
         try:
-            result = _gather_stages(conn, vessel)
+            result = _gather_stages(conn)
             if result:
                 _stage_cache = result
         except Exception:

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -129,15 +129,15 @@ foreach ($file in $dllFiles) {
     Assert-RequiredFile (Join-Path $GameDataPath $file.Source)
 }
 
-# v0.1.4 requires the StageStats keep-warm service. Older release DLLs expose
-# the same RPC surface but leave MechJeb's asynchronous simulation idle, which
-# produces frozen delta-v and incomplete stage rows. Fail before packaging
-# instead of silently reusing the v0.1.0 binary.
+# v0.1.5 requires the StageStats revert-safe service. Older release DLLs expose
+# the same RPC surface but can retain a destroyed MechJeb module after reverting
+# to launch, producing frozen delta-v and incomplete stage rows. Fail before
+# packaging instead of silently reusing the v0.1.1 binary.
 $stageStatsDll = Join-Path $GameDataPath 'KRPC.StageStats/KRPC.StageStats.dll'
 $stageStatsVersion = [System.Reflection.AssemblyName]::GetAssemblyName(
     $stageStatsDll
 ).Version
-$requiredStageStatsVersion = [Version]'0.1.1.0'
+$requiredStageStatsVersion = [Version]'0.1.2.0'
 if ($stageStatsVersion -ne $requiredStageStatsVersion) {
     throw "KRPC.StageStats.dll must be version $requiredStageStatsVersion for v$Version; found $stageStatsVersion. Rebuild the service in Woobies-KRPC-Service-Builder and update its dist/GameData copy."
 }


### PR DESCRIPTION
## What changed

- require complete MechJeb stage arrays before publishing a staging snapshot
- stop relabeling incomplete rows by engine activation stage
- clear cached staging data when universal time rewinds after Revert to Launch
- verify the stage count again after the multi-call snapshot
- prepare the dashboard, documentation, changelog, and release tool for v0.1.5
- require the private `KRPC.StageStats` 0.1.2.0 DLL during release packaging

## Root cause

`KRPC.StageStats` 0.1.1 cached the MechJeb stage-stats module by vessel GUID. KSP can recreate the Vessel and MechJebCore objects during Revert to Launch while reusing that GUID, leaving the service attached to the destroyed flight's simulation arrays. The Python engine-stage fallback then made the partial result look valid as rows such as S0/S4.

The corresponding private builder change binds the cache to the actual Vessel and MechJebCore object instances and resets the reflected RequestUpdate method when either instance changes. Private C# sources remain outside this public repository.

## Validation

- `python -m py_compile telemetry_server.py ksp_dashboard_app.py panel_bridge.py`
- mocked complete, incomplete, and mid-read stage snapshot checks
- `git diff --check`
- rebuilt `KRPC.StageStats` 0.1.2.0 in the private group builder
- live KSP test confirmed complete, updating stage data before and after Revert to Launch

## Release note

Keep this PR draft until the verified 0.1.2.0 DLL is present under the private builder's `dist/GameData/KRPC.StageStats` path. After merge, build and audit v0.1.5 with `tools/Publish-Release.ps1 -Version 0.1.5` before creating the draft GitHub Release.