### PR TITLE
Add Support For zer0Kerbal's Notes Mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ a control-pad start button.
 - System Heat loop temperatures, generation, rejection, and net heat
 - Electrical output by reactor, solar, RTG, and other generation sources
 - Target-vessel and docking-alignment information
+- Notes panel showing recent files from the Notes mod (zer0Kerbal/Notes)
 - Optional ESP32 stage/abort control with local arm/safe gates
 
 ## Feature tour
@@ -234,6 +235,13 @@ no other program is using port 8090.
 Optional sections require their corresponding KSP mod and service DLL. Missing
 optional integrations should leave the relevant section blank without stopping
 the rest of the dashboard.
+
+### Notes panel says folder not found
+
+The Notes panel reads text files from
+`GameData/Notes/Plugins/PluginData/notes`.
+
+This integration assumes the dashboard is started from `KSP_ROOT/Dashboard`.
 
 ### The ESP32 is not found
 

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -318,6 +318,18 @@
   .sl-row .t{color:var(--slate);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .sl-row .v{color:var(--amber);font-variant-numeric:tabular-nums}
 
+  /* ---- notes ---- */
+  .notes-status{font-size:10px;color:var(--slate);margin-bottom:8px;line-height:1.35}
+  .notes-meta{font-size:9px;color:var(--slate-dim)}
+  .notes-list{display:flex;flex-direction:column;gap:7px;max-height:min(320px,42vh);overflow-y:auto}
+  .notes-card{border:1px solid var(--rule);border-radius:3px;background:var(--panel);padding:7px 9px}
+  .notes-head{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:4px}
+  .notes-name{font-size:11px;color:var(--cyan);letter-spacing:.02em;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .notes-tag{font-size:8px;letter-spacing:.1em;text-transform:uppercase;padding:1px 5px;border-radius:2px;border:1px solid var(--rule-bright);color:var(--slate)}
+  .notes-tag.live{color:var(--green);border-color:#2f6c42;background:rgba(56,139,73,.14)}
+  .notes-preview{margin:0;font-size:10px;line-height:1.35;color:var(--amber);white-space:pre-wrap;word-break:break-word}
+  .notes-empty{font-size:11px;color:var(--slate-dim);font-style:italic;padding:2px 0}
+
   /* ---- heat ---- */
   .heat-strip{display:grid;grid-template-columns:1fr 1fr 1fr;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:3px;overflow:hidden}
   .heat-loops{margin-top:8px;display:flex;flex-direction:column;gap:1px;background:var(--rule);border:1px solid var(--rule);border-radius:3px;overflow:hidden}
@@ -756,6 +768,17 @@
     </div>
   </section>
 
+  <!-- ============ NOTES (zer0Kerbal/Notes compatibility) ============ -->
+  <section class="panel" id="notesPanel" style="display:none">
+    <h2>Notes <span class="tag">zer0Kerbal/Notes</span></h2>
+    <div class="body">
+      <div class="notes-status" id="notesStatus">awaiting kRPC link</div>
+      <div class="notes-meta" id="notesMeta"></div>
+      <div class="notes-list" id="notesList"></div>
+      <div class="notes-empty" id="notesEmpty">No note files found</div>
+    </div>
+  </section>
+
   </div><!-- /wide-mission -->
 
   </div><!-- /deck -->
@@ -1015,6 +1038,7 @@ function onDataKrpc(d){
   updateComms(d);
   updateSasMode(d);
   updateScience(d);
+  updateNotes(d);
   renderHeat(d);
   renderElec(d);
   updateTarget(d);
@@ -1040,7 +1064,7 @@ function nullOutDashboard(){
     "heatGen","heatRem","heatNet",
     "ecTotal","solarOut","solarEff","rtgOut","otherOut",
     "dv_total","dv_stage","dv_twr","dv_burn","stageNum",
-    "sciSub","sciLoc"
+    "sciSub","sciLoc","notesStatus","notesMeta"
   ];
   dash.forEach(id=>set(id,"—"));
 
@@ -1053,13 +1077,15 @@ function nullOutDashboard(){
   const sv=$("sciValue"); if(sv){ sv.className="sci-value blocked"; sv.textContent="no flight"; }
 
   // clear list/table containers and per-vessel panels
-  ["resRows","reactorList","heatLoops","sciList","stageTable"].forEach(id=>{
+  ["resRows","reactorList","heatLoops","sciList","stageTable","notesList"].forEach(id=>{
     const el=$(id); if(el) el.innerHTML="";
   });
   const rxSummary=$("reactorSummary"); if(rxSummary) rxSummary.classList.add("hidden");
   const rxDetails=$("reactorDetails"); if(rxDetails) rxDetails.classList.add("hidden");
   const rxEmpty=$("reactorEmpty"); if(rxEmpty) rxEmpty.style.display="none";
   const tgt=$("target"); if(tgt) tgt.classList.remove("active");
+  const notesEmpty=$("notesEmpty"); if(notesEmpty) notesEmpty.style.display="none";
+  const notesPanel=$("notesPanel"); if(notesPanel) notesPanel.style.display="none";
   if(typeof initNavballEmpty==="function") initNavballEmpty();
   const ht=$("hdgTape"); if(ht) ht.innerHTML="";
 }
@@ -1318,6 +1344,74 @@ function updateScience(d){
       +`<span class="v">${sciFmt(r.value)} <span style="color:var(--slate-dim)">/ ${sciFmt(r.transmit)} tx</span></span></div>`
     ).join("");
   }
+}
+
+/* ---- notes (zer0Kerbal/Notes files exposed by telemetry_server.py) ---- */
+function fmtLocalTime(epochSeconds){
+  if(!num(epochSeconds)) return "unknown time";
+  const date = new Date(epochSeconds*1000);
+  return date.toLocaleString();
+}
+function updateNotes(d){
+  const panelEl=$("notesPanel");
+  const statusEl=$("notesStatus");
+  const metaEl=$("notesMeta");
+  const listEl=$("notesList");
+  const emptyEl=$("notesEmpty");
+  if(!panelEl || !statusEl || !metaEl || !listEl || !emptyEl) return;
+
+  if(d["notes.available"]===false){
+    panelEl.style.display = "none";
+    statusEl.textContent = d["notes.message"] || "Notes folder unavailable";
+    metaEl.textContent = d["notes.path"] ? "Path: "+d["notes.path"] : "";
+    listEl.innerHTML = "";
+    emptyEl.style.display = "none";
+    return;
+  }
+
+  if(d["notes.available"]!==true){
+    panelEl.style.display = "none";
+    statusEl.textContent = "awaiting notes scan";
+    return;
+  }
+
+  panelEl.style.display = "block";
+  const files = Array.isArray(d["notes.files"]) ? d["notes.files"] : [];
+  const totalCount = num(d["notes.count"]) ? Math.round(d["notes.count"]) : files.length;
+  const displayed = files.length;
+  statusEl.textContent = totalCount>0
+    ? `showing ${displayed} of ${totalCount} note files`
+    : "notes folder found · no notes created yet";
+
+  const path = (typeof d["notes.path"]==="string") ? d["notes.path"] : "";
+  metaEl.textContent = path ? "Path: "+path : "";
+
+  if(!files.length){
+    listEl.innerHTML = "";
+    emptyEl.textContent = "No note files yet. Create your first note in the Notes mod.";
+    emptyEl.style.display = "block";
+    return;
+  }
+
+  emptyEl.style.display = "none";
+  listEl.innerHTML = files.map(file=>{
+    const name = escapeHtml(file.name || "untitled");
+    const rel = escapeHtml(file.path || "");
+    const modified = fmtLocalTime(file.modified);
+    const size = num(file.size) ? `${Math.round(file.size).toLocaleString()} B` : "—";
+    const tag = file.isActiveLog
+      ? '<span class="notes-tag live">active vessel log</span>'
+      : (file.isLog ? '<span class="notes-tag">ship log</span>' : '');
+    const preview = escapeHtml(file.preview || "").trim() || "(empty note)";
+    return `<article class="notes-card">
+      <div class="notes-head">
+        <div class="notes-name" title="${name}">${name}</div>
+        ${tag}
+      </div>
+      <div class="notes-meta" title="${rel}">${rel} · ${size} · ${modified}</div>
+      <pre class="notes-preview">${preview}</pre>
+    </article>`;
+  }).join("");
 }
 
 /* ---- heat (System Heat via the custom kRPC service) ---- */

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -328,6 +328,7 @@
   .notes-tag{font-size:8px;letter-spacing:.1em;text-transform:uppercase;padding:1px 5px;border-radius:2px;border:1px solid var(--rule-bright);color:var(--slate)}
   .notes-tag.live{color:var(--green);border-color:#2f6c42;background:rgba(56,139,73,.14)}
   .notes-preview{margin:0;font-size:10px;line-height:1.35;color:var(--amber);white-space:pre-wrap;word-break:break-word}
+  .notes-preview-active{max-height:220px;overflow-y:auto;padding-right:4px}
   .notes-empty{font-size:11px;color:var(--slate-dim);font-style:italic;padding:2px 0}
 
   /* ---- heat ---- */
@@ -773,7 +774,6 @@
     <h2>Notes <span class="tag">zer0Kerbal/Notes</span></h2>
     <div class="body">
       <div class="notes-status" id="notesStatus">awaiting kRPC link</div>
-      <div class="notes-meta" id="notesMeta"></div>
       <div class="notes-list" id="notesList"></div>
       <div class="notes-empty" id="notesEmpty">No note files found</div>
     </div>
@@ -935,6 +935,7 @@ document.getElementById("calToggle").addEventListener("click",e=>{
    KRPC TELEMETRY LINK
    ========================================================================== */
 let wsK=null, connectedK=false, wantConnectK=false, reconnectTimerK=null;
+let lastActiveLogSignature="";
 // status reflected in BOTH the slim top bar and the connect pop-out
 const ledK=$("ledK"), statusTxtK=$("statusTxtK");
 const ledK2=$("ledK2"), statusTxtK2=$("statusTxtK2");
@@ -1064,7 +1065,7 @@ function nullOutDashboard(){
     "heatGen","heatRem","heatNet",
     "ecTotal","solarOut","solarEff","rtgOut","otherOut",
     "dv_total","dv_stage","dv_twr","dv_burn","stageNum",
-    "sciSub","sciLoc","notesStatus","notesMeta"
+    "sciSub","sciLoc","notesStatus"
   ];
   dash.forEach(id=>set(id,"—"));
 
@@ -1355,15 +1356,13 @@ function fmtLocalTime(epochSeconds){
 function updateNotes(d){
   const panelEl=$("notesPanel");
   const statusEl=$("notesStatus");
-  const metaEl=$("notesMeta");
   const listEl=$("notesList");
   const emptyEl=$("notesEmpty");
-  if(!panelEl || !statusEl || !metaEl || !listEl || !emptyEl) return;
+  if(!panelEl || !statusEl || !listEl || !emptyEl) return;
 
   if(d["notes.available"]===false){
     panelEl.style.display = "none";
     statusEl.textContent = d["notes.message"] || "Notes folder unavailable";
-    metaEl.textContent = d["notes.path"] ? "Path: "+d["notes.path"] : "";
     listEl.innerHTML = "";
     emptyEl.style.display = "none";
     return;
@@ -1377,14 +1376,17 @@ function updateNotes(d){
 
   panelEl.style.display = "block";
   const files = Array.isArray(d["notes.files"]) ? d["notes.files"] : [];
-  const totalCount = num(d["notes.count"]) ? Math.round(d["notes.count"]) : files.length;
-  const displayed = files.length;
-  statusEl.textContent = totalCount>0
-    ? `showing ${displayed} of ${totalCount} note files`
-    : "notes folder found · no notes created yet";
+  const activeLog = files.find(file=>file && file.isActiveLog);
+  const activeSignature = activeLog
+    ? `${activeLog.path||""}|${activeLog.size||""}|${activeLog.preview||""}`
+    : "";
+  const activeUpdated = !!activeLog && activeSignature!==lastActiveLogSignature;
+  lastActiveLogSignature = activeSignature;
 
-  const path = (typeof d["notes.path"]==="string") ? d["notes.path"] : "";
-  metaEl.textContent = path ? "Path: "+path : "";
+  const totalCount = num(d["notes.count"]) ? Math.round(d["notes.count"]) : files.length;
+  statusEl.textContent = totalCount>0
+    ? ""
+    : "notes folder found · no notes created yet";
 
   if(!files.length){
     listEl.innerHTML = "";
@@ -1393,25 +1395,42 @@ function updateNotes(d){
     return;
   }
 
+  if(!activeLog){
+    listEl.innerHTML = "";
+    emptyEl.textContent = "No active vessel log yet. Open Ship Log in the Notes mod for this vessel.";
+    emptyEl.style.display = "block";
+    return;
+  }
+
+  const priorActivePreview = listEl.querySelector(".notes-preview-active");
+
+  // Keep the existing DOM and scroll position when the active log content
+  // hasn't changed. Rebuilding every poll can make scrolling feel stuck.
+  if(priorActivePreview && !activeUpdated) return;
+
   emptyEl.style.display = "none";
-  listEl.innerHTML = files.map(file=>{
-    const name = escapeHtml(file.name || "untitled");
-    const rel = escapeHtml(file.path || "");
-    const modified = fmtLocalTime(file.modified);
-    const size = num(file.size) ? `${Math.round(file.size).toLocaleString()} B` : "—";
-    const tag = file.isActiveLog
-      ? '<span class="notes-tag live">active vessel log</span>'
-      : (file.isLog ? '<span class="notes-tag">ship log</span>' : '');
-    const preview = escapeHtml(file.preview || "").trim() || "(empty note)";
-    return `<article class="notes-card">
+  {
+    const name = escapeHtml(activeLog.name || "untitled");
+    const modified = fmtLocalTime(activeLog.modified);
+    const size = num(activeLog.size) ? `${(activeLog.size/1024).toFixed(1)} KB` : "—";
+    const preview = escapeHtml(activeLog.preview || "").trim() || "(empty note)";
+    listEl.innerHTML = `<article class="notes-card">
       <div class="notes-head">
         <div class="notes-name" title="${name}">${name}</div>
-        ${tag}
+        <span class="notes-tag live">active vessel log</span>
       </div>
-      <div class="notes-meta" title="${rel}">${rel} · ${size} · ${modified}</div>
-      <pre class="notes-preview">${preview}</pre>
+      <div class="notes-meta">${size} · ${modified}</div>
+      <pre class="notes-preview notes-preview-active">${preview}</pre>
     </article>`;
-  }).join("");
+  }
+
+  if(activeUpdated){
+    const activePreview = listEl.querySelector(".notes-preview-active");
+    if(activePreview){
+      // New lines were appended; show the latest info at the tail.
+      activePreview.scrollTop = activePreview.scrollHeight;
+    }
+  }
 }
 
 /* ---- heat (System Heat via the custom kRPC service) ---- */

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -17,6 +17,8 @@ Optional args: telemetry_server.py [host] [port]
 import math
 import sys
 import time
+from pathlib import Path
+
 import krpc
 
 TELEMETRY_WS_PORT = 8090  # dashboard connects here
@@ -31,6 +33,9 @@ RES_POLL_SECONDS = 0.5    # 2N calls for N resources aboard
 TGT_POLL_SECONDS = 0.5    # target + docking geometry
 STAGE_POLL_SECONDS = 0.5  # dv changes continuously during a burn; ~2 Hz readout
 STAGE_SETTLE_SECONDS = 0.12  # let MechJeb's 100 ms async sim finish before read
+NOTES_POLL_SECONDS = 2.0
+NOTES_MAX_FILES = 16
+NOTES_MAX_CHARS = 1200
 
 # KSP Recall exposes these internal refund-bookkeeping resources through kRPC.
 # They are implementation details, not vessel consumables. Match normalized
@@ -54,6 +59,10 @@ _tgt_last_poll = 0.0
 _stage_cache = {}
 _stage_last_poll = 0.0
 _stage_last_ut = None
+_notes_cache = {}
+_notes_last_poll = 0.0
+
+_NOTES_RELATIVE_DIR = Path("GameData") / "Notes" / "Plugins" / "PluginData" / "notes"
 
 # Current-stage resource ownership is inferred only when one decouple group
 # contains multiple engine stages. Cache the part assignment until the vessel
@@ -321,6 +330,103 @@ def _resource_values_for_parts(parts):
                 previous_maximum + maximum,
             )
     return values
+
+
+# ---------------------------------------------------------------------------
+# Notes mod compatibility (zer0Kerbal/Notes)
+# ---------------------------------------------------------------------------
+def _resolve_notes_dir():
+    """Return the expected Notes directory from the KSP_ROOT/Dashboard layout."""
+    candidates = []
+
+    candidates.append(Path.cwd().parent / _NOTES_RELATIVE_DIR)
+    candidates.append(Path.cwd() / _NOTES_RELATIVE_DIR)
+    candidates.append(Path(__file__).resolve().parent.parent / _NOTES_RELATIVE_DIR)
+    candidates.append(Path(__file__).resolve().parent / _NOTES_RELATIVE_DIR)
+
+    checked = []
+    seen = set()
+    for candidate in candidates:
+        try:
+            candidate = candidate.resolve(strict=False)
+        except Exception:
+            continue
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        checked.append(candidate)
+        try:
+            if candidate.is_dir():
+                return candidate, True
+        except Exception:
+            pass
+
+    return (checked[0] if checked else None), False
+
+
+def _clip_note_text(text, limit=NOTES_MAX_CHARS):
+    clean = text.replace("\r\n", "\n").replace("\r", "\n")
+    if len(clean) <= limit:
+        return clean
+    return clean[:limit].rstrip() + "\n\n[...truncated...]"
+
+
+def _gather_notes(vessel_name):
+    """Read recent Notes-mod files from disk for dashboard display."""
+    notes_dir, exists = _resolve_notes_dir()
+    if not exists or notes_dir is None:
+        return {
+            "notes.available": False,
+            "notes.message": "Notes folder not found.",
+            "notes.path": str(notes_dir) if notes_dir is not None else "",
+            "notes.count": 0,
+            "notes.files": [],
+        }
+
+    files = []
+    try:
+        txt_files = sorted(
+            (path for path in notes_dir.rglob("*.txt") if path.is_file()),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+    except Exception:
+        txt_files = []
+
+    for path in txt_files[:NOTES_MAX_FILES]:
+        try:
+            stat = path.stat()
+            body = path.read_text(encoding="utf-8", errors="replace")
+            rel = path.relative_to(notes_dir).as_posix()
+            name = path.stem
+            is_log = name.startswith("log_")
+            is_active = bool(vessel_name) and name == f"log_{vessel_name}"
+            preview = (
+                body.replace("\r\n", "\n").replace("\r", "\n")
+                if is_active
+                else _clip_note_text(body, NOTES_MAX_CHARS)
+            )
+            files.append(
+                {
+                    "name": name,
+                    "path": rel,
+                    "modified": stat.st_mtime,
+                    "size": stat.st_size,
+                    "preview": preview,
+                    "isLog": is_log,
+                    "isActiveLog": is_active,
+                }
+            )
+        except Exception:
+            pass
+
+    return {
+        "notes.available": True,
+        "notes.path": str(notes_dir),
+        "notes.count": len(txt_files),
+        "notes.files": files,
+    }
 
 
 def _current_stage_resource_values(vessel, current_stage):
@@ -751,6 +857,11 @@ def gather_telemetry(conn):
     # ---- clocks (every tick) ----
     universal_time = None
     try:
+        d["v.name"] = vessel.name
+    except Exception:
+        d["v.name"] = ""
+
+    try:
         universal_time = sc.ut
         d["t.universalTime"] = universal_time
         d["v.missionTime"] = vessel.met
@@ -993,6 +1104,16 @@ def gather_telemetry(conn):
             _elec_cache = elec
     d.update(_elec_cache)
 
+    # ---- Notes mod text files (GameData/Notes/Plugins/PluginData/notes) ----
+    global _notes_cache, _notes_last_poll
+    if now - _notes_last_poll >= NOTES_POLL_SECONDS:
+        _notes_last_poll = now
+        try:
+            _notes_cache = _gather_notes(d.get("v.name", ""))
+        except Exception:
+            pass
+    d.update(_notes_cache)
+
     return d
 
 
@@ -1029,14 +1150,13 @@ def run_telemetry_server(host, port):
             print(f"[telemetry] waiting for kRPC server... ({e})")
             time.sleep(2)
 
-    print(f"[telemetry] serving dashboard on ws://{host}:{port}  ({TELEMETRY_HZ} Hz)")
     clients = set()
 
     async def handler(ws, *args):  # *args tolerates old & new websockets signatures
         clients.add(ws)
         try:
             async for _ in ws:
-                pass  # ignore the dashboard's subscription msg; we push everything
+                pass
         except Exception:
             pass
         finally:
@@ -1060,10 +1180,26 @@ def run_telemetry_server(host, port):
 
     async def serve():
         async with websockets.serve(handler, host, port):
+            print(
+                f"[telemetry] serving dashboard on ws://{host}:{port}  "
+                f"({TELEMETRY_HZ} Hz)"
+            )
             await broadcaster()
 
     try:
         asyncio.run(serve())
+    except OSError as e:
+        if getattr(e, "errno", None) == 10048 or "10048" in str(e):
+            print(
+                "[telemetry] failed to bind websocket port "
+                f"{host}:{port} (WinError 10048)."
+            )
+            print(
+                "[telemetry] another process is already using this address. "
+                "Stop the other telemetry instance or choose a different port."
+            )
+        else:
+            print(f"[telemetry] server stopped: {e}")
     except Exception as e:
         print(f"[telemetry] server stopped: {e}")
 


### PR DESCRIPTION
## Mod in question:
https://forum.kerbalspaceprogram.com/topic/207118-112x-notes-in-game-notes-notepad-checklist-v01700-adoption-kollege-ruled-edition2022-mar-02/

## Images:

### New Notes Window Look
<img width="2737" height="1220" alt="NOTES-SUPPORT" src="https://github.com/user-attachments/assets/00063887-9861-4c88-9886-b407330babdd" />

### Example of Note (Ship Log) In-Game
<img width="1879" height="1809" alt="NOTE-EXAMPLE-INGAME" src="https://github.com/user-attachments/assets/9bd6cbbc-6de2-4235-bb6b-18c0d2f7db86" />

## If Notes mod is installed:
- New NOTES section will be displayed and will show the active vessel's logs (or prompt the user to create the log if it is not detected).

## If Notes mod is NOT installed:
- NOTES section will not be displayed.