### PR TITLE
Simplify Windows setup for v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable public changes will be recorded here.
 
+## v0.2.1 - Simplified Windows setup
+
+- Added automatic first-run creation and repair of the isolated Python
+  environment, removing the normal need to copy setup commands from the README.
+- Added a non-blocking, cached GitHub release check to the launcher with manual
+  refresh, a release-page link, and a control for disabling automatic checks.
+- Added a packaged `QUICKSTART.txt` and made the automatic setup path primary in
+  the README while retaining manual commands as a troubleshooting fallback.
+- Continued to package the v0.2.0 KSP service DLLs without changing telemetry,
+  dashboard schema, or in-game behavior.
+
 ## v0.2.0 - Editor craft planning
 
 - Added MechJeb-backed stage analysis in the VAB and SPH with selectable

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -1,0 +1,37 @@
+WOOBIE'S MISSION CONTROL - WINDOWS QUICK START
+==============================================
+
+1. INSTALL THE KSP SERVICES
+
+   Close KSP. Copy the three folders inside this package's GameData folder
+   into Kerbal Space Program\GameData:
+
+     KRPC.StageStats
+     KRPC.SystemHeat
+     KRPC.VesselScience
+
+   Copy the folders themselves, not the package's top-level GameData folder.
+   The kRPC KSP mod is required. Other supported mods enable optional panels.
+
+2. SET UP AND START THE DASHBOARD
+
+   Open this package's Dashboard folder and double-click:
+
+     Start KSP Dashboard.bat
+
+   On the first run, approve the setup prompt. The launcher creates an
+   isolated .venv folder and downloads the required Python packages into it.
+   It does not add, upgrade, or remove packages in your system Python.
+
+   Python 3.14 is required for this release. If it is not installed, the
+   launcher provides the official download address and can be run again after
+   Python is installed.
+
+3. CONNECT TO KSP
+
+   Start KSP, enable its kRPC server, and load a vessel or open the VAB/SPH.
+   In the Mission Control launcher, start Dashboard feed (telemetry). The
+   dashboard opens in your browser automatically.
+
+For component choices, compatibility information, troubleshooting, and ESP32
+control-pad instructions, see README.md.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Woobie's Mission Control
 
-Current release: **v0.2.0**
+Current release: **v0.2.1**
+
+For the fastest Windows release setup, start with
+[`QUICKSTART.txt`](QUICKSTART.txt). It covers the `GameData` copy and automatic
+first-run dashboard setup; the full component, compatibility, and
+troubleshooting details remain below.
 
 A modular mission dashboard and optional ESP32 control-pad bridge for Kerbal
 Space Program 1, powered by [kRPC](https://krpc.github.io/krpc/).
@@ -167,36 +172,41 @@ For the ESP32 control pad, also keep:
 - `panel_bridge.py`
 - `firmware/KSP_control.ino` when programming or modifying the panel
 
-### 3. Create a Python environment
+### 3. Run the automatic first-time setup
 
-Choose the folder that contains `Start KSP Dashboard.bat` and the requirements
-files:
+Python 3.14 is required for the current release. Open the folder that contains
+`Start KSP Dashboard.bat`:
 
 - In the complete release ZIP, this is the extracted `Dashboard` folder—not the
   package's top-level folder.
 - In a source checkout, this is the repository root.
 
-Open Command Prompt or PowerShell in that folder and run:
+Double-click `Start KSP Dashboard.bat`. On the first run, approve the setup
+prompt. The launcher creates `.venv`, installs all dashboard and control-pad
+dependencies into that isolated folder, verifies them, and then opens Mission
+Control. It does not install, upgrade, or remove packages in the system Python
+environment.
+
+If setup is interrupted, run the launcher again. It will reuse and repair the
+local environment without requiring Python to be reinstalled. Setup details are
+written to `mission_control_setup.log`; review that file before sharing it
+because it can contain local paths.
+
+For a read-only diagnostic from Command Prompt, run:
+
+```bat
+"Start KSP Dashboard.bat" --check
+```
+
+For source development or manual troubleshooting, the equivalent commands are:
 
 ```bat
 py -3.14 -m venv .venv
-```
-
-Install only the dependencies for the component you want:
-
-```bat
-rem Dashboard only
-.venv\Scripts\python.exe -m pip install -r requirements-dashboard.txt
-
-rem ESP32 panel only
-.venv\Scripts\python.exe -m pip install -r requirements-panel.txt
-
-rem Everything
 .venv\Scripts\python.exe -m pip install -r requirements.txt
 ```
 
-The launcher automatically uses `.venv` when that folder is beside
-`Start KSP Dashboard.bat`.
+The component-specific requirements files remain available to developers who
+do not want the complete environment.
 
 ### 4. Start KSP and the tools
 
@@ -224,6 +234,12 @@ in Arduino IDE.
 
 ## Network and safety notes
 
+- By default, the launcher makes one cached HTTPS request per day to GitHub's
+  public Releases API to report whether a newer stable release is available.
+  It sends no authentication token or Mission Control telemetry. Automatic
+  checks can be disabled in the launcher, and `Check now` remains available.
+  The preference and last successful result are stored under
+  `%LOCALAPPDATA%\WoobiesMissionControl` on Windows.
 - Keep the telemetry server bound to `127.0.0.1` unless you intentionally need
   another device on your trusted local network to view it.
 - The WebSocket feed is read-only but has no authentication or encryption. Do
@@ -241,6 +257,12 @@ in Arduino IDE.
 
 Make sure `telemetry_server.py` and/or `panel_bridge.py` is in the same folder as
 `ksp_dashboard_app.py`. Only installed components are displayed.
+
+### The launcher could not check for updates
+
+Update checks require internet access to `api.github.com`. A failed check does
+not affect Mission Control or its local KSP connection; use `Check now` later or
+open the project page from the About dialog.
 
 ### The dashboard says it is offline
 
@@ -290,7 +312,7 @@ From a clean, up-to-date `main` checkout, first create and audit the package
 without changing anything on GitHub:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.0
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.1
 ```
 
 The script writes the ZIP, SHA-256 checksum, and generated release notes to the
@@ -310,7 +332,7 @@ Open a new PowerShell window after installation, authenticate once with
 `gh auth login`, and then rerun:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.0 -CreateDraftRelease
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.1 -CreateDraftRelease
 ```
 
 The release remains private as a draft until it is reviewed and published on

--- a/Start KSP Dashboard.bat
+++ b/Start KSP Dashboard.bat
@@ -1,11 +1,18 @@
 @echo off
-setlocal
+setlocal EnableExtensions
 
-rem Launch the modular KSP component window. The Python launcher discovers
-rem telemetry_server.py and panel_bridge.py at runtime, and shows only the
-rem components whose scripts are present beside it.
+rem First-run bootstrapper and launcher for Woobie's Mission Control.
+rem The bootstrapper creates an isolated .venv beside this file. It never
+rem installs or removes packages from the user's system Python environment.
 
 set "APP=%~dp0ksp_dashboard_app.py"
+set "VENV_DIR=%~dp0.venv"
+set "VENV_PYTHON=%VENV_DIR%\Scripts\python.exe"
+set "VENV_PYTHONW=%VENV_DIR%\Scripts\pythonw.exe"
+set "REQUIREMENTS=%~dp0requirements.txt"
+set "SETUP_LOG=%~dp0mission_control_setup.log"
+set "SETUP_ONLY="
+set "BOOTSTRAP_KIND="
 
 if not exist "%APP%" (
     echo ERROR: ksp_dashboard_app.py was not found beside this launcher.
@@ -14,46 +21,151 @@ if not exist "%APP%" (
     exit /b 1
 )
 
-rem Prefer a project-local virtual environment when one has been created using
-rem the README instructions. This keeps dashboard packages isolated from other
-rem Python programs on the computer.
-if exist "%~dp0.venv\Scripts\pythonw.exe" (
-    start "" "%~dp0.venv\Scripts\pythonw.exe" "%APP%"
+if /I "%~1"=="--check" goto check_only
+if /I "%~1"=="--setup-only" (
+    set "SETUP_ONLY=1"
+    goto setup
+)
+if not "%~1"=="" (
+    echo ERROR: Unknown option "%~1".
+    echo Supported options: --check, --setup-only
+    pause
+    exit /b 2
+)
+
+call :venv_ready
+if not errorlevel 1 goto launch
+
+echo.
+echo Woobie's Mission Control needs a one-time setup.
+echo.
+echo This will:
+echo   - create an isolated .venv folder beside this launcher
+echo   - download the required Python packages into that folder
+echo   - leave your system Python and its packages unchanged
+echo.
+choice /C YN /N /M "Set up Mission Control now? [Y/N] "
+if errorlevel 2 exit /b 1
+
+:setup
+if not exist "%REQUIREMENTS%" (
+    echo.
+    echo ERROR: requirements.txt was not found beside this launcher.
+    echo Expected: "%REQUIREMENTS%"
+    pause
+    exit /b 1
+)
+
+call :find_python
+if errorlevel 1 goto python_missing
+
+>"%SETUP_LOG%" echo Woobie's Mission Control setup log
+>>"%SETUP_LOG%" echo Started: %DATE% %TIME%
+>>"%SETUP_LOG%" echo Launcher folder: "%~dp0"
+
+echo.
+echo [1/3] Creating or repairing the local Python environment...
+if "%BOOTSTRAP_KIND%"=="py" (
+    py -3.14 -m venv "%VENV_DIR%" >>"%SETUP_LOG%" 2>&1
+) else (
+    python.exe -m venv "%VENV_DIR%" >>"%SETUP_LOG%" 2>&1
+)
+if errorlevel 1 goto setup_failed
+
+echo [2/3] Installing Mission Control dependencies...
+echo       This can take a minute on the first run.
+"%VENV_PYTHON%" -m pip install --disable-pip-version-check -r "%REQUIREMENTS%" >>"%SETUP_LOG%" 2>&1
+if errorlevel 1 goto setup_failed
+
+echo [3/3] Verifying the installation...
+call :venv_ready
+if errorlevel 1 goto setup_failed
+
+>>"%SETUP_LOG%" echo Completed: %DATE% %TIME%
+echo.
+echo Setup complete. Your system Python installation was not changed.
+
+if defined SETUP_ONLY exit /b 0
+
+:launch
+if exist "%VENV_PYTHONW%" (
+    start "" "%VENV_PYTHONW%" "%APP%"
     exit /b 0
 )
 
-if exist "%~dp0.venv\Scripts\python.exe" (
-    start "KSP Components" "%~dp0.venv\Scripts\python.exe" "%APP%"
+if exist "%VENV_PYTHON%" (
+    start "KSP Components" "%VENV_PYTHON%" "%APP%"
     exit /b 0
 )
 
-rem Prefer the windowless Python executables so the GUI has no extra console.
-where pythonw.exe >nul 2>&1
+echo ERROR: The local Python environment disappeared before launch.
+pause
+exit /b 1
+
+:check_only
+echo Checking Woobie's Mission Control without changing any files...
+echo.
+call :venv_ready
 if not errorlevel 1 (
-    start "" pythonw.exe "%APP%"
+    echo READY: The local environment and required packages are installed.
+    "%VENV_PYTHON%" --version
     exit /b 0
 )
 
-where pyw.exe >nul 2>&1
+if exist "%VENV_PYTHON%" (
+    echo INCOMPLETE: A local environment exists, but required packages are missing.
+) else (
+    echo NOT SET UP: No local environment exists beside this launcher.
+)
+
+call :find_python
+if errorlevel 1 (
+    echo Python 3.14 was not detected. No changes were made.
+    exit /b 1
+)
+
+echo Python 3.14 is available for first-run setup. No changes were made.
+exit /b 2
+
+:venv_ready
+if not exist "%VENV_PYTHON%" exit /b 1
+"%VENV_PYTHON%" -c "import importlib.metadata as m, sys, tkinter, krpc, websockets, serial; expected={'krpc':'0.5.4','websockets':'16.0','pyserial':'3.5'}; raise SystemExit(0 if sys.version_info[:2] == (3, 14) and all(m.version(name) == version for name, version in expected.items()) else 1)" >nul 2>&1
+exit /b %errorlevel%
+
+:find_python
+py -3.14 -c "import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 14) else 1)" >nul 2>&1
 if not errorlevel 1 (
-    start "" pyw.exe -3 "%APP%"
+    set "BOOTSTRAP_KIND=py"
     exit /b 0
 )
 
-rem Fall back to a visible console, which also makes Python errors readable.
-where python.exe >nul 2>&1
+python.exe -c "import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 14) else 1)" >nul 2>&1
 if not errorlevel 1 (
-    start "KSP Components" python.exe "%APP%"
+    set "BOOTSTRAP_KIND=python"
     exit /b 0
 )
 
-where py.exe >nul 2>&1
-if not errorlevel 1 (
-    start "KSP Components" py.exe -3 "%APP%"
-    exit /b 0
-)
+exit /b 1
 
-echo ERROR: Python 3 was not found on PATH.
-echo Install Python 3 from https://www.python.org/ and enable "Add Python to PATH".
+:python_missing
+echo.
+echo ERROR: Python 3.14 was not found.
+echo.
+echo Install Python 3.14 from:
+echo https://www.python.org/downloads/windows/
+echo.
+echo During installation, enable "Add python.exe to PATH", then run this
+echo launcher again. Mission Control will keep its packages isolated in .venv.
+pause
+exit /b 1
+
+:setup_failed
+echo.
+echo ERROR: Mission Control setup did not complete.
+echo No system Python packages were installed or removed.
+echo Review the setup log for details:
+echo "%SETUP_LOG%"
+echo.
+echo Running this launcher again will safely retry and repair the local .venv.
 pause
 exit /b 1

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -14,11 +14,16 @@ The launcher itself uses only the Python standard library. Each optional script
 is responsible for its own dependencies.
 """
 
+import json
 import os
 import queue
+import re
 import subprocess
 import sys
 import threading
+import time
+import urllib.parse
+import urllib.request
 import webbrowser
 from pathlib import Path
 
@@ -30,9 +35,26 @@ HERE = Path(__file__).resolve().parent
 DASHBOARD = HERE / "ksp_mission_dashboard.html"
 PYTHON = sys.executable
 APP_NAME = "Woobie's Mission Control"
-APP_VERSION = "0.2.0"
+APP_VERSION = "0.2.1"
 APP_AUTHOR = "SacredWoobie"
 PROJECT_URL = "https://github.com/SacredWoobie/woobies-mission-control"
+LATEST_RELEASE_API = (
+    "https://api.github.com/repos/SacredWoobie/"
+    "woobies-mission-control/releases/latest"
+)
+UPDATE_CACHE_SECONDS = 24 * 60 * 60
+UPDATE_TIMEOUT_SECONDS = 4
+_VERSION_TAG = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+
+def _default_update_state_path():
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        return Path(local_app_data) / "WoobiesMissionControl" / "update_state.json"
+    return Path.home() / ".woobies-mission-control" / "update_state.json"
+
+
+UPDATE_STATE_PATH = _default_update_state_path()
 
 # Add future optional programs here. The GUI will expose a component only when
 # its script is present beside this launcher.
@@ -55,6 +77,109 @@ COMPONENTS = (
 
 # Prevent child processes from opening extra console windows on Windows.
 CREATE_NO_WINDOW = 0x08000000 if os.name == "nt" else 0
+
+
+def parse_version_tag(tag):
+    """Return a comparable three-part version tuple, or ``None``."""
+    if not isinstance(tag, str):
+        return None
+    match = _VERSION_TAG.fullmatch(tag.strip())
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def classify_release(current_version, latest_tag):
+    """Classify *latest_tag* as current, available, or behind this build."""
+    current = parse_version_tag(current_version)
+    latest = parse_version_tag(latest_tag)
+    if current is None or latest is None:
+        raise ValueError("release versions must use vMAJOR.MINOR.PATCH")
+    if latest > current:
+        return "available"
+    if latest < current:
+        return "development"
+    return "current"
+
+
+def validate_release_payload(payload):
+    """Validate and return the update fields used from a GitHub response."""
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub returned an invalid release response")
+
+    tag_name = payload.get("tag_name")
+    html_url = payload.get("html_url")
+    if parse_version_tag(tag_name) is None:
+        raise ValueError("the latest release tag is not vMAJOR.MINOR.PATCH")
+    if not isinstance(html_url, str):
+        raise ValueError("the latest release does not have a web address")
+
+    parsed = urllib.parse.urlparse(html_url)
+    expected_path = "/sacredwoobie/woobies-mission-control/releases/"
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc.lower() != "github.com"
+        or not parsed.path.lower().startswith(expected_path)
+    ):
+        raise ValueError("the latest release has an unexpected web address")
+
+    return {"tag_name": tag_name.strip(), "html_url": html_url}
+
+
+def fetch_latest_release(opener=urllib.request.urlopen, timeout=UPDATE_TIMEOUT_SECONDS):
+    """Fetch and validate the latest stable public GitHub release."""
+    request = urllib.request.Request(
+        LATEST_RELEASE_API,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"Woobies-Mission-Control/{APP_VERSION}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with opener(request, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return validate_release_payload(payload)
+
+
+def load_update_state(path=UPDATE_STATE_PATH):
+    """Load cached update state, returning an empty state on any error."""
+    try:
+        state = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return {}
+    return state if isinstance(state, dict) else {}
+
+
+def save_update_state(state, path=UPDATE_STATE_PATH):
+    """Atomically save update preferences and the last successful result."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(state, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def get_fresh_cached_release(state, now=None, max_age=UPDATE_CACHE_SECONDS):
+    """Return a validated cached release if it is recent enough."""
+    if not isinstance(state, dict):
+        return None
+    if state.get("app_version") != APP_VERSION:
+        return None
+    checked_at = state.get("last_checked")
+    if not isinstance(checked_at, (int, float)):
+        return None
+    if now is None:
+        now = time.time()
+    age = now - checked_at
+    if age < 0 or age > max_age:
+        return None
+    try:
+        return validate_release_payload(state)
+    except ValueError:
+        return None
 
 
 def discover_components(directory=HERE):
@@ -138,11 +263,17 @@ class Backend:
 
 
 class App:
-    def __init__(self, root):
+    def __init__(self, root, update_state_path=UPDATE_STATE_PATH):
         self.root = root
         self.log_queue = queue.Queue()
+        self.update_queue = queue.Queue()
         self.backends = []
         self.backend_rows = []
+        self.update_state_path = Path(update_state_path)
+        self.update_state = load_update_state(self.update_state_path)
+        self.update_generation = 0
+        self.update_checking = False
+        self.latest_release_url = None
 
         root.title(f"{APP_NAME} v{APP_VERSION}")
         root.minsize(600, 360)
@@ -159,6 +290,38 @@ class App:
         tk.Button(header, text="About", width=8, command=self._show_about).pack(
             side="right"
         )
+
+        update_bar = tk.Frame(root)
+        update_bar.pack(fill="x", padx=10, pady=(2, 4))
+        self.update_status = tk.Label(
+            update_bar,
+            text="Update status: waiting",
+            fg="#666",
+            anchor="w",
+        )
+        self.update_status.pack(side="left", fill="x", expand=True)
+        self.view_release_button = tk.Button(
+            update_bar,
+            text="View release",
+            state="disabled",
+            command=self._open_latest_release,
+        )
+        self.view_release_button.pack(side="right", padx=(4, 0))
+        self.check_updates_button = tk.Button(
+            update_bar,
+            text="Check now",
+            command=lambda: self._start_update_check(use_cache=False),
+        )
+        self.check_updates_button.pack(side="right", padx=(4, 0))
+        self.check_updates_var = tk.BooleanVar(
+            value=self.update_state.get("check_enabled", True) is not False
+        )
+        tk.Checkbutton(
+            update_bar,
+            text="Check automatically",
+            variable=self.check_updates_var,
+            command=self._toggle_automatic_updates,
+        ).pack(side="right", padx=(4, 0))
 
         components = discover_components()
         if components:
@@ -189,7 +352,12 @@ class App:
             self._enqueue("launcher", f"available components: {names}")
 
         self._drain_log()
+        self._drain_update_queue()
         self._refresh()
+        if self.check_updates_var.get():
+            self.root.after(300, lambda: self._start_update_check(use_cache=True))
+        else:
+            self.update_status.config(text="Automatic update checks are off")
 
     def _add_component(self, component):
         script = HERE / component["script"]
@@ -252,6 +420,112 @@ class App:
         except queue.Empty:
             pass
         self.root.after(100, self._drain_log)
+
+    def _start_update_check(self, use_cache):
+        if self.update_checking:
+            return
+
+        if use_cache:
+            cached = get_fresh_cached_release(self.update_state)
+            if cached is not None:
+                self._apply_release_status(cached)
+                return
+
+        self.update_generation += 1
+        generation = self.update_generation
+        self.update_checking = True
+        self.update_status.config(text="Checking GitHub for updates…", fg="#666")
+        self.check_updates_button.config(state="disabled")
+
+        def worker():
+            try:
+                release = fetch_latest_release()
+            except Exception as exc:
+                self.update_queue.put((generation, "error", str(exc)))
+            else:
+                self.update_queue.put((generation, "release", release))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _drain_update_queue(self):
+        try:
+            while True:
+                generation, result_type, result = self.update_queue.get_nowait()
+                if generation != self.update_generation:
+                    continue
+
+                self.update_checking = False
+                self.check_updates_button.config(state="normal")
+                if result_type == "release":
+                    self.update_state.update(result)
+                    self.update_state["app_version"] = APP_VERSION
+                    self.update_state["last_checked"] = time.time()
+                    self.update_state["check_enabled"] = self.check_updates_var.get()
+                    self._save_update_state()
+                    self._apply_release_status(result)
+                else:
+                    self.update_status.config(
+                        text="Couldn’t check for updates (offline is OK)",
+                        fg="#666",
+                    )
+                    self._enqueue("updates", f"update check unavailable: {result}")
+        except queue.Empty:
+            pass
+        self.root.after(100, self._drain_update_queue)
+
+    def _apply_release_status(self, release):
+        tag_name = release["tag_name"]
+        self.latest_release_url = release["html_url"]
+        self.view_release_button.config(state="normal")
+
+        status = classify_release(APP_VERSION, tag_name)
+        if status == "available":
+            self.update_status.config(
+                text=f"Update available: {tag_name}",
+                fg="#1a5fb4",
+            )
+            self._enqueue(
+                "updates",
+                f"{tag_name} is available; use View release to review it.",
+            )
+        elif status == "development":
+            self.update_status.config(
+                text=f"Development build—newer than published {tag_name}",
+                fg="#8a6d1d",
+            )
+        else:
+            self.update_status.config(
+                text=f"Mission Control is up to date ({tag_name})",
+                fg="#2a8a3a",
+            )
+
+    def _toggle_automatic_updates(self):
+        enabled = self.check_updates_var.get()
+        self.update_state["check_enabled"] = enabled
+        self._save_update_state()
+
+        if enabled:
+            self._start_update_check(use_cache=True)
+            return
+
+        self.update_generation += 1
+        self.update_checking = False
+        self.check_updates_button.config(state="normal")
+        self.update_status.config(text="Automatic update checks are off", fg="#666")
+
+    def _save_update_state(self):
+        try:
+            save_update_state(self.update_state, self.update_state_path)
+        except OSError as exc:
+            self._enqueue("updates", f"couldn't save update preferences: {exc}")
+
+    def _open_latest_release(self):
+        if not self.latest_release_url:
+            return
+        try:
+            webbrowser.open(self.latest_release_url)
+        except Exception as exc:
+            self._enqueue("updates", f"couldn't open the release page: {exc}")
 
     def _toggle(self, backend, open_dashboard):
         if backend.running():

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -852,7 +852,7 @@
 </div>
 
 <footer class="project-footer" aria-label="Project information">
-  <span>Woobie's Mission Control v0.2.0</span><span class="sep">·</span>
+  <span>Woobie's Mission Control v0.2.1</span><span class="sep">·</span>
   <span>by SacredWoobie</span><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control" target="_blank" rel="noopener noreferrer">GitHub</a><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,0 +1,123 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import ksp_dashboard_app
+
+
+VALID_RELEASE = {
+    "tag_name": "v0.3.0",
+    "html_url": (
+        "https://github.com/SacredWoobie/"
+        "woobies-mission-control/releases/tag/v0.3.0"
+    ),
+}
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    def read(self):
+        return self.payload
+
+
+class UpdateCheckerTests(unittest.TestCase):
+    def test_parse_version_tag_accepts_release_versions(self):
+        self.assertEqual(ksp_dashboard_app.parse_version_tag("v1.2.3"), (1, 2, 3))
+        self.assertEqual(ksp_dashboard_app.parse_version_tag("1.2.3"), (1, 2, 3))
+
+    def test_parse_version_tag_rejects_prereleases_and_extra_parts(self):
+        self.assertIsNone(ksp_dashboard_app.parse_version_tag("v1.2.3-beta"))
+        self.assertIsNone(ksp_dashboard_app.parse_version_tag("v1.2.3.4"))
+
+    def test_classify_release_handles_update_current_and_development(self):
+        self.assertEqual(
+            ksp_dashboard_app.classify_release("0.2.0", "v0.3.0"),
+            "available",
+        )
+        self.assertEqual(
+            ksp_dashboard_app.classify_release("0.2.0", "v0.2.0"),
+            "current",
+        )
+        self.assertEqual(
+            ksp_dashboard_app.classify_release("0.3.0", "v0.2.0"),
+            "development",
+        )
+
+    def test_validate_release_payload_rejects_unexpected_link(self):
+        payload = dict(VALID_RELEASE, html_url="https://example.com/update.zip")
+        with self.assertRaises(ValueError):
+            ksp_dashboard_app.validate_release_payload(payload)
+
+    def test_fetch_latest_release_sets_headers_and_validates_response(self):
+        captured = {}
+
+        def opener(request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return FakeResponse(VALID_RELEASE)
+
+        result = ksp_dashboard_app.fetch_latest_release(opener=opener, timeout=2)
+
+        self.assertEqual(result, VALID_RELEASE)
+        self.assertEqual(captured["timeout"], 2)
+        self.assertEqual(
+            captured["request"].get_header("User-agent"),
+            "Woobies-Mission-Control/0.2.1",
+        )
+        self.assertEqual(
+            captured["request"].get_header("Accept"),
+            "application/vnd.github+json",
+        )
+
+    def test_cache_must_be_recent_and_valid(self):
+        state = dict(VALID_RELEASE, app_version="0.2.1", last_checked=1000)
+        self.assertEqual(
+            ksp_dashboard_app.get_fresh_cached_release(
+                state,
+                now=1050,
+                max_age=100,
+            ),
+            VALID_RELEASE,
+        )
+        self.assertIsNone(
+            ksp_dashboard_app.get_fresh_cached_release(
+                state,
+                now=1200,
+                max_age=100,
+            )
+        )
+        state["app_version"] = "0.1.0"
+        self.assertIsNone(
+            ksp_dashboard_app.get_fresh_cached_release(
+                state,
+                now=1050,
+                max_age=100,
+            )
+        )
+
+    def test_update_state_round_trip(self):
+        state = dict(
+            VALID_RELEASE,
+            app_version="0.2.1",
+            last_checked=1234,
+            check_enabled=False,
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "update_state.json"
+            ksp_dashboard_app.save_update_state(state, path)
+
+            self.assertEqual(ksp_dashboard_app.load_update_state(path), state)
+            self.assertFalse(path.with_suffix(".json.tmp").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -106,6 +106,7 @@ $sourceFiles = @(
     @{ Source = 'requirements.txt'; Destination = 'Dashboard/requirements.txt' },
     @{ Source = 'telemetry_server.py'; Destination = 'Dashboard/telemetry_server.py' },
     @{ Source = 'LICENSE'; Destination = 'LICENSE' },
+    @{ Source = 'QUICKSTART.txt'; Destination = 'QUICKSTART.txt' },
     @{ Source = 'README.md'; Destination = 'README.md' },
     @{ Source = 'docs/CONTROL_PAD_PROTOCOL.md'; Destination = 'docs/CONTROL_PAD_PROTOCOL.md' },
     @{ Source = 'docs/images/dashboard-overview.png'; Destination = 'docs/images/dashboard-overview.png' },
@@ -129,7 +130,7 @@ foreach ($file in $dllFiles) {
     Assert-RequiredFile (Join-Path $GameDataPath $file.Source)
 }
 
-# v0.2.0 requires the editor-capable StageStats service. Older release DLLs do
+# v0.2.x requires the editor-capable StageStats service. Older release DLLs do
 # not expose the VAB/SPH planning API or the corrected initial-TWR calculation.
 # Fail before packaging instead of silently producing a flight-only release.
 $stageStatsDll = Join-Path $GameDataPath 'KRPC.StageStats/KRPC.StageStats.dll'


### PR DESCRIPTION
## Summary

- make `Start KSP Dashboard.bat` create, repair, and verify an isolated Python 3.14 environment on first run
- add a non-blocking, cached GitHub stable-release check with manual refresh, release link, and an automatic-check preference
- add `QUICKSTART.txt`, make automatic setup the primary README path, and retain manual commands as a fallback
- coordinate the launcher, dashboard footer, changelog, README, tests, and packaging metadata for v0.2.1
- continue packaging the unchanged v0.2.0 KSP service DLLs

## Why

The previous Windows installation path required users to open a shell and copy virtual-environment and pip commands from the README. This keeps Python packages isolated while reducing the normal flow to copying the service folders into `GameData` and double-clicking the launcher.

## User impact

Python 3.14 remains a prerequisite for this crawl-stage installer. If it is missing, the launcher stops with a clear official download link. The update checker only reports stable GitHub releases; it does not download or replace files, and offline failures do not affect Mission Control.

## Validation

- Python compilation passed for the launcher, telemetry server, panel bridge, and update-check tests
- all 9 unit tests passed
- live GitHub latest-release request returned and validated v0.2.0
- hidden Tk launcher validation rendered the cached status and enabled release button
- first-run setup, interrupted-network retry, repeat setup, and a path containing spaces were exercised in isolated folders
- user confirmed the packaged first-run setup and update checker worked
- audited v0.2.1 package created successfully with `QUICKSTART.txt`, without `.venv` or tests
- candidate ZIP SHA-256: `e4ba5d11b39494840e3a0bb87016b549e6896d921aa305045305d73e0b04d56e`
- packaged `KRPC.StageStats.dll` remains version `0.2.0.0`
