### PR TITLE
Add v0.2.0 editor craft planning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# Repository guidance
+
+## Purpose
+
+Woobie's Mission Control is a local KSP dashboard plus an optional ESP32 control-panel bridge. The dashboard receives kRPC telemetry through a local WebSocket server. Three custom kRPC DLLs are built in the separate `Woobies-KRPC-Service-Builder` repository.
+
+## Architecture and ownership
+
+- `telemetry_server.py` owns the kRPC connection, scene detection, telemetry gathering, caches, reconnect behavior, dashboard WebSocket, and editor-condition commands.
+- `ksp_mission_dashboard.html` owns presentation and browser rendering.
+- `ksp_dashboard_app.py` launches optional components; it should not duplicate telemetry logic.
+- `panel_bridge.py` is only for the ESP32 serial/kRPC control path. Do not modify it for dashboard-only telemetry or UI work.
+- `firmware/KSP_control.ino` and `docs/CONTROL_PAD_PROTOCOL.md` belong to the hardware path.
+- `tools/Publish-Release.ps1` packages and audits releases but does not build the service DLLs.
+
+When a displayed field is wrong, trace it in this order: raw kRPC/service value, Python telemetry payload, browser WebSocket payload, then HTML renderer state.
+
+## Local setup and run commands
+
+Use Windows PowerShell from the repository root.
+
+```powershell
+py -3 -m venv .venv
+.venv\Scripts\python.exe -m pip install -r requirements-dashboard.txt
+```
+
+For the complete dashboard plus ESP32 environment:
+
+```powershell
+.venv\Scripts\python.exe -m pip install -r requirements.txt
+```
+
+Start with `Start KSP Dashboard.bat`, or run telemetry directly while debugging:
+
+```powershell
+.venv\Scripts\python.exe -u .\telemetry_server.py
+```
+
+## Engineering constraints
+
+- Inspect and update from the current Git branch before editing. Do not base new work on stale chat attachments when the repository is available.
+- Preserve the separation between dashboard telemetry and the ESP32 control bridge.
+- Keep existing telemetry keys stable where practical; add explicit fields instead of silently changing semantics.
+- Treat KSP scene transitions and reverts as lifecycle boundaries. Clear or replace cached vessel, resource, stage, and editor state deliberately.
+- If code clears dynamically generated DOM, reset the JavaScript signature/cache that controls rebuilding it.
+- Keep unavailable, pending, empty, and stale states distinguishable. Do not hide backend failures with front-end defaults.
+- Preserve modded resources and planet packs. Never hard-code the stock body list or stock-only resources.
+- Editor analysis must support VAB and SPH. Preserve Hangar Extender compatibility by relying on editor/craft state, not window geometry.
+- Do not update scattered release versions until v0.2.0 scope is accepted and the feature branch is stable.
+- Preserve unrelated changes in a dirty worktree.
+
+## Validation
+
+After Python changes:
+
+```powershell
+.venv\Scripts\python.exe -m py_compile .\telemetry_server.py .\ksp_dashboard_app.py .\panel_bridge.py
+```
+
+For dashboard JavaScript, load the page with the browser console open and verify no exceptions. Inspect the WebSocket payload independently from the DOM.
+
+Lifecycle changes should cover this manual KSP matrix where applicable:
+
+1. Start in VAB and modify a craft.
+2. Select Kerbin and an airless body; compare atmospheric/vacuum values.
+3. Repeat in SPH.
+4. Launch to a fresh flight.
+5. Stage or burn briefly.
+6. Revert to launch; verify consumables and staging repopulate.
+7. Revert to editor, modify the craft, and relaunch.
+8. Disconnect and reconnect the dashboard without restarting KSP.
+
+State which tests were automated and which require the user's KSP installation. Do not claim an in-game pass from mocked data.
+
+## Release boundaries
+
+- The service builder must produce and verify all three DLLs before packaging.
+- Run `tools\Publish-Release.ps1` without release creation first, then inspect and test the ZIP.
+- Pushing a branch, opening a PR, creating a release, or publishing it requires explicit user direction.
+- Do not publish v0.2.0 while a known revert regression remains unresolved unless the user explicitly accepts and documents it.
+
+## Review guidance
+
+- Flag dashboard features that unnecessarily touch `panel_bridge.py`.
+- Look for stale caches across `flight -> inactive/editor -> flight` transitions.
+- Check that dynamic resource rows rebuild after `nullOutDashboard()` or equivalent DOM clearing.
+- Check StageStats states independently: `available`, `complete`, `pending`, `count`, `currentKsp`, and `stages` must form a coherent snapshot or an explicit transition state.
+- Treat compatibility with the released telemetry schema and external consumers as part of correctness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable public changes will be recorded here.
 
+## v0.2.0 - Editor craft planning
+
+- Added MechJeb-backed stage analysis in the VAB and SPH with selectable
+  reference body, altitude above sea level, and Mach.
+- Displayed atmospheric and vacuum delta-v and initial TWR side by side in
+  editor planning while preserving the compact flight condition toggle.
+- Updated `KRPC.StageStats` to `0.2.0`, including corrected initial-TWR values
+  and editor simulation lifecycle support.
+- Rebuilt consumable rows and stage snapshots across launches, scene changes,
+  dashboard reconnects, and reverts without showing stale pre-revert values.
+- Added opt-in StageStats lifecycle tracing, a raw service probe, and browser
+  and telemetry regression coverage for the diagnosed failure paths.
+
 ## v0.1.5 - Revert-safe staging analysis
 
 - Invalidated the private `KRPC.StageStats` MechJeb-module cache when KSP

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Woobie's Mission Control
 
-Current release: **v0.1.5**
+Current release: **v0.2.0**
 
 A modular mission dashboard and optional ESP32 control-pad bridge for Kerbal
 Space Program 1, powered by [kRPC](https://krpc.github.io/krpc/).
@@ -41,6 +41,7 @@ a control-pad start button.
 - Flight and orbit instruments, navball, throttle, clocks, and sparklines
 - Vessel-total and current-stage resources
 - MechJeb atmospheric/vacuum delta-v, TWR, and burn-time staging analysis
+- VAB/SPH craft planning with selectable body, altitude, and Mach conditions
 - Stock CommNet data with optional RemoteTech signal delay
 - Recoverable and transmittable science, including science-container contents
 - System Heat loop temperatures, generation, rejection, and net heat
@@ -57,8 +58,9 @@ a control-pad start button.
 The science panel totals recoverable and transmittable science aboard the active
 vessel, including experiments moved into stock science containers. It also
 reports experiment count, biome, situation, and career science already banked
-at the KSC. The staging panel presents atmospheric or vacuum delta-v, TWR, burn
-time, throttle, and a per-stage breakdown using MechJeb simulation data.
+at the KSC. In flight, the staging panel presents a compact atmospheric/vacuum
+toggle for delta-v and TWR. In the VAB and SPH, the planning view shows both
+conditions side by side and can simulate a selected body, altitude, and Mach.
 
 Stored-science reporting uses `KRPC.VesselScience`. Full staging analysis uses
 MechJeb 2, KRPC.MechJeb, and `KRPC.StageStats`.
@@ -102,7 +104,7 @@ still need confirmation before release.
 | MechJeb 2 | `2.14.3.0` |
 | KRPC.MechJeb | `0.7.1` |
 | KRPC.SystemHeat service | `0.2.0` |
-| KRPC.StageStats service | `0.1.2` |
+| KRPC.StageStats service | `0.2.0` |
 | KRPC.VesselScience service | `0.1.0` |
 | System Heat | `0.9.1` |
 | Near Future Electrical | `2.0.8` |
@@ -272,7 +274,7 @@ From a clean, up-to-date `main` checkout, first create and audit the package
 without changing anything on GitHub:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.5
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.0
 ```
 
 The script writes the ZIP, SHA-256 checksum, and generated release notes to the
@@ -292,7 +294,7 @@ Open a new PowerShell window after installation, authenticate once with
 `gh auth login`, and then rerun:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.1.5 -CreateDraftRelease
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.0 -CreateDraftRelease
 ```
 
 The release remains private as a draft until it is reviewed and published on

--- a/docs/V0.2.0_STATUS.md
+++ b/docs/V0.2.0_STATUS.md
@@ -1,0 +1,106 @@
+# v0.2.0 working status
+
+This records the feature scope, diagnosis, and acceptance evidence used to
+prepare the v0.2.0 pull request. Public release notes live in `CHANGELOG.md`.
+
+## Intended scope
+
+- Show MechJeb-backed stage analysis while building in VAB and SPH.
+- Select reference body, altitude above sea level, and Mach.
+- Show atmospheric and vacuum delta-v and TWR side by side in editor mode.
+- Preserve the compact atmospheric/vacuum toggle in flight.
+- Support modded bodies and avoid assumptions that conflict with Hangar Extender.
+- Fix consumables going blank across scene changes and reverts.
+- Diagnose and fix the remaining flight StageStats failure after revert.
+- Prepare a v0.2.0 draft PR and test ZIP; publish only after the packaged-build
+  acceptance matrix passes.
+
+## Confirmed results
+
+### StageStats editor service
+
+- The service is available in the editor and recognizes VAB.
+- It finds MechJeb's `MechJebModuleStageStats` through reflection and reads atmospheric and vacuum fuel-flow results.
+- A Python client received 32 installed bodies, including planet-pack bodies.
+- Changing the reference body from Kerbin to Mun changed TWR appropriately.
+- On airless Mun, atmospheric-condition delta-v matched vacuum delta-v.
+- The tested API exposes editor craft name, body, altitude, Mach, revision/stability state, and per-stage atmo/vac values.
+- The tested project declares `KRPC.StageStats` version `0.2.0` and explicitly compiles only `StageStatsService.cs`.
+
+For `_A_DeltaB Build Test`, Kerbin sea level produced 1067.8 m/s
+atmospheric delta-v and 4152.6 m/s vacuum delta-v; Mun surface produced
+4152.6 m/s for both. These demonstrate body-dependent atmosphere handling and
+are not expected values for other crafts. Post-fix initial TWR was checked
+directly against MechJeb rather than preserving a craft-specific value here.
+
+### Dashboard editor path
+
+- The planning view was observed working in VAB.
+- The integration work uses explicit `flight`, `editor`, and `inactive` contexts.
+- The editor payload carries the service body list and accepts body, altitude,
+  and Mach commands.
+- The editor UI shows atmospheric and vacuum delta-v and initial TWR together.
+- The flight UI retains its compact atmospheric/vacuum toggle and switches
+  both delta-v and TWR.
+
+## Consumables diagnosis and fix
+
+The post-revert WebSocket payload contained valid `res.names`, vessel totals, and current-stage resource values. The blank panel was a browser rendering-state problem, not missing kRPC data.
+
+Failure sequence:
+
+1. `nullOutDashboard()` clears the generated `resRows` DOM.
+2. The cached resource signature still says that list was rendered.
+3. The next flight has the same resource names, so `updateResources()` skips `buildResRows()`.
+4. Values arrive, but no row elements exist to update.
+
+The durable fix invalidates both `RESOURCES` and `lastResSig` whenever `resRows`
+is cleared, then lets the next valid `res.names` payload rebuild the rows. A
+browser regression now covers `flight -> inactive/editor -> same-craft flight`
+with an unchanged resource signature.
+
+## Flight StageStats diagnosis and resolution
+
+An early post-revert capture showed an incomplete StageStats snapshot:
+
+```json
+{
+  "context.mode": "flight",
+  "flight.active": true,
+  "stage.available": true,
+  "stage.complete": false,
+  "stage.count": 7,
+  "stage.currentKsp": 7,
+  "stage.stages": []
+}
+```
+
+Opt-in telemetry tracing and the raw service probe separated the service result
+from telemetry caching. The final lifecycle test showed complete rows after a
+fresh launch, staging, Revert to Launch, and Revert to Editor. Telemetry now
+clears flight caches on scene entry and universal-time rewind, publishes an
+explicit pending editor state, and rejects mixed/incomplete service snapshots
+rather than showing stale pre-revert rows.
+
+The same investigation found that TWR used `MaxThrust / StartMass / g`, which
+matched neither MechJeb's initial nor maximum TWR. `KRPC.StageStats` 0.2.0 uses
+`StartThrust / StartMass / g`, matching MechJeb's Initial TWR in VAB and flight.
+
+## Required test matrix
+
+| Area | Result before test ZIP |
+| --- | --- |
+| VAB craft edits | Passed: settled stage rows refreshed |
+| Body selection | Passed: Kerbin/airless-body values followed atmosphere and gravity |
+| Planet packs | Passed: 32 service-provided bodies were enumerated |
+| Fresh flight | Passed: consumables and staging populated |
+| Initial TWR | Passed: matched MechJeb in VAB and flight |
+| Revert to launch | Passed: consumables and staging repopulated |
+| Revert to editor | Passed: planning repopulated and relaunch recovered |
+| Dashboard rendering | Passed automated editor/flight mode and consumables regressions |
+| ESP32 path | Unchanged; `panel_bridge.py` was not modified |
+| SPH and clean-package install | Required during release-candidate acceptance |
+
+The final v0.2.0 release remains gated on installing and testing the packaged
+ZIP, including an SPH planning pass. A successful source-tree test is not a
+substitute for testing the release artifact.

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -30,7 +30,7 @@ HERE = Path(__file__).resolve().parent
 DASHBOARD = HERE / "ksp_mission_dashboard.html"
 PYTHON = sys.executable
 APP_NAME = "Woobie's Mission Control"
-APP_VERSION = "0.1.5"
+APP_VERSION = "0.2.0"
 APP_AUTHOR = "SacredWoobie"
 PROJECT_URL = "https://github.com/SacredWoobie/woobies-mission-control"
 

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -548,14 +548,14 @@
   </div>
 </div>
 
-<!-- ============ NO-FLIGHT OVERLAY ============ -->
+<!-- ============ INACTIVE-SCENE OVERLAY ============ -->
 <div class="scrim" id="scrimNoFlight">
   <div class="popout alert">
     <div class="popout-inner">
-      <h3><span class="haz-badge"></span> No Flight in Progress</h3>
-      <div class="sub">Telemetry linked · awaiting active vessel</div>
+      <h3><span class="haz-badge"></span> Awaiting Flight or Editor</h3>
+      <div class="sub">Telemetry linked · open a vessel in Flight, VAB, or SPH</div>
       <div class="big-status">STANDBY</div>
-      <div class="statusline"><span class="led wait"></span><span>Enter a flight scene to resume telemetry</span></div>
+      <div class="statusline"><span class="led wait"></span><span>Flight, VAB, and SPH scenes are supported</span></div>
     </div>
   </div>
 </div>
@@ -1062,9 +1062,9 @@ if(connectBtnK2) connectBtnK2.addEventListener("click", toggleK);
 
 /* ---- overlay control ------------------------------------------------------
    Two mutually-exclusive centered pop-outs over a dimmed dashboard:
-     * not linked            -> connect pop-out
-     * linked, but no vessel -> "No Flight in Progress"
-   Linked WITH a vessel -> no overlay, live dashboard. */
+     * not linked                 -> connect pop-out
+     * linked, but inactive scene -> "Awaiting Flight or Editor"
+   Linked in Flight, VAB, or SPH -> no overlay, live dashboard. */
 let hasFlight=false, contextMode="inactive";
 const scrimConnect=$("scrimConnect"), scrimNoFlight=$("scrimNoFlight");
 function updateOverlays(){

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -282,6 +282,7 @@
   .dv-grid{display:grid;grid-template-columns:1.25fr 1.25fr 0.7fr 1fr;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:3px;overflow:hidden}
   .dv-grid .stat{align-items:flex-start;padding:9px 10px}
   .dv-grid .stat .v{font-size:17px}
+  .editor-dv-grid{display:none}
   .stage-table{margin-top:2px;display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:3px;overflow:hidden}
   .st-row{display:grid;grid-template-columns:60px 1fr 1fr 1fr;gap:1px;background:var(--rule)}
   .st-row > span{background:var(--panel);padding:4px 8px;font-variant-numeric:tabular-nums;font-size:11px;color:var(--amber)}
@@ -476,6 +477,55 @@
   }
   /* dashboard content dims/locks out behind a scrim */
   body.modal-open .wrap{filter:saturate(.5) brightness(.55);pointer-events:none;user-select:none}
+
+  /* ---- VAB / SPH craft analysis ---- */
+  #editorContext{display:none}
+  #editorContext .body{display:flex;flex-direction:column;gap:10px}
+  .editor-head{display:grid;grid-template-columns:1fr auto;gap:12px;align-items:end}
+  .editor-craft{font-size:20px;color:var(--cyan);letter-spacing:.03em;
+                white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .editor-facility{font-size:11px;color:var(--amber);letter-spacing:.14em;text-transform:uppercase}
+  .editor-controls{display:grid;grid-template-columns:minmax(150px,1.5fr) 1fr 1fr auto;
+                   gap:8px;align-items:end}
+  .editor-control{display:flex;flex-direction:column;gap:4px;min-width:0}
+  .editor-control select,.editor-control input{
+    width:100%;min-width:0;background:#060a0f;border:1px solid var(--rule-bright);
+    color:var(--amber);font-family:var(--mono);font-size:12px;padding:7px 8px;
+    border-radius:3px;
+  }
+  .editor-control select:focus-visible,.editor-control input:focus-visible{
+    outline:2px solid var(--cyan);outline-offset:1px;
+  }
+  .editor-state{font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--slate)}
+  .editor-state.wait{color:var(--amber)}
+  .editor-state.ok{color:var(--green)}
+  .editor-state.bad{color:var(--warn)}
+
+  body.editor-mode #editorContext{display:block}
+  body.editor-mode .status-strip{display:block!important;background:none;border:0;overflow:visible}
+  body.editor-mode .status-strip #conn{display:block}
+  body.editor-mode .status-strip #conn .body{display:flex!important;align-items:center!important}
+  body.editor-mode .status-strip #clock{display:none!important}
+  body.editor-mode .flight-grid{display:block!important}
+  body.editor-mode .flight-grid > #asc{display:none!important}
+  body.editor-mode .flight-grid > .deck{display:block!important;column-count:1!important}
+  body.editor-mode .wide-left,body.editor-mode .wide-systems{display:none!important}
+  body.editor-mode .wide-mission{display:block!important}
+  body.editor-mode #target{display:none!important}
+  body.editor-mode #stage{display:block;max-width:900px;margin-left:auto;margin-right:auto}
+  body.editor-mode #stageThrottle{display:none}
+  body.editor-mode #dvModeToggle{display:none}
+  body.editor-mode .flight-dv-grid{display:none}
+  body.editor-mode .editor-dv-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr))}
+  body.editor-mode .editor-dv-grid .stat:last-child{grid-column:3/5}
+  body.editor-mode .st-row{grid-template-columns:56px 1.35fr 1.35fr .85fr .85fr 1fr}
+  @media (max-width:640px){
+    .editor-head{grid-template-columns:1fr}
+    .editor-controls{grid-template-columns:1fr 1fr}
+    .editor-control:first-child{grid-column:1/-1}
+    body.editor-mode .editor-dv-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+    body.editor-mode .editor-dv-grid .stat:last-child{grid-column:1/-1}
+  }
 </style>
 </head>
 <body>
@@ -553,6 +603,36 @@
   </section>
 
   </div><!-- /status-strip -->
+
+  <!-- ============ EDITOR CRAFT ANALYSIS (VAB / SPH only) ============ -->
+  <section class="panel" id="editorContext">
+    <h2>Craft analysis <span class="tag">VAB · SPH · MechJeb simulation</span></h2>
+    <div class="body">
+      <div class="editor-head">
+        <div>
+          <div class="label">Craft</div>
+          <div class="editor-craft" id="editorCraftName">—</div>
+        </div>
+        <div class="editor-facility" id="editorFacility">EDITOR</div>
+      </div>
+      <div class="editor-controls">
+        <label class="editor-control">
+          <span class="label">Reference body</span>
+          <select id="editorBody"></select>
+        </label>
+        <label class="editor-control">
+          <span class="label">Altitude ASL (m)</span>
+          <input id="editorAltitude" type="number" min="0" step="100" value="0">
+        </label>
+        <label class="editor-control">
+          <span class="label">Mach</span>
+          <input id="editorMach" type="number" min="0" step="0.1" value="0">
+        </label>
+        <button id="editorApply" type="button">Recalculate</button>
+      </div>
+      <div class="editor-state wait" id="editorState">Awaiting editor simulation</div>
+    </div>
+  </section>
 
   <div class="flight-grid">
 
@@ -717,21 +797,30 @@
 
   <!-- ============ STAGING ============ -->
   <section class="panel" id="stage">
-    <h2>Staging analysis <span class="tag">throttle · Δv (kRPC · MechJeb)
+    <h2><span id="stageHeading">Staging analysis</span> <span class="tag"><span id="stageHeaderText">throttle · Δv (kRPC · MechJeb)</span>
       <span id="dvModeToggle" style="cursor:pointer;color:var(--cyan);margin-left:6px">[ATMO]</span></span></h2>
     <div class="body">
       <div class="stage-top">
-        <div class="stage-num"><span class="label">Stage</span><span class="v" id="stageNum">—</span></div>
-        <div class="thr-inline">
+        <div class="stage-num"><span class="label" id="stagePrimaryLabel">Stage</span><span class="v" id="stageNum">—</span></div>
+        <div class="thr-inline" id="stageThrottle">
           <span class="label">Throttle <span id="thrPct2" class="live">0%</span></span>
           <div class="track"><div class="fill" id="thrFill2" style="width:0%"></div></div>
         </div>
       </div>
-      <div class="dv-grid">
+      <div class="dv-grid flight-dv-grid">
         <div class="stat"><span class="label">Stage Δv</span><span class="v" id="dv_stage">—</span></div>
         <div class="stat"><span class="label">Total Δv</span><span class="v" id="dv_total">—</span></div>
         <div class="stat"><span class="label">TWR</span><span class="v" id="dv_twr">—</span></div>
         <div class="stat"><span class="label">Burn time</span><span class="v" id="dv_burn">—</span></div>
+      </div>
+      <div class="dv-grid editor-dv-grid">
+        <div class="stat"><span class="label">Stage Δv · Atmo</span><span class="v" id="ed_dv_stage_atmo">—</span></div>
+        <div class="stat"><span class="label">Stage Δv · Vac</span><span class="v" id="ed_dv_stage_vac">—</span></div>
+        <div class="stat"><span class="label">Total Δv · Atmo</span><span class="v" id="ed_dv_total_atmo">—</span></div>
+        <div class="stat"><span class="label">Total Δv · Vac</span><span class="v" id="ed_dv_total_vac">—</span></div>
+        <div class="stat"><span class="label">Initial TWR · Atmo</span><span class="v" id="ed_twr_atmo">—</span></div>
+        <div class="stat"><span class="label">Initial TWR · Vac</span><span class="v" id="ed_twr_vac">—</span></div>
+        <div class="stat"><span class="label">Burn time</span><span class="v" id="ed_dv_burn">—</span></div>
       </div>
       <div class="stage-table" id="stageTable"></div>
     </div>
@@ -763,7 +852,7 @@
 </div>
 
 <footer class="project-footer" aria-label="Project information">
-  <span>Woobie's Mission Control v0.1.5</span><span class="sep">·</span>
+  <span>Woobie's Mission Control v0.2.0</span><span class="sep">·</span>
   <span>by SacredWoobie</span><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control" target="_blank" rel="noopener noreferrer">GitHub</a><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
@@ -944,6 +1033,8 @@ function connectK(){
   wsK.onclose=()=>{
     connectedK=false;
     hasFlight=false;          // stale once the link drops
+    contextMode="inactive";
+    document.body.classList.remove("editor-mode");
     connectBtnK.textContent="Connect";
     connectBtnK.classList.remove("danger");
     if(wantConnectK){
@@ -961,6 +1052,8 @@ function disconnectK(){
   clearTimeout(reconnectTimerK);
   if(wsK){ wsK.close(); wsK=null; }
   hasFlight=false;
+  contextMode="inactive";
+  document.body.classList.remove("editor-mode");
   setStatusK("","Offline");
 }
 function toggleK(){ (connectedK||wantConnectK) ? disconnectK() : connectK(); }
@@ -972,12 +1065,12 @@ if(connectBtnK2) connectBtnK2.addEventListener("click", toggleK);
      * not linked            -> connect pop-out
      * linked, but no vessel -> "No Flight in Progress"
    Linked WITH a vessel -> no overlay, live dashboard. */
-let hasFlight=false;
+let hasFlight=false, contextMode="inactive";
 const scrimConnect=$("scrimConnect"), scrimNoFlight=$("scrimNoFlight");
 function updateOverlays(){
   const linked = connectedK;
   const showConnect  = !linked;
-  const showNoFlight = linked && !hasFlight;
+  const showNoFlight = linked && contextMode==="inactive";
   if(scrimConnect)  scrimConnect.classList.toggle("show", showConnect);
   if(scrimNoFlight) scrimNoFlight.classList.toggle("show", showNoFlight);
   document.body.classList.toggle("modal-open", showConnect || showNoFlight);
@@ -993,19 +1086,36 @@ if(/[?&]autoconnect=1/.test(location.search)){
 /* The bridge pushes everything on every frame, so this is just a fan-out. */
 let lastKrpcData=null;   // kept so the Δv atmo/vac toggle can repaint on click
 function onDataKrpc(d){
-  // Bridge sends flight.active=false when connected but no vessel is loaded.
-  // Treat an explicit false as "no flight"; missing key (older bridge) is
-  // assumed to be a flight so the dashboard still works.
-  hasFlight = (d["flight.active"] !== false);
+  // New servers name the active context explicitly. Preserve compatibility
+  // with released servers that only publish flight.active.
+  const suppliedMode=d["context.mode"];
+  contextMode = suppliedMode || (d["flight.active"]===false ? "inactive" : "flight");
+  hasFlight = contextMode==="flight";
+  const editorActive = contextMode==="editor";
+  document.body.classList.toggle("editor-mode",editorActive);
   updateOverlays();
+  if(editorActive){
+    if(onDataKrpc._paintedMode!=="editor") nullOutDashboard();
+    onDataKrpc._blanked=false;
+    onDataKrpc._paintedMode="editor";
+    lastKrpcData=d;
+    updateEditorContext(d);
+    updateStaging(d);
+    return;
+  }
   if(!hasFlight){
     // Don't paint stale numbers behind the overlay -- blank the dashboard so a
     // glance behind the dimmed pop-out doesn't show frozen values.
     if(!onDataKrpc._blanked){ nullOutDashboard(); onDataKrpc._blanked=true; }
     lastKrpcData=d;
+    onDataKrpc._paintedMode="inactive";
     return;
   }
   onDataKrpc._blanked=false;
+  onDataKrpc._paintedMode="flight";
+  set("stageHeading","Staging analysis");
+  set("stageHeaderText","throttle · Δv (kRPC · MechJeb) ");
+  set("stagePrimaryLabel","Stage");
 
   lastKrpcData=d;
   updateClocks(d);
@@ -1020,6 +1130,70 @@ function onDataKrpc(d){
   updateTarget(d);
   updateStaging(d);
 }
+
+let lastEditorBodiesSig="";
+function updateEditorContext(d){
+  set("editorCraftName",d["editor.craftName"]||"Untitled Space Craft");
+  set("editorFacility",d["editor.facility"]||"EDITOR");
+  set("stageHeading","Editor staging analysis");
+  set("stageHeaderText","selected conditions · Δv (kRPC · MechJeb) ");
+  set("stagePrimaryLabel","Launch stage");
+
+  const bodies=Array.isArray(d["editor.bodies"])?d["editor.bodies"]:[];
+  const signature=bodies.join("\u0000");
+  const bodySelect=$("editorBody");
+  if(bodySelect && signature!==lastEditorBodiesSig){
+    const options=bodies.map(name=>{
+      const option=document.createElement("option");
+      option.value=name;
+      option.textContent=name;
+      return option;
+    });
+    bodySelect.replaceChildren(...options);
+    lastEditorBodiesSig=signature;
+  }
+  if(bodySelect && d["editor.body"] && document.activeElement!==bodySelect){
+    bodySelect.value=d["editor.body"];
+  }
+
+  const altitude=$("editorAltitude"),mach=$("editorMach");
+  if(altitude && num(d["editor.altitude"]) && document.activeElement!==altitude)
+    altitude.value=String(Math.round(d["editor.altitude"]));
+  if(mach && num(d["editor.mach"]) && document.activeElement!==mach)
+    mach.value=String(Number(d["editor.mach"].toFixed(2)));
+
+  const state=$("editorState");
+  if(!state) return;
+  if(d["stage.available"]===false){
+    state.className="editor-state bad";
+    state.textContent="MechJeb core required on this craft";
+  }else if(d["stage.pending"]===true || d["editor.stable"]===false){
+    state.className="editor-state wait";
+    state.textContent="Calculating · waiting for two matching simulations";
+  }else{
+    state.className="editor-state ok";
+    const revision=num(d["editor.revision"])?` · revision ${d["editor.revision"]}`:"";
+    state.textContent=`Settled${revision}`;
+  }
+}
+
+function sendEditorConditions(){
+  if(!wsK || wsK.readyState!==WebSocket.OPEN || contextMode!=="editor") return;
+  const altitude=Number($("editorAltitude")?.value);
+  const mach=Number($("editorMach")?.value);
+  const command={type:"editor.conditions",body:$("editorBody")?.value};
+  if(Number.isFinite(altitude)) command.altitude=altitude;
+  if(Number.isFinite(mach)) command.mach=mach;
+  wsK.send(JSON.stringify(command));
+  const state=$("editorState");
+  if(state){state.className="editor-state wait";state.textContent="Recalculation requested";}
+}
+$("editorApply").addEventListener("click",sendEditorConditions);
+[$("editorBody"),$("editorAltitude"),$("editorMach")].forEach(control=>{
+  control?.addEventListener("keydown",event=>{
+    if(event.key==="Enter"){event.preventDefault();sendEditorConditions();}
+  });
+});
 
 // Δv atmo/vac toggle in the staging panel header.
 $("dvModeToggle").addEventListener("click",e=>{
@@ -1040,6 +1214,8 @@ function nullOutDashboard(){
     "heatGen","heatRem","heatNet",
     "ecTotal","solarOut","solarEff","rtgOut","otherOut",
     "dv_total","dv_stage","dv_twr","dv_burn","stageNum",
+    "ed_dv_stage_atmo","ed_dv_stage_vac","ed_dv_total_atmo","ed_dv_total_vac",
+    "ed_twr_atmo","ed_twr_vac","ed_dv_burn",
     "sciSub","sciLoc"
   ];
   dash.forEach(id=>set(id,"—"));
@@ -1052,8 +1228,14 @@ function nullOutDashboard(){
 
   const sv=$("sciValue"); if(sv){ sv.className="sci-value blocked"; sv.textContent="no flight"; }
 
-  // clear list/table containers and per-vessel panels
-  ["resRows","reactorList","heatLoops","sciList","stageTable"].forEach(id=>{
+  // Resource rows are generated from res.names. Invalidate the matching
+  // renderer caches with the DOM so a same-craft flight rebuilds its rows.
+  const resRows=$("resRows"); if(resRows) resRows.innerHTML="";
+  RESOURCES=[];
+  lastResSig="";
+
+  // clear the remaining list/table containers and per-vessel panels
+  ["reactorList","heatLoops","sciList","stageTable"].forEach(id=>{
     const el=$(id); if(el) el.innerHTML="";
   });
   const rxSummary=$("reactorSummary"); if(rxSummary) rxSummary.classList.add("hidden");
@@ -1179,8 +1361,9 @@ function updateResource(r,d){
 
 /* ---- staging / delta-V — fed by KRPC.StageStats (MechJeb) via the bridge ----
    The bridge sends stage.stages[] with each row carrying BOTH its array index
-   and its mapped KSP stage number (row.ksp), plus atmo and vac Δv. We label by
-   KSP number (what shows in-game) and pick atmo/vac per the header toggle.
+   and its mapped KSP stage number (row.ksp), plus atmo and vac Δv/TWR. We label
+   by KSP number (what shows in-game). Flight picks one condition with the header
+   toggle; editor planning shows both conditions side by side.
 
    The current-burning stage is the one whose KSP number equals stage.currentKsp
    (equivalently, the highest array index). Zero-Δv rows (pure decouplers, which
@@ -1189,21 +1372,35 @@ function updateResource(r,d){
 function blankStaging(){
   set("dv_total","—"); set("stageNum","—");
   set("dv_stage","—"); set("dv_twr","—"); set("dv_burn","—");
+  ["ed_dv_stage_atmo","ed_dv_stage_vac","ed_dv_total_atmo","ed_dv_total_vac",
+   "ed_twr_atmo","ed_twr_vac","ed_dv_burn"].forEach(id=>set(id,"—"));
   const t=$("stageTable"); if(t) t.innerHTML="";
 }
 function updateStaging(d){
   // stage.available is explicitly false when MechJeb isn't on the vessel;
   // undefined means we simply haven't heard yet (leave the panel as-is).
+  if(d["stage.pending"]===true){ blankStaging(); return; }
   if(d["stage.available"]===false){ blankStaging(); return; }
   const stages = Array.isArray(d["stage.stages"]) ? d["stage.stages"] : null;
   if(!stages){ if(d["stage.available"]===true) blankStaging(); return; }
 
+  const editorDual = contextMode==="editor";
+  const atmoTwrOf = s => num(s.twrAtmo) ? s.twrAtmo : s.twr;
+  const vacTwrOf = s => num(s.twrVac) ? s.twrVac : s.twr;
   const dvOf = s => stageVac ? s.dvVac : s.dvAtmo;
-  const total = stageVac ? d["stage.totalDvVac"] : d["stage.totalDvAtmo"];
-  set("dv_total", num(total)?dvfmt(total)+" m/s":"—");
+  const twrOf = s => stageVac ? vacTwrOf(s) : atmoTwrOf(s);
+  if(!editorDual){
+    const total = stageVac ? d["stage.totalDvVac"] : d["stage.totalDvAtmo"];
+    set("dv_total",num(total)?dvfmt(total)+" m/s":"—");
+  }else{
+    set("ed_dv_total_atmo",num(d["stage.totalDvAtmo"])?dvfmt(d["stage.totalDvAtmo"])+" m/s":"—");
+    set("ed_dv_total_vac",num(d["stage.totalDvVac"])?dvfmt(d["stage.totalDvVac"])+" m/s":"—");
+  }
 
   // Propulsive stages only, for the readout + table.
-  const rows = stages.filter(s => num(dvOf(s)) && dvOf(s) > 0.5);
+  const rows = stages.filter(s => editorDual
+    ? (num(s.dvAtmo) && s.dvAtmo > 0.5) || (num(s.dvVac) && s.dvVac > 0.5)
+    : num(dvOf(s)) && dvOf(s) > 0.5);
 
   // Current stage: the row matching stage.currentKsp. Only fall back to the
   // highest KSP number when the current-stage key itself is absent; a known
@@ -1214,27 +1411,48 @@ function updateStaging(d){
 
   if(cur){
     set("stageNum", cur.ksp);
-    set("dv_stage", dvfmt(dvOf(cur))+" m/s");
-    set("dv_twr",   num(cur.twr)?cur.twr.toFixed(2):"—");
-    set("dv_burn",  num(cur.burn)?hms(cur.burn):"—");
+    if(editorDual){
+      set("ed_dv_stage_atmo",num(cur.dvAtmo)?dvfmt(cur.dvAtmo)+" m/s":"—");
+      set("ed_dv_stage_vac",num(cur.dvVac)?dvfmt(cur.dvVac)+" m/s":"—");
+      set("ed_twr_atmo",num(atmoTwrOf(cur))?atmoTwrOf(cur).toFixed(2):"—");
+      set("ed_twr_vac",num(vacTwrOf(cur))?vacTwrOf(cur).toFixed(2):"—");
+      set("ed_dv_burn",num(cur.burn)?hms(cur.burn):"—");
+    }else{
+      set("dv_stage",dvfmt(dvOf(cur))+" m/s");
+      set("dv_twr",num(twrOf(cur))?twrOf(cur).toFixed(2):"—");
+      set("dv_burn",num(cur.burn)?hms(cur.burn):"—");
+    }
   }else if(curKsp!=null){
     // current stage carries no propulsion (e.g. a payload/coast stage)
     set("stageNum", curKsp);
     set("dv_stage","—"); set("dv_twr","—"); set("dv_burn","—");
+    set("ed_dv_stage_atmo","—"); set("ed_dv_stage_vac","—");
+    set("ed_twr_atmo","—"); set("ed_twr_vac","—"); set("ed_dv_burn","—");
   }else{
     set("stageNum","—"); set("dv_stage","—"); set("dv_twr","—"); set("dv_burn","—");
+    set("ed_dv_stage_atmo","—"); set("ed_dv_stage_vac","—");
+    set("ed_twr_atmo","—"); set("ed_twr_vac","—"); set("ed_dv_burn","—");
   }
 
   const t=$("stageTable");
   if(!rows.length){ t.innerHTML=""; return; }
-  let html=`<div class="st-row st-head"><span>Stage</span><span>Δv m/s</span><span>TWR</span><span>Burn</span></div>`;
+  let html=editorDual
+    ? `<div class="st-row st-head"><span>Stage</span><span>Δv atmo</span><span>Δv vac</span><span>TWR atmo</span><span>TWR vac</span><span>Burn</span></div>`
+    : `<div class="st-row st-head"><span>Stage</span><span>Δv m/s</span><span>TWR</span><span>Burn</span></div>`;
   rows.sort((a,b)=> STAGE_DESC ? b.ksp-a.ksp : a.ksp-b.ksp);
   for(const r of rows){
     const isCur=cur&&r.ksp===cur.ksp;
-    html+=`<div class="st-row${isCur?' cur':''}"><span class="sname">${isCur?'▶ ':''}S${r.ksp}</span>`+
-          `<span>${dvfmt(dvOf(r))}</span>`+
-          `<span>${num(r.twr)?r.twr.toFixed(2):'—'}</span>`+
-          `<span>${num(r.burn)?hms(r.burn):'—'}</span></div>`;
+    html+=`<div class="st-row${isCur?' cur':''}"><span class="sname">${isCur?'▶ ':''}S${r.ksp}</span>`;
+    if(editorDual){
+      html+=`<span>${num(r.dvAtmo)?dvfmt(r.dvAtmo):'—'}</span>`+
+            `<span>${num(r.dvVac)?dvfmt(r.dvVac):'—'}</span>`+
+            `<span>${num(atmoTwrOf(r))?atmoTwrOf(r).toFixed(2):'—'}</span>`+
+            `<span>${num(vacTwrOf(r))?vacTwrOf(r).toFixed(2):'—'}</span>`;
+    }else{
+      html+=`<span>${dvfmt(dvOf(r))}</span>`+
+            `<span>${num(twrOf(r))?twrOf(r).toFixed(2):'—'}</span>`;
+    }
+    html+=`<span>${num(r.burn)?hms(r.burn):'—'}</span></div>`;
   }
   t.innerHTML=html;
 }

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -3,6 +3,7 @@
 This module owns every dashboard-facing responsibility:
   * its own kRPC connection and reconnect loop
   * flight, orbit, resource, science, heat, electricity, target, and stage data
+  * VAB/SPH craft stage analysis and editor-condition selection
   * the WebSocket server consumed by ksp_mission_dashboard.html
 
 It has no ESP32, serial-port, staging, abort, or panel-control dependencies.
@@ -13,8 +14,12 @@ Requires:  pip install krpc websockets
 
 Optional args: telemetry_server.py [host] [port]
   telemetry_server.py 0.0.0.0 8090
+
+Set WOOBIE_STAGE_TRACE=1 to emit opt-in StageStats lifecycle diagnostics.
 """
+import json
 import math
+import os
 import sys
 import time
 import krpc
@@ -31,6 +36,9 @@ RES_POLL_SECONDS = 0.5    # 2N calls for N resources aboard
 TGT_POLL_SECONDS = 0.5    # target + docking geometry
 STAGE_POLL_SECONDS = 0.5  # dv changes continuously during a burn; ~2 Hz readout
 STAGE_SETTLE_SECONDS = 0.12  # let MechJeb's 100 ms async sim finish before read
+STAGE_TRACE_ENABLED = os.environ.get("WOOBIE_STAGE_TRACE", "").casefold() in {
+    "1", "true", "yes", "on",
+}
 
 # KSP Recall exposes these internal refund-bookkeeping resources through kRPC.
 # They are implementation details, not vessel consumables. Match normalized
@@ -54,6 +62,18 @@ _tgt_last_poll = 0.0
 _stage_cache = {}
 _stage_last_poll = 0.0
 _stage_last_ut = None
+_stage_trace_last_published = None
+
+# MechJeb recalculates editor craft asynchronously. The service exposes an
+# editor_stable flag; the server also requires two matching snapshots before
+# publishing a changed craft/environment to the dashboard.
+_editor_revision = None
+_editor_bodies_cache = []
+_editor_stage_cache = {}
+_editor_stage_last_poll = 0.0
+_editor_stage_candidate = None
+_editor_stage_candidate_hits = 0
+_telemetry_mode = None
 
 # Current-stage resource ownership is inferred only when one decouple group
 # contains multiple engine stages. Cache the part assignment until the vessel
@@ -79,6 +99,48 @@ def connect_krpc(name):
     conn = krpc.connect(name=name)
     print(f"Connected to kRPC ({name}).")
     return conn
+
+
+def _stage_summary(snapshot):
+    """Return the small StageStats state needed for lifecycle diagnostics."""
+    if not isinstance(snapshot, dict):
+        return {}
+    rows = snapshot.get("stage.stages")
+    return {
+        "available": snapshot.get("stage.available"),
+        "complete": snapshot.get("stage.complete"),
+        "pending": snapshot.get("stage.pending"),
+        "count": snapshot.get("stage.count"),
+        "currentKsp": snapshot.get("stage.currentKsp"),
+        "rows": len(rows) if isinstance(rows, list) else None,
+    }
+
+
+def _stage_trace(event, **fields):
+    """Emit one compact JSON diagnostic when StageStats tracing is enabled."""
+    if not STAGE_TRACE_ENABLED:
+        return
+    record = {
+        "event": event,
+        "wallTime": round(time.time(), 3),
+    }
+    record.update(fields)
+    print("[stage-trace] " + json.dumps(record, sort_keys=True, default=str),
+          flush=True)
+
+
+def _trace_stage_publish(snapshot, source):
+    """Trace only stage-state transitions, not every 4 Hz telemetry frame."""
+    global _stage_trace_last_published
+    if not STAGE_TRACE_ENABLED:
+        return
+    summary = _stage_summary(snapshot)
+    signature = tuple(summary.get(key) for key in (
+        "available", "complete", "pending", "count", "currentKsp", "rows",
+    ))
+    if signature != _stage_trace_last_published:
+        _stage_trace_last_published = signature
+        _stage_trace("publish_transition", source=source, stage=summary)
 
 
 # ---------------------------------------------------------------------------
@@ -539,16 +601,21 @@ def _gather_target(conn, vessel):
 # The custom service pumps MechJeb's async sim on every read. Prime it, allow
 # MechJeb's 100 ms flight refresh window to complete, then take one snapshot.
 # ---------------------------------------------------------------------------
-def _gather_stages(conn):
+def _gather_stages(conn, source="flight"):
     try:
         ss = conn.stage_stats
-    except Exception:
+    except Exception as exc:
+        _stage_trace("service_missing", source=source,
+                     error=type(exc).__name__, message=str(exc))
         return {}  # service DLL not installed this session
 
     try:
         if not ss.available:
+            _stage_trace("service_unavailable", source=source)
             return {"stage.available": False}  # MechJeb not on this vessel
-    except Exception:
+    except Exception as exc:
+        _stage_trace("availability_error", source=source,
+                     error=type(exc).__name__, message=str(exc))
         return {}
 
     out = {"stage.available": True}
@@ -557,7 +624,7 @@ def _gather_stages(conn):
         # new asynchronous simulation. Waiting past MechJeb's 100 ms refresh
         # interval lets the second call collect that new result before we read
         # its individual fields.
-        ss.stage_count()
+        prime_count = int(ss.stage_count())
         time.sleep(STAGE_SETTLE_SECONDS)
         count = int(ss.stage_count())
         current_ksp = int(ss.current_stage())
@@ -568,6 +635,11 @@ def _gather_stages(conn):
         # continuing to show rows from the previous staging state.
         expected_count = max(0, current_ksp + 1)
         if count != expected_count:
+            _stage_trace(
+                "service_sample", source=source, primeCount=prime_count,
+                count=count, currentKsp=current_ksp,
+                expectedCount=expected_count, complete=False,
+            )
             return {
                 "stage.available": True,
                 "stage.complete": False,
@@ -585,6 +657,8 @@ def _gather_stages(conn):
         for i in range(count):
             dv_atmo = ss.stage_delta_v(i, False)
             dv_vac = ss.stage_delta_v(i, True)
+            twr_atmo = ss.stage_twr(i, False)
+            twr_vac = ss.stage_twr(i, True)
             total_atmo += dv_atmo
             total_vac += dv_vac
             stages.append({
@@ -592,7 +666,11 @@ def _gather_stages(conn):
                 "ksp": i,
                 "dvAtmo": round(dv_atmo, 1),
                 "dvVac": round(dv_vac, 1),
-                "twr": round(ss.stage_twr(i, False), 2),
+                # Keep `twr` as the atmospheric alias so released dashboards
+                # and any external consumers remain compatible.
+                "twr": round(twr_atmo, 2),
+                "twrAtmo": round(twr_atmo, 2),
+                "twrVac": round(twr_vac, 2),
                 "burn": round(ss.stage_burn_time(i, False), 1),
             })
         out["stage.stages"] = stages
@@ -601,16 +679,163 @@ def _gather_stages(conn):
 
         # If staging or a scene change happened while the individual RPCs were
         # being read, discard the mixed snapshot and retry on the next poll.
-        if int(ss.stage_count()) != count or int(ss.current_stage()) != current_ksp:
+        final_count = int(ss.stage_count())
+        final_current_ksp = int(ss.current_stage())
+        if final_count != count or final_current_ksp != current_ksp:
+            _stage_trace(
+                "mixed_service_sample", source=source,
+                primeCount=prime_count, count=count,
+                currentKsp=current_ksp, finalCount=final_count,
+                finalCurrentKsp=final_current_ksp,
+            )
             return {
                 "stage.available": True,
                 "stage.complete": False,
                 "stage.stages": [],
             }
-    except Exception:
+        _stage_trace(
+            "service_sample", source=source, primeCount=prime_count,
+            count=count, currentKsp=current_ksp,
+            expectedCount=expected_count, complete=True, rows=len(stages),
+        )
+    except Exception as exc:
+        _stage_trace("service_read_error", source=source,
+                     error=type(exc).__name__, message=str(exc))
         return {}  # mid-scene-change / sim not ready; retain last good cache
 
     return out
+
+
+def _stage_signature(result):
+    """Return a compact signature for recognizing a settled MechJeb result."""
+    rows = result.get("stage.stages") if isinstance(result, dict) else None
+    if not isinstance(rows, list) or result.get("stage.complete") is not True:
+        return None
+    return tuple(
+        (
+            row.get("index"), row.get("ksp"), row.get("dvAtmo"),
+            row.get("dvVac"), row.get("twrAtmo"), row.get("twrVac"),
+            row.get("burn"),
+        )
+        for row in rows
+    )
+
+
+def _reset_editor_stage_state(revision=None):
+    global _editor_revision, _editor_stage_cache, _editor_stage_last_poll
+    global _editor_stage_candidate, _editor_stage_candidate_hits
+    _editor_revision = revision
+    _editor_stage_cache = {}
+    _editor_stage_last_poll = 0.0
+    _editor_stage_candidate = None
+    _editor_stage_candidate_hits = 0
+
+
+def _gather_editor_telemetry(conn, facility):
+    """Gather the focused VAB/SPH payload from KRPC.StageStats."""
+    global _editor_revision, _editor_bodies_cache
+    global _editor_stage_cache, _editor_stage_last_poll
+    global _editor_stage_candidate, _editor_stage_candidate_hits
+
+    data = {
+        "context.mode": "editor",
+        "flight.active": False,
+        "editor.active": True,
+        "editor.facility": facility,
+        "stage.pending": True,
+    }
+
+    try:
+        service = conn.stage_stats
+    except Exception:
+        data["stage.available"] = False
+        data["stage.pending"] = False
+        return data
+
+    try:
+        revision = int(service.editor_revision)
+        stable = bool(service.editor_stable)
+        data.update({
+            "editor.craftName": (
+                service.editor_craft_name or "Untitled Space Craft"
+            ),
+            "editor.body": service.editor_body,
+            "editor.altitude": service.editor_altitude,
+            "editor.mach": service.editor_mach,
+            "editor.revision": revision,
+            "editor.stable": stable,
+        })
+    except Exception:
+        return data  # editor scene/service is still loading
+
+    if not _editor_bodies_cache:
+        try:
+            _editor_bodies_cache = list(service.editor_body_names())
+        except Exception:
+            pass
+    data["editor.bodies"] = _editor_bodies_cache
+
+    if revision != _editor_revision:
+        _reset_editor_stage_state(revision)
+
+    if not stable:
+        return data
+
+    now = time.time()
+    if now - _editor_stage_last_poll >= STAGE_POLL_SECONDS:
+        _editor_stage_last_poll = now
+        try:
+            result = _gather_stages(conn, "editor")
+            signature = _stage_signature(result)
+            if signature is None:
+                if result.get("stage.available") is False:
+                    _editor_stage_cache = result
+                    _editor_stage_candidate = None
+                    _editor_stage_candidate_hits = 0
+            elif signature == _editor_stage_candidate:
+                _editor_stage_candidate_hits += 1
+                if _editor_stage_candidate_hits >= 2:
+                    _editor_stage_cache = result
+            else:
+                _editor_stage_candidate = signature
+                _editor_stage_candidate_hits = 1
+        except Exception:
+            pass
+
+    if _editor_stage_cache:
+        data.update(_editor_stage_cache)
+        data["stage.pending"] = False
+    return data
+
+
+def _apply_telemetry_command(conn, command):
+    """Apply a dashboard editor-condition command on the telemetry connection."""
+    if not isinstance(command, dict) or command.get("type") != "editor.conditions":
+        return
+
+    try:
+        scene = conn.krpc.current_game_scene
+        if scene not in (
+            conn.krpc.GameScene.editor_vab,
+            conn.krpc.GameScene.editor_sph,
+        ):
+            return
+
+        service = conn.stage_stats
+        if "body" in command:
+            service.editor_body = str(command["body"])
+        if "altitude" in command:
+            altitude = float(command["altitude"])
+            if math.isfinite(altitude):
+                service.editor_altitude = altitude
+        if "mach" in command:
+            mach = float(command["mach"])
+            if math.isfinite(mach):
+                service.editor_mach = mach
+    except (TypeError, ValueError):
+        pass
+    except Exception:
+        pass  # scene transition or service temporarily unavailable
 
 
 # ---------------------------------------------------------------------------
@@ -725,13 +950,46 @@ def _gather_science(conn, vessel):
 # ---------------------------------------------------------------------------
 def gather_telemetry(conn):
     global _stage_cache, _stage_last_poll, _stage_last_ut
+    global _telemetry_mode, _editor_bodies_cache, _stage_trace_last_published
     d = {}
 
     # The game scene is the authoritative signal. A vessel handle may remain
     # available briefly during editor and scene transitions.
     try:
-        if conn.krpc.current_game_scene != conn.krpc.GameScene.flight:
-            return {"flight.active": False}
+        scene = conn.krpc.current_game_scene
+        if scene == conn.krpc.GameScene.editor_vab:
+            mode = "editor_vab"
+        elif scene == conn.krpc.GameScene.editor_sph:
+            mode = "editor_sph"
+        elif scene == conn.krpc.GameScene.flight:
+            mode = "flight"
+        else:
+            mode = "inactive"
+
+        if mode != _telemetry_mode:
+            previous_mode = _telemetry_mode
+            _stage_trace("mode_transition", previous=previous_mode, current=mode)
+            if mode == "flight":
+                _stage_trace("cache_clear", reason="enter_flight",
+                             previous=_stage_summary(_stage_cache))
+                _stage_cache = {}
+                _stage_last_poll = 0.0
+                _stage_last_ut = None
+            _telemetry_mode = mode
+            _stage_trace_last_published = None
+            _editor_bodies_cache = []
+            _reset_editor_stage_state()
+
+        if mode == "editor_vab":
+            return _gather_editor_telemetry(conn, "VAB")
+        if mode == "editor_sph":
+            return _gather_editor_telemetry(conn, "SPH")
+        if mode != "flight":
+            return {
+                "context.mode": "inactive",
+                "flight.active": False,
+                "editor.active": False,
+            }
     except Exception:
         pass
 
@@ -743,9 +1001,15 @@ def gather_telemetry(conn):
         # tracking station, VAB, main menu, or a scene load). The dashboard uses
         # this flag to show its "No Flight in Progress" overlay instead of
         # guessing from absent keys.
-        return {"flight.active": False}
+        return {
+            "context.mode": "inactive",
+            "flight.active": False,
+            "editor.active": False,
+        }
 
+    d["context.mode"] = "flight"
     d["flight.active"] = True
+    d["editor.active"] = False
     now = time.time()
 
     # ---- clocks (every tick) ----
@@ -851,6 +1115,11 @@ def gather_telemetry(conn):
     # stage snapshot across that boundary.
     if universal_time is not None:
         if _stage_last_ut is not None and universal_time < _stage_last_ut:
+            _stage_trace(
+                "ut_rewind", previousUt=_stage_last_ut,
+                currentUt=universal_time,
+                previousCache=_stage_summary(_stage_cache),
+            )
             _stage_cache = {}
             _stage_last_poll = 0.0
         _stage_last_ut = universal_time
@@ -860,10 +1129,17 @@ def gather_telemetry(conn):
         try:
             result = _gather_stages(conn)
             if result:
+                previous_stage_cache = _stage_summary(_stage_cache)
                 _stage_cache = result
+                _stage_trace(
+                    "cache_replace", source="flight",
+                    previous=previous_stage_cache,
+                    current=_stage_summary(result),
+                )
         except Exception:
             pass  # keep last good cache through scene changes
     d.update(_stage_cache)
+    _trace_stage_publish(d, "flight")
 
     # ---- science aboard: VesselScience, with stock experiment fallback ----
     global _sci_cache, _sci_last_poll
@@ -1031,12 +1307,19 @@ def run_telemetry_server(host, port):
 
     print(f"[telemetry] serving dashboard on ws://{host}:{port}  ({TELEMETRY_HZ} Hz)")
     clients = set()
+    commands = asyncio.Queue()
 
     async def handler(ws, *args):  # *args tolerates old & new websockets signatures
         clients.add(ws)
         try:
-            async for _ in ws:
-                pass  # ignore the dashboard's subscription msg; we push everything
+            async for raw in ws:
+                try:
+                    command = json.loads(raw)
+                    if (isinstance(command, dict) and
+                            command.get("type") == "editor.conditions"):
+                        await commands.put(command)
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    pass
         except Exception:
             pass
         finally:
@@ -1048,6 +1331,12 @@ def run_telemetry_server(host, port):
         while True:
             if clients:
                 try:
+                    # Serialize commands and reads through this connection;
+                    # kRPC's protobuf stream is not safe for concurrent calls.
+                    while not commands.empty():
+                        command = commands.get_nowait()
+                        await loop.run_in_executor(
+                            None, _apply_telemetry_command, tconn, command)
                     # run the blocking kRPC gather off the event loop
                     data = await loop.run_in_executor(None, gather_telemetry, tconn)
                     # Reject any non-finite value that escaped _json_safe.

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -997,10 +997,10 @@ def gather_telemetry(conn):
         sc = conn.space_center
         vessel = sc.active_vessel
     except Exception:
-        # Connected to kRPC, but no active vessel -- not in flight (in the
-        # tracking station, VAB, main menu, or a scene load). The dashboard uses
-        # this flag to show its "No Flight in Progress" overlay instead of
-        # guessing from absent keys.
+        # Connected to kRPC, but no active vessel in a supported context (for
+        # example, the tracking station, space center, main menu, or a scene
+        # load). The dashboard uses this mode to show its inactive-scene overlay
+        # instead of guessing from absent keys.
         return {
             "context.mode": "inactive",
             "flight.active": False,

--- a/tests/dashboard_consumables_lifecycle.html
+++ b/tests/dashboard_consumables_lifecycle.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dashboard consumables lifecycle regression</title>
+</head>
+<body>
+  <h1>Dashboard consumables lifecycle regression</h1>
+  <pre id="result">Running…</pre>
+  <iframe id="dashboard" src="../ksp_mission_dashboard.html" hidden></iframe>
+  <script>
+    const result = document.getElementById("result");
+    const frame = document.getElementById("dashboard");
+
+    function assert(condition, message) {
+      if (!condition) throw new Error(message);
+    }
+
+    frame.addEventListener("load", () => {
+      try {
+        const dashboard = frame.contentWindow;
+        const document = frame.contentDocument;
+        const payload = {
+          "res.names": ["LiquidFuel", "Oxidizer"],
+          "r.resource[LiquidFuel]": 90,
+          "r.resourceMax[LiquidFuel]": 100,
+          "r.resourceCurrent[LiquidFuel]": 45,
+          "r.resourceCurrentMax[LiquidFuel]": 50,
+          "r.resource[Oxidizer]": 110,
+          "r.resourceMax[Oxidizer]": 120,
+          "r.resourceCurrent[Oxidizer]": 55,
+          "r.resourceCurrentMax[Oxidizer]": 60,
+          "res.stageKnown": true
+        };
+
+        dashboard.updateResources(payload);
+        assert(document.querySelectorAll("#resRows .res-row").length === 2,
+          "initial flight did not build consumable rows");
+
+        // Exercise the failure sequence: flight -> inactive/editor DOM reset
+        // -> same-craft flight with an unchanged res.names signature.
+        dashboard.nullOutDashboard();
+        assert(document.querySelectorAll("#resRows .res-row").length === 0,
+          "lifecycle reset did not clear consumable rows");
+
+        dashboard.updateResources(payload);
+        assert(document.querySelectorAll("#resRows .res-row").length === 2,
+          "same-craft flight did not rebuild consumable rows");
+        assert(document.getElementById("rtv_LiquidFuel").textContent !== "—",
+          "rebuilt LiquidFuel row did not receive values");
+
+        result.textContent = "PASS: consumables rebuild after a lifecycle reset with unchanged resource names.";
+        result.dataset.status = "pass";
+      } catch (error) {
+        result.textContent = `FAIL: ${error.stack || error}`;
+        result.dataset.status = "fail";
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tests/dashboard_staging_modes.html
+++ b/tests/dashboard_staging_modes.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dashboard staging mode regression</title>
+  <style>
+    body{margin:0;font:14px system-ui;background:#111;color:#eee}
+    #result{margin:0;padding:12px;white-space:pre-wrap}
+    #dashboard{display:block;width:100%;height:900px;border:0}
+  </style>
+</head>
+<body>
+  <pre id="result">Running…</pre>
+  <iframe id="dashboard" src="../ksp_mission_dashboard.html"></iframe>
+  <script>
+    const result = document.getElementById("result");
+    const frame = document.getElementById("dashboard");
+
+    function assert(condition, message) {
+      if (!condition) throw new Error(message);
+    }
+
+    frame.addEventListener("load", () => {
+      try {
+        const dashboard = frame.contentWindow;
+        const document = frame.contentDocument;
+        const stages = [
+          {index:0,ksp:0,dvAtmo:500,dvVac:650,twr:0.8,twrAtmo:0.8,twrVac:1.0,burn:42},
+          {index:1,ksp:1,dvAtmo:0,dvVac:0,twr:0,twrAtmo:0,twrVac:0,burn:0},
+          {index:2,ksp:2,dvAtmo:1000,dvVac:1200,twr:1.25,twrAtmo:1.25,twrVac:1.55,burn:75}
+        ];
+        const stagePayload = {
+          "stage.available": true,
+          "stage.complete": true,
+          "stage.currentKsp": 2,
+          "stage.stages": stages,
+          "stage.totalDvAtmo": 1500,
+          "stage.totalDvVac": 1850
+        };
+        const editorPayload = {
+          ...stagePayload,
+          "context.mode": "editor",
+          "editor.craftName": "Dual-condition regression craft",
+          "editor.facility": "VAB",
+          "editor.bodies": ["Kerbin", "Mun"],
+          "editor.body": "Kerbin",
+          "editor.altitude": 0,
+          "editor.mach": 0,
+          "editor.stable": true
+        };
+
+        dashboard.onDataKrpc(editorPayload);
+        assert(document.body.classList.contains("editor-mode"),
+          "editor payload did not select editor mode");
+        assert(getComputedStyle(document.querySelector(".editor-dv-grid")).display === "grid",
+          "editor dual-condition summary is not visible");
+        assert(getComputedStyle(document.querySelector(".flight-dv-grid")).display === "none",
+          "compact flight summary remained visible in editor mode");
+        assert(getComputedStyle(document.getElementById("dvModeToggle")).display === "none",
+          "flight condition toggle remained visible in editor mode");
+        assert(document.getElementById("ed_dv_stage_atmo").textContent === "1,000 m/s",
+          "editor atmospheric stage delta-v is wrong");
+        assert(document.getElementById("ed_dv_stage_vac").textContent === "1,200 m/s",
+          "editor vacuum stage delta-v is wrong");
+        assert(document.getElementById("ed_twr_atmo").textContent === "1.25",
+          "editor atmospheric TWR is wrong");
+        assert(document.getElementById("ed_twr_vac").textContent === "1.55",
+          "editor vacuum TWR is wrong");
+        assert(document.querySelectorAll("#stageTable .st-head span").length === 6,
+          "editor stage table does not have dual-condition columns");
+
+        dashboard.onDataKrpc({...stagePayload,"context.mode":"flight","flight.active":true});
+        assert(!document.body.classList.contains("editor-mode"),
+          "flight payload did not leave editor mode");
+        assert(getComputedStyle(document.querySelector(".flight-dv-grid")).display === "grid",
+          "compact flight summary is not visible in flight mode");
+        assert(document.getElementById("dv_stage").textContent === "1,000 m/s",
+          "flight atmospheric delta-v is wrong");
+        assert(document.getElementById("dv_twr").textContent === "1.25",
+          "flight atmospheric TWR is wrong");
+        assert(document.querySelectorAll("#stageTable .st-head span").length === 4,
+          "flight stage table did not retain its compact columns");
+
+        document.getElementById("dvModeToggle").click();
+        assert(document.getElementById("dv_stage").textContent === "1,200 m/s",
+          "flight vacuum toggle did not select vacuum delta-v");
+        assert(document.getElementById("dv_twr").textContent === "1.55",
+          "flight vacuum toggle did not select vacuum TWR");
+
+        // Leave the visible fixture in editor mode for visual inspection.
+        dashboard.onDataKrpc(editorPayload);
+        document.body.classList.remove("modal-open");
+        document.querySelectorAll(".scrim").forEach(scrim=>scrim.classList.remove("show"));
+
+        result.textContent = "PASS: editor shows atmospheric and vacuum Δv/TWR together; flight retains its compact toggle.";
+        result.dataset.status = "pass";
+      } catch (error) {
+        result.textContent = `FAIL: ${error.stack || error}`;
+        result.dataset.status = "fail";
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tests/dashboard_staging_modes.html
+++ b/tests/dashboard_staging_modes.html
@@ -24,6 +24,8 @@
       try {
         const dashboard = frame.contentWindow;
         const document = frame.contentDocument;
+        assert(document.querySelector("#scrimNoFlight h3").textContent.includes("Awaiting Flight or Editor"),
+          "inactive overlay does not describe flight/editor support");
         const stages = [
           {index:0,ksp:0,dvAtmo:500,dvVac:650,twr:0.8,twrAtmo:0.8,twrVac:1.0,burn:42},
           {index:1,ksp:1,dvAtmo:0,dvVac:0,twr:0,twrAtmo:0,twrVac:0,burn:0},

--- a/tests/test_stage_diagnostics.py
+++ b/tests/test_stage_diagnostics.py
@@ -1,0 +1,101 @@
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+sys.modules.setdefault("krpc", types.ModuleType("krpc"))
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import telemetry_server
+
+
+def _load_probe_module():
+    path = ROOT / "tools" / "probe_stage_stats.py"
+    spec = importlib.util.spec_from_file_location("probe_stage_stats", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+probe_stage_stats = _load_probe_module()
+
+
+class FakeStageStats:
+    available = True
+
+    def __init__(self, count, current):
+        self.count = count
+        self.current = current
+
+    def stage_count(self):
+        return self.count
+
+    def current_stage(self):
+        return self.current
+
+    def stage_delta_v(self, index, vacuum):
+        return (index + 1) * (200.0 if vacuum else 100.0)
+
+    def stage_twr(self, index, vacuum):
+        return (index + 1) * (2.0 if vacuum else 1.0)
+
+    def stage_burn_time(self, index, vacuum):
+        return (index + 1) * 10.0
+
+
+class FakeVessel:
+    name = "Diagnostic Craft"
+    id = "vessel-guid"
+
+
+class FakeConnection:
+    def __init__(self, service):
+        self.stage_stats = service
+        self.krpc = types.SimpleNamespace(current_game_scene="flight")
+        self.space_center = types.SimpleNamespace(active_vessel=FakeVessel())
+
+
+class StageDiagnosticsTests(unittest.TestCase):
+    def test_telemetry_trace_records_incomplete_service_sample(self):
+        conn = FakeConnection(FakeStageStats(count=7, current=7))
+        output = io.StringIO()
+
+        with mock.patch.object(telemetry_server, "STAGE_TRACE_ENABLED", True), \
+                mock.patch.object(telemetry_server, "STAGE_SETTLE_SECONDS", 0), \
+                contextlib.redirect_stdout(output):
+            result = telemetry_server._gather_stages(conn)
+
+        self.assertEqual(result["stage.count"], 7)
+        self.assertEqual(result["stage.currentKsp"], 7)
+        self.assertFalse(result["stage.complete"])
+        self.assertEqual(result["stage.stages"], [])
+
+        prefix = "[stage-trace] "
+        trace = json.loads(output.getvalue().split(prefix, 1)[1])
+        self.assertEqual(trace["event"], "service_sample")
+        self.assertEqual(trace["expectedCount"], 8)
+        self.assertFalse(trace["complete"])
+
+    def test_raw_probe_records_complete_rows(self):
+        conn = FakeConnection(FakeStageStats(count=2, current=1))
+
+        record = probe_stage_stats.sample(conn, settle_seconds=0)
+
+        self.assertTrue(record["complete"])
+        self.assertEqual(record["count"], 2)
+        self.assertEqual(record["expectedCount"], 2)
+        self.assertEqual(len(record["rows"]), 2)
+        self.assertEqual(record["rowErrors"], [])
+        self.assertEqual(record["vesselId"], "vessel-guid")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -129,15 +129,14 @@ foreach ($file in $dllFiles) {
     Assert-RequiredFile (Join-Path $GameDataPath $file.Source)
 }
 
-# v0.1.5 requires the StageStats revert-safe service. Older release DLLs expose
-# the same RPC surface but can retain a destroyed MechJeb module after reverting
-# to launch, producing frozen delta-v and incomplete stage rows. Fail before
-# packaging instead of silently reusing the v0.1.1 binary.
+# v0.2.0 requires the editor-capable StageStats service. Older release DLLs do
+# not expose the VAB/SPH planning API or the corrected initial-TWR calculation.
+# Fail before packaging instead of silently producing a flight-only release.
 $stageStatsDll = Join-Path $GameDataPath 'KRPC.StageStats/KRPC.StageStats.dll'
 $stageStatsVersion = [System.Reflection.AssemblyName]::GetAssemblyName(
     $stageStatsDll
 ).Version
-$requiredStageStatsVersion = [Version]'0.1.2.0'
+$requiredStageStatsVersion = [Version]'0.2.0.0'
 if ($stageStatsVersion -ne $requiredStageStatsVersion) {
     throw "KRPC.StageStats.dll must be version $requiredStageStatsVersion for v$Version; found $stageStatsVersion. Rebuild the service in Woobies-KRPC-Service-Builder and update its dist/GameData copy."
 }

--- a/tools/probe_stage_stats.py
+++ b/tools/probe_stage_stats.py
@@ -1,0 +1,168 @@
+"""Poll the raw KRPC.StageStats service and write JSON Lines diagnostics.
+
+This probe deliberately bypasses telemetry_server.py. Run it alongside the
+dashboard feed while reproducing a launch/revert failure to determine whether
+the service itself recovers before telemetry caching is involved.
+
+Requires: pip install krpc
+"""
+
+import argparse
+import json
+import sys
+import time
+
+import krpc
+
+
+def _safe(call, default=None):
+    try:
+        return call()
+    except Exception:
+        return default
+
+
+def _scene_name(conn):
+    scene = _safe(lambda: conn.krpc.current_game_scene)
+    return str(scene) if scene is not None else None
+
+
+def _vessel_identity(conn):
+    vessel = _safe(lambda: conn.space_center.active_vessel)
+    if vessel is None:
+        return {"vesselName": None, "vesselId": None}
+    vessel_id = _safe(lambda: vessel.id)
+    return {
+        "vesselName": _safe(lambda: vessel.name),
+        "vesselId": str(vessel_id) if vessel_id is not None else None,
+    }
+
+
+def _stage_rows(service, count):
+    rows = []
+    errors = []
+    for index in range(max(0, count)):
+        try:
+            rows.append({
+                "index": index,
+                "dvAtmo": service.stage_delta_v(index, False),
+                "dvVac": service.stage_delta_v(index, True),
+                "twrAtmo": service.stage_twr(index, False),
+                "twrVac": service.stage_twr(index, True),
+                "burn": service.stage_burn_time(index, False),
+            })
+        except Exception as exc:
+            errors.append({
+                "index": index,
+                "error": type(exc).__name__,
+                "message": str(exc),
+            })
+    return rows, errors
+
+
+def sample(conn, settle_seconds):
+    record = {
+        "wallTime": round(time.time(), 3),
+        "monotonic": round(time.monotonic(), 3),
+        "scene": _scene_name(conn),
+    }
+    record.update(_vessel_identity(conn))
+
+    try:
+        service = conn.stage_stats
+        record["available"] = bool(service.available)
+        if not record["available"]:
+            return record
+
+        record["primeCount"] = int(service.stage_count())
+        time.sleep(settle_seconds)
+        record["count"] = int(service.stage_count())
+        record["currentKsp"] = int(service.current_stage())
+        record["expectedCount"] = max(0, record["currentKsp"] + 1)
+        record["complete"] = record["count"] == record["expectedCount"]
+        record["rows"], record["rowErrors"] = _stage_rows(
+            service, record["count"]
+        )
+        record["finalCount"] = int(service.stage_count())
+        record["finalCurrentKsp"] = int(service.current_stage())
+    except Exception as exc:
+        record["error"] = type(exc).__name__
+        record["message"] = str(exc)
+    return record
+
+
+def _write(record, output):
+    line = json.dumps(record, sort_keys=True, default=str)
+    print(line, flush=True)
+    if output is not None:
+        output.write(line + "\n")
+        output.flush()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Continuously poll raw KRPC.StageStats lifecycle state."
+    )
+    parser.add_argument("--interval", type=float, default=0.5,
+                        help="seconds between samples (default: 0.5)")
+    parser.add_argument("--settle", type=float, default=0.12,
+                        help="seconds between prime and read calls (default: 0.12)")
+    parser.add_argument("--samples", type=int, default=0,
+                        help="stop after N samples; 0 runs until Ctrl+C")
+    parser.add_argument("--output",
+                        help="optional JSONL file; stdout is always retained")
+    args = parser.parse_args(argv)
+    if args.interval < 0 or args.settle < 0 or args.samples < 0:
+        parser.error("interval, settle, and samples must be non-negative")
+
+    output = open(args.output, "a", encoding="utf-8") if args.output else None
+    conn = None
+    emitted = 0
+    try:
+        while args.samples == 0 or emitted < args.samples:
+            started = time.monotonic()
+            if conn is None:
+                try:
+                    conn = krpc.connect(name="StageStats raw lifecycle probe")
+                    _write({
+                        "event": "connected",
+                        "wallTime": round(time.time(), 3),
+                    }, output)
+                except Exception as exc:
+                    _write({
+                        "event": "connect_error",
+                        "wallTime": round(time.time(), 3),
+                        "error": type(exc).__name__,
+                        "message": str(exc),
+                    }, output)
+                    time.sleep(max(args.interval, 0.25))
+                    continue
+
+            record = sample(conn, args.settle)
+            _write(record, output)
+            emitted += 1
+            if "error" in record:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                conn = None
+
+            remaining = args.interval - (time.monotonic() - started)
+            if remaining > 0:
+                time.sleep(remaining)
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        if output is not None:
+            output.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add MechJeb-backed VAB/SPH craft planning with selectable reference body, altitude, and Mach
- show atmospheric and vacuum delta-v and initial TWR side by side in editor mode while retaining the compact flight toggle
- make consumables and StageStats recover cleanly across scene changes, launches, dashboard reconnects, and KSP reverts
- add opt-in StageStats tracing, a raw lifecycle probe, browser/telemetry regressions, and v0.2.0 release metadata

## Why

The editor-capable service and telemetry fields existed during v0.2.0 development, but the dashboard renderer had regressed to the flight-only condition toggle. Separately, `nullOutDashboard()` cleared generated consumable rows without invalidating the renderer signature, so same-craft flights could receive valid resource data with no DOM rows to update.

Tracing also confirmed that the StageStats TWR calculation combined maximum thrust with starting mass, matching neither MechJeb Initial TWR nor Max TWR. The packaged local-only StageStats 0.2.0 build now uses `StartThrust / (StartMass * g)` and rejects incomplete/mixed lifecycle snapshots instead of displaying stale pre-revert data.

## Validation

- full clean release build of all three kRPC services: zero warnings/errors; release verification passed
- `KRPC.StageStats.dll` 0.2.0.0 SHA-256: `F18DBE497C2ED61285908869323241B8135312ADE7425AF3417488E1FAF7B911`
- Python compilation passed for telemetry, launcher, panel bridge, and raw probe
- 2 StageStats diagnostic unit tests passed
- dashboard JavaScript and both browser fixtures passed syntax checks
- browser regression passed editor dual-condition rendering, editor-to-flight transition, flight atmospheric/vacuum toggle, and consumable-row rebuild
- in KSP, Initial TWR matched MechJeb in VAB and flight; fresh launch, Revert to Launch, and Revert to Editor all repopulated planning/staging/consumables
- package-only v0.2.0 release audit passed with exactly three DLLs and allowlisted files

## Release gate

Keep this PR draft until the ZIP built from this commit is installed and tested, including an SPH planning pass. The ESP32 path is unchanged; `panel_bridge.py` was not modified.