### PR TITLE
Add v0.2.3 launcher DLL install repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable public changes will be recorded here.
 
+## v0.2.3 - Guided KSP service maintenance
+
+- Added SHA-256 status checks for the three packaged Mission Control KSP
+  service DLLs, with clear Current, Missing, and Repair available states.
+- Added a confirmed Install / Repair workflow that refuses to run while KSP is
+  open, backs up existing DLLs, stages and verifies replacements, and limits
+  changes to the three allowlisted service paths.
+- Added adjacent shortcuts for opening the selected KSP `GameData` destination
+  and the packaged service-DLL source folder for optional manual copying.
+- Made launcher-version changes bypass a still-fresh 24-hour release-check
+  cache while continuing to respect the automatic-update preference.
+- Added an optional once-per-version What's New window and an always-available
+  Changelog button in the launcher.
+- Added a dependency-free ttk visual theme using the dashboard's dark panels,
+  cyan headings, amber values, status colors, and monospaced typography.
+- Prioritized the frequently used dashboard-feed and panel-bridge controls
+  above the lower-frequency KSP installation and service-maintenance section.
+- Made initial window sizing screen-aware, added explicit Cascadia-to-Consolas
+  font fallback, and reused the drawn check/X control in the changelog viewer.
+- Added failure-injection coverage for install rollback and a prominent manual
+  restoration warning when Windows prevents automatic rollback from completing.
+
 ## v0.2.2 - Read-only Notes integration
 
 - Added optional integration with zer0Kerbal's Notes mod through a responsive

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -1,16 +1,15 @@
 WOOBIE'S MISSION CONTROL - WINDOWS QUICK START
 ==============================================
 
-1. INSTALL THE KSP SERVICES
+1. KEEP THE COMPLETE PACKAGE TOGETHER
 
-   Close KSP. Copy the three folders inside this package's GameData folder
-   into Kerbal Space Program\GameData:
+   Extract the complete ZIP so its Dashboard and GameData folders remain next
+   to one another. The launcher can then install or repair these services:
 
      KRPC.StageStats
      KRPC.SystemHeat
      KRPC.VesselScience
 
-   Copy the folders themselves, not the package's top-level GameData folder.
    The kRPC KSP mod is required. Other supported mods enable optional panels.
 
 2. SET UP AND START THE DASHBOARD
@@ -27,18 +26,27 @@ WOOBIE'S MISSION CONTROL - WINDOWS QUICK START
    launcher provides the official download address and can be run again after
    Python is installed.
 
-3. CONNECT TO KSP
+3. SELECT KSP AND INSTALL THE SERVICES
+
+   Before starting KSP, choose the main Kerbal Space Program installation
+   folder in the launcher's KSP installation section. Select the folder that
+   contains GameData, not GameData itself.
+
+   Review the Mission Control KSP services panel. If any service says Missing
+   or Repair available, choose Install / Repair and confirm the listed changes.
+   Existing service DLLs are backed up and each installed copy is verified.
+   No other GameData files are changed.
+
+4. CONNECT TO KSP
 
    Start KSP, enable its kRPC server, and load a vessel or open the VAB/SPH.
    In the Mission Control launcher, start Dashboard feed (telemetry). The
    dashboard opens in your browser automatically.
 
-   OPTIONAL NOTES INTEGRATION: Before starting the feed, choose the main KSP
-   installation folder in the launcher's KSP installation section. Select the
-   folder that contains GameData, not GameData itself. When the Notes mod is
-   detected, a Notes button appears in the dashboard during flight and opens
-   the active vessel's ship log in a right-side drawer. Select any saved note
-   and choose Pin to flight to show it in a scrollable final flight panel.
+   OPTIONAL NOTES INTEGRATION: When the Notes mod is detected at the selected
+   KSP location, a Notes button appears in the dashboard during flight and
+   opens the active vessel's ship log in a right-side drawer. Select any saved
+   note and choose Pin to flight to show it in a scrollable final flight panel.
    Use A- and A+ in either Notes view to adjust text size; click the size value
    to return to the default.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Woobie's Mission Control
 
-Current release: **v0.2.2**
+Current release: **v0.2.3**
 
 For the fastest Windows release setup, start with
 [`QUICKSTART.txt`](QUICKSTART.txt). It covers the `GameData` copy and automatic
@@ -203,9 +203,18 @@ The release package contains only this project's three service DLLs:
 - `KRPC.StageStats.dll`
 - `KRPC.VesselScience.dll`
 
-Copy each provided service folder into your KSP `GameData` folder. The intended
-layout uses `KRPC.SystemHeat`, `KRPC.StageStats`, and `KRPC.VesselScience` as the
-folder names, with the matching DLL inside each folder.
+After starting Mission Control, choose the main KSP installation folder that
+contains `GameData`. The launcher's **Mission Control KSP services** panel
+compares the packaged and installed DLLs by SHA-256. If a service is missing or
+different, close KSP and choose **Install / Repair**. Existing DLLs are backed
+up under `%LOCALAPPDATA%\WoobiesMissionControl\dll_backups` before replacement,
+and each new copy is verified after installation. The launcher changes only the
+three service DLL paths listed above.
+
+Manual copying remains available: copy each provided service folder into your
+KSP `GameData` folder. The intended layout uses `KRPC.SystemHeat`,
+`KRPC.StageStats`, and `KRPC.VesselScience` as the folder names, with the
+matching DLL inside each folder.
 
 The release DLLs are optimized deterministic builds without PDB files or
 embedded local build paths.
@@ -305,8 +314,13 @@ in Arduino IDE.
   public Releases API to report whether a newer stable release is available.
   It sends no authentication token or Mission Control telemetry. Automatic
   checks can be disabled in the launcher, and `Check now` remains available.
+  Starting a different launcher version bypasses a cached result from the
+  previous version and checks immediately when automatic checks are enabled.
   The preference and last successful result are stored under
   `%LOCALAPPDATA%\WoobiesMissionControl` on Windows.
+- The launcher shows that version's What's New notes once after an update by
+  default. This can be disabled independently in the changelog window, while
+  the `Changelog` button remains available for manual viewing.
 - Keep the telemetry server bound to `127.0.0.1` unless you intentionally need
   another device on your trusted local network to view it.
 - The WebSocket feed is read-only but has no authentication or encryption. Do
@@ -390,7 +404,7 @@ From a clean, up-to-date `main` checkout, first create and audit the package
 without changing anything on GitHub:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.2
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.3
 ```
 
 The script writes the ZIP, SHA-256 checksum, and generated release notes to the
@@ -410,7 +424,7 @@ Open a new PowerShell window after installation, authenticate once with
 `gh auth login`, and then rerun:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.2 -CreateDraftRelease
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.2.3 -CreateDraftRelease
 ```
 
 The release remains private as a draft until it is reviewed and published on

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -14,10 +14,13 @@ The launcher itself uses only the Python standard library. Each optional script
 is responsible for its own dependencies.
 """
 
+import csv
+import hashlib
 import json
 import os
 import queue
 import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -28,14 +31,14 @@ import webbrowser
 from pathlib import Path
 
 import tkinter as tk
-from tkinter import filedialog, scrolledtext
+from tkinter import filedialog, font as tkfont, messagebox, scrolledtext, ttk
 
 
 HERE = Path(__file__).resolve().parent
 DASHBOARD = HERE / "ksp_mission_dashboard.html"
 PYTHON = sys.executable
 APP_NAME = "Woobie's Mission Control"
-APP_VERSION = "0.2.2"
+APP_VERSION = "0.2.3"
 APP_AUTHOR = "SacredWoobie"
 PROJECT_URL = "https://github.com/SacredWoobie/woobies-mission-control"
 LATEST_RELEASE_API = (
@@ -87,6 +90,529 @@ COMPONENTS = (
 
 # Prevent child processes from opening extra console windows on Windows.
 CREATE_NO_WINDOW = 0x08000000 if os.name == "nt" else 0
+
+PACKAGED_GAMEDATA = HERE.parent / "GameData"
+CHANGELOG_CANDIDATES = (HERE / "CHANGELOG.md", HERE.parent / "CHANGELOG.md")
+SERVICE_DLLS = (
+    ("KRPC.StageStats", "Stage statistics"),
+    ("KRPC.SystemHeat", "System Heat / electricity"),
+    ("KRPC.VesselScience", "Stored science"),
+)
+
+THEME = {
+    "bg": "#080b11",
+    "panel": "#0f151f",
+    "panel_2": "#0b1019",
+    "input": "#060a0f",
+    "rule": "#1c2735",
+    "rule_bright": "#2a3a4e",
+    "amber": "#ffb454",
+    "amber_dim": "#a9762f",
+    "cyan": "#4ec9e0",
+    "slate": "#7d8ba0",
+    "slate_dim": "#4a5568",
+    "green": "#7ee787",
+    "warn": "#ff6b5b",
+    "button": "#12202c",
+    "button_hover": "#173040",
+}
+UI_FONT_FAMILY = "Consolas"
+UI_FONT = (UI_FONT_FAMILY, 9)
+UI_FONT_BOLD = (UI_FONT_FAMILY, 9, "bold")
+
+
+def choose_ui_font_family(available_families):
+    """Choose the first available dashboard-style monospaced font."""
+    available = {str(name).casefold(): str(name) for name in available_families}
+    for candidate in ("Cascadia Mono", "Cascadia Code", "Consolas", "Courier New"):
+        match = available.get(candidate.casefold())
+        if match:
+            return match
+    return "TkFixedFont"
+
+
+def calculate_initial_window_size(
+    screen_width,
+    screen_height,
+    requested_width,
+    requested_height,
+):
+    """Return a roomy launcher size clamped for the current display."""
+    available_width = max(640, int(screen_width) - 80)
+    available_height = max(520, int(screen_height) - 120)
+    desired_width = max(960, int(requested_width) + 24)
+    desired_height = max(820, int(requested_height) + 12)
+    return min(desired_width, available_width), min(
+        desired_height, available_height
+    )
+
+
+def configure_dashboard_theme(root):
+    """Apply a standard-library ttk theme inspired by the dashboard."""
+    global UI_FONT_FAMILY, UI_FONT, UI_FONT_BOLD
+    UI_FONT_FAMILY = choose_ui_font_family(tkfont.families(root))
+    UI_FONT = (UI_FONT_FAMILY, 9)
+    UI_FONT_BOLD = (UI_FONT_FAMILY, 9, "bold")
+    root.configure(background=THEME["bg"])
+    root.option_add("*Font", UI_FONT)
+    style = ttk.Style(root)
+    style.theme_use("clam")
+    style.configure(".", font=UI_FONT)
+    style.configure("TFrame", background=THEME["panel"])
+    style.configure("Shell.TFrame", background=THEME["bg"])
+    style.configure(
+        "Card.TFrame",
+        background=THEME["panel_2"],
+        bordercolor=THEME["rule_bright"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.configure("CardInner.TFrame", background=THEME["panel_2"])
+    style.configure(
+        "TLabel", background=THEME["panel"], foreground=THEME["slate"]
+    )
+    style.configure(
+        "Shell.TLabel", background=THEME["bg"], foreground=THEME["slate"]
+    )
+    style.configure(
+        "Title.TLabel",
+        background=THEME["bg"],
+        foreground=THEME["cyan"],
+        font=(UI_FONT_FAMILY, 13, "bold"),
+    )
+    style.configure(
+        "Version.TLabel",
+        background=THEME["bg"],
+        foreground=THEME["amber"],
+        font=UI_FONT_BOLD,
+    )
+    style.configure(
+        "Card.TLabel", background=THEME["panel_2"], foreground=THEME["slate"]
+    )
+    style.configure(
+        "CardTitle.TLabel",
+        background=THEME["panel_2"],
+        foreground=THEME["cyan"],
+        font=UI_FONT_BOLD,
+    )
+    style.configure(
+        "DialogTitle.TLabel",
+        background=THEME["panel"],
+        foreground=THEME["cyan"],
+        font=(UI_FONT_FAMILY, 13, "bold"),
+    )
+    style.configure(
+        "Amber.TLabel", background=THEME["panel"], foreground=THEME["amber"]
+    )
+    style.configure(
+        "Link.TLabel", background=THEME["panel"], foreground=THEME["cyan"]
+    )
+    style.configure(
+        "TLabelframe",
+        background=THEME["panel"],
+        bordercolor=THEME["rule"],
+        lightcolor=THEME["rule"],
+        darkcolor=THEME["rule"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.configure(
+        "TLabelframe.Label",
+        background=THEME["bg"],
+        foreground=THEME["cyan"],
+        font=UI_FONT_BOLD,
+        padding=(5, 1),
+    )
+    style.configure(
+        "TButton",
+        background=THEME["button"],
+        foreground=THEME["cyan"],
+        bordercolor="#24485a",
+        lightcolor="#24485a",
+        darkcolor="#24485a",
+        borderwidth=1,
+        relief="solid",
+        padding=(9, 5),
+        focuscolor=THEME["cyan"],
+    )
+    style.map(
+        "TButton",
+        background=[("active", THEME["button_hover"]), ("pressed", "#0e2029")],
+        foreground=[("disabled", THEME["slate_dim"])],
+        bordercolor=[("active", "#3a6f86"), ("disabled", THEME["rule"])],
+    )
+    style.configure(
+        "Accent.TButton",
+        background="#241c0d",
+        foreground=THEME["amber"],
+        bordercolor=THEME["amber_dim"],
+    )
+    style.map("Accent.TButton", background=[("active", "#332713")])
+    style.configure(
+        "TCheckbutton",
+        background=THEME["bg"],
+        foreground=THEME["slate"],
+        indicatorbackground=THEME["input"],
+        indicatorforeground=THEME["cyan"],
+        padding=(2, 3),
+    )
+    style.map(
+        "TCheckbutton",
+        background=[("active", THEME["bg"])],
+        foreground=[("active", THEME["cyan"])],
+        indicatorbackground=[("selected", THEME["cyan"])],
+    )
+    style.configure(
+        "Panel.TCheckbutton",
+        background=THEME["panel"],
+        foreground=THEME["slate"],
+    )
+    style.map("Panel.TCheckbutton", background=[("active", THEME["panel"])])
+    style.configure(
+        "TEntry",
+        fieldbackground=THEME["input"],
+        foreground=THEME["amber"],
+        insertcolor=THEME["cyan"],
+        bordercolor=THEME["rule_bright"],
+        lightcolor=THEME["rule_bright"],
+        darkcolor=THEME["rule_bright"],
+        padding=(7, 5),
+    )
+    style.map(
+        "TEntry",
+        bordercolor=[("focus", THEME["cyan"])],
+        lightcolor=[("focus", THEME["cyan"])],
+        darkcolor=[("focus", THEME["cyan"])],
+    )
+    return style
+
+
+class CheckXControl(ttk.Frame):
+    """A compact Boolean control with a DPI-stable drawn check or X."""
+
+    def __init__(self, parent, variable, text, command, panel=False):
+        frame_style = "TFrame" if panel else "Shell.TFrame"
+        label_style = "TLabel" if panel else "Shell.TLabel"
+        surface = THEME["panel"] if panel else THEME["bg"]
+        super().__init__(parent, style=frame_style, takefocus=True)
+        self.variable = variable
+        self.command = command
+        self.indicator = tk.Canvas(
+            self,
+            width=18,
+            height=18,
+            background=surface,
+            highlightthickness=0,
+            borderwidth=0,
+            cursor="hand2",
+        )
+        self.indicator.pack(side="left", padx=(3, 6))
+        self.label = ttk.Label(
+            self,
+            text=text,
+            style=label_style,
+            cursor="hand2",
+        )
+        self.label.pack(side="left")
+        for widget in (self, self.indicator, self.label):
+            widget.bind("<Button-1>", self._toggle)
+        self.bind("<space>", self._toggle)
+        self.bind("<Return>", self._toggle)
+        self.bind("<FocusIn>", lambda _event: self._draw(focused=True))
+        self.bind("<FocusOut>", lambda _event: self._draw(focused=False))
+        self.variable.trace_add("write", lambda *_args: self._draw())
+        self._draw()
+
+    def _toggle(self, _event=None):
+        self.focus_set()
+        self.variable.set(not self.variable.get())
+        self.command()
+        return "break"
+
+    def _draw(self, focused=False):
+        canvas = self.indicator
+        canvas.delete("all")
+        selected = self.variable.get()
+        outline = THEME["cyan"] if selected else THEME["amber_dim"]
+        if focused:
+            outline = THEME["amber"]
+        canvas.create_rectangle(2, 2, 16, 16, outline=outline, width=1)
+        if selected:
+            canvas.create_line(
+                5,
+                9,
+                8,
+                12,
+                14,
+                5,
+                fill=THEME["green"],
+                width=2,
+                capstyle="round",
+                joinstyle="round",
+            )
+        else:
+            canvas.create_line(
+                6,
+                6,
+                12,
+                12,
+                fill=THEME["warn"],
+                width=2,
+                capstyle="round",
+            )
+            canvas.create_line(
+                12,
+                6,
+                6,
+                12,
+                fill=THEME["warn"],
+                width=2,
+                capstyle="round",
+            )
+
+
+def _default_backup_root():
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        return Path(local_app_data) / "WoobiesMissionControl" / "dll_backups"
+    return Path.home() / ".woobies-mission-control" / "dll_backups"
+
+
+DLL_BACKUP_ROOT = _default_backup_root()
+
+
+def find_changelog_path(candidates=CHANGELOG_CANDIDATES):
+    """Return the first packaged or source-tree changelog, if available."""
+    for candidate in candidates:
+        path = Path(candidate)
+        if path.is_file():
+            return path.resolve()
+    return None
+
+
+def load_changelog(path=None):
+    """Load the UTF-8 changelog or return an empty string on read failure."""
+    path = Path(path) if path is not None else find_changelog_path()
+    if path is None:
+        return ""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def extract_version_changelog(changelog, version):
+    """Return one Markdown version section, including its heading."""
+    if not isinstance(changelog, str) or not changelog.strip():
+        return ""
+    pattern = re.compile(
+        rf"(?ms)^## v{re.escape(version)}[^\r\n]*\r?\n"
+        rf".*?(?=^## v\d|\Z)"
+    )
+    match = pattern.search(changelog)
+    return match.group(0).strip() if match else ""
+
+
+def should_show_changelog(state, version=APP_VERSION, changelog_available=True):
+    """Return whether this launcher version should show What's New once."""
+    if not changelog_available or not isinstance(state, dict):
+        return False
+    if state.get("show_changelog_on_update", True) is False:
+        return False
+    return state.get("last_changelog_version") != version
+
+
+def sha256_file(path):
+    """Return the lowercase SHA-256 digest for *path*."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def service_inventory(ksp_root_value, packaged_gamedata=PACKAGED_GAMEDATA):
+    """Describe packaged and installed Mission Control service DLLs."""
+    if isinstance(ksp_root_value, os.PathLike):
+        ksp_root_value = os.fspath(ksp_root_value)
+    root = resolve_ksp_root(ksp_root_value)
+    packaged_gamedata = Path(packaged_gamedata).resolve()
+    inventory = []
+    for folder, title in SERVICE_DLLS:
+        relative_path = Path(folder) / f"{folder}.dll"
+        source = packaged_gamedata / relative_path
+        target = root / "GameData" / relative_path if root is not None else None
+        source_hash = sha256_file(source) if source.is_file() else None
+        target_hash = (
+            sha256_file(target)
+            if target is not None and target.is_file()
+            else None
+        )
+        if root is None:
+            status = "unconfigured"
+        elif source_hash is None:
+            status = "package_missing"
+        elif target_hash is None:
+            status = "missing"
+        elif source_hash == target_hash:
+            status = "current"
+        else:
+            status = "different"
+        inventory.append(
+            {
+                "folder": folder,
+                "title": title,
+                "relative_path": relative_path,
+                "source": source,
+                "target": target,
+                "source_hash": source_hash,
+                "target_hash": target_hash,
+                "status": status,
+            }
+        )
+    return inventory
+
+
+def running_ksp_processes(tasklist_runner=None):
+    """Return supported KSP process names currently running on Windows."""
+    if os.name != "nt":
+        return []
+    if tasklist_runner is None:
+        def tasklist_runner():
+            result = subprocess.run(
+                ["tasklist", "/FO", "CSV", "/NH"],
+                capture_output=True,
+                text=True,
+                check=False,
+                creationflags=CREATE_NO_WINDOW,
+            )
+            if result.returncode != 0:
+                raise OSError("tasklist could not enumerate running processes")
+            return result.stdout
+    try:
+        output = tasklist_runner()
+        rows = csv.reader(output.splitlines())
+        names = {
+            row[0].strip().lower()
+            for row in rows
+            if row and row[0].strip()
+        }
+    except (OSError, csv.Error) as exc:
+        raise RuntimeError(
+            "Unable to verify whether KSP is running; no DLLs were changed."
+        ) from exc
+    return [
+        name
+        for name in ("KSP_x64.exe", "KSP.exe")
+        if name.lower() in names
+    ]
+
+
+class ServiceRollbackError(RuntimeError):
+    """Raised when an install fails and automatic restoration is incomplete."""
+
+
+def install_service_dlls(
+    ksp_root_value,
+    packaged_gamedata=PACKAGED_GAMEDATA,
+    backup_root=DLL_BACKUP_ROOT,
+    running_process_provider=running_ksp_processes,
+):
+    """Install missing or changed service DLLs with backup and rollback."""
+    if isinstance(ksp_root_value, os.PathLike):
+        ksp_root_value = os.fspath(ksp_root_value)
+    root = resolve_ksp_root(ksp_root_value)
+    if root is None:
+        raise ValueError("Choose a valid KSP folder before installing services.")
+
+    running = running_process_provider()
+    if running:
+        raise RuntimeError(
+            "Close KSP before installing service DLLs. Running: "
+            + ", ".join(running)
+        )
+
+    inventory = service_inventory(root, packaged_gamedata)
+    missing_sources = [item for item in inventory if item["source_hash"] is None]
+    if missing_sources:
+        names = ", ".join(item["folder"] for item in missing_sources)
+        raise FileNotFoundError(f"Packaged service DLLs are missing: {names}")
+
+    changes = [
+        item for item in inventory if item["status"] in {"missing", "different"}
+    ]
+    if not changes:
+        return {"installed": [], "backup_dir": None}
+
+    game_data = (root / "GameData").resolve()
+    for item in changes:
+        target = item["target"]
+        if target is None or not target.resolve().is_relative_to(game_data):
+            raise ValueError(f"Unsafe service destination: {target}")
+
+    stamp = (
+        time.strftime("%Y%m%d-%H%M%S")
+        + f"-{time.time_ns() % 1_000_000_000:09d}-{os.getpid()}"
+    )
+    backup_dir = Path(backup_root).resolve() / stamp
+    prior_files = {}
+    staged_files = []
+    changed_targets = []
+
+    try:
+        for item in changes:
+            target = item["target"]
+            relative_path = item["relative_path"]
+            prior_files[target] = target.is_file()
+            if target.is_file():
+                backup = backup_dir / relative_path
+                backup.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(target, backup)
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            staged = target.with_name(target.name + ".woobie-install.tmp")
+            staged_files.append(staged)
+            shutil.copy2(item["source"], staged)
+            if sha256_file(staged) != item["source_hash"]:
+                raise OSError(f"Copy verification failed for {item['folder']}")
+
+        for item, staged in zip(changes, staged_files):
+            os.replace(staged, item["target"])
+            changed_targets.append(item["target"])
+            if sha256_file(item["target"]) != item["source_hash"]:
+                raise OSError(f"Install verification failed for {item['folder']}")
+    except Exception as install_error:
+        rollback_errors = []
+        for staged in staged_files:
+            try:
+                staged.unlink(missing_ok=True)
+            except OSError as exc:
+                rollback_errors.append(f"temporary cleanup {staged}: {exc}")
+        for target in reversed(changed_targets):
+            relative_path = target.relative_to(game_data)
+            backup = backup_dir / relative_path
+            try:
+                if prior_files[target]:
+                    if not backup.is_file():
+                        raise FileNotFoundError(f"backup not found at {backup}")
+                    shutil.copy2(backup, target)
+                elif not prior_files[target]:
+                    target.unlink(missing_ok=True)
+            except OSError as exc:
+                rollback_errors.append(f"restore {target}: {exc}")
+        if rollback_errors:
+            details = "\n".join(f"- {item}" for item in rollback_errors)
+            raise ServiceRollbackError(
+                f"Installation failed: {install_error}\n\n"
+                "Automatic rollback was incomplete. Manual restoration may "
+                f"be required.\nBackups: {backup_dir}\n\n{details}"
+            ) from install_error
+        raise
+
+    return {
+        "installed": [item["folder"] for item in changes],
+        "backup_dir": backup_dir if backup_dir.is_dir() else None,
+    }
 
 
 def parse_version_tag(tag):
@@ -335,40 +861,53 @@ class App:
         self.update_generation = 0
         self.update_checking = False
         self.latest_release_url = None
+        self.changelog_path = find_changelog_path()
+        self.changelog_dialog = None
 
+        self.style = configure_dashboard_theme(root)
         root.title(f"{APP_NAME} v{APP_VERSION}")
-        root.minsize(660, 430)
         root.protocol("WM_DELETE_WINDOW", self._on_close)
 
-        header = tk.Frame(root)
-        header.pack(fill="x", padx=10, pady=(10, 2))
-        tk.Label(
+        header = ttk.Frame(root, style="Shell.TFrame")
+        header.pack(fill="x", padx=14, pady=(14, 4))
+        ttk.Label(
             header,
-            text=f"{APP_NAME}  v{APP_VERSION}",
+            text=APP_NAME.upper(),
             anchor="w",
-            font=("TkDefaultFont", 11, "bold"),
+            style="Title.TLabel",
         ).pack(side="left")
-        tk.Button(header, text="About", width=8, command=self._show_about).pack(
+        ttk.Label(
+            header, text=f"  //  v{APP_VERSION}", style="Version.TLabel"
+        ).pack(side="left")
+        ttk.Button(header, text="ABOUT", width=9, command=self._show_about).pack(
             side="right"
         )
 
-        update_bar = tk.Frame(root)
-        update_bar.pack(fill="x", padx=10, pady=(2, 4))
-        self.update_status = tk.Label(
+        update_bar = ttk.Frame(root, style="Shell.TFrame")
+        update_bar.pack(fill="x", padx=14, pady=(2, 7))
+        self.update_status = ttk.Label(
             update_bar,
             text="Update status: waiting",
-            fg="#666",
+            foreground=THEME["slate_dim"],
             anchor="w",
+            style="Shell.TLabel",
         )
         self.update_status.pack(side="left", fill="x", expand=True)
-        self.view_release_button = tk.Button(
+        self.view_release_button = ttk.Button(
             update_bar,
             text="View release",
             state="disabled",
             command=self._open_latest_release,
         )
         self.view_release_button.pack(side="right", padx=(4, 0))
-        self.check_updates_button = tk.Button(
+        self.changelog_button = ttk.Button(
+            update_bar,
+            text="Changelog",
+            state="normal" if self.changelog_path is not None else "disabled",
+            command=lambda: self._show_changelog(current_version_only=False),
+        )
+        self.changelog_button.pack(side="right", padx=(4, 0))
+        self.check_updates_button = ttk.Button(
             update_bar,
             text="Check now",
             command=lambda: self._start_update_check(use_cache=False),
@@ -377,34 +916,107 @@ class App:
         self.check_updates_var = tk.BooleanVar(
             value=self.update_state.get("check_enabled", True) is not False
         )
-        tk.Checkbutton(
+        self.check_updates_control = CheckXControl(
             update_bar,
-            text="Check automatically",
-            variable=self.check_updates_var,
-            command=self._toggle_automatic_updates,
-        ).pack(side="right", padx=(4, 0))
+            self.check_updates_var,
+            "AUTOMATIC UPDATE CHECKS",
+            self._toggle_automatic_updates,
+        )
+        self.check_updates_control.pack(side="right", padx=(6, 0))
 
-        settings_frame = tk.LabelFrame(root, text="KSP installation")
-        settings_frame.pack(fill="x", padx=10, pady=6)
-        settings_controls = tk.Frame(settings_frame)
+        settings_frame = ttk.LabelFrame(root, text="KSP INSTALLATION")
+        settings_controls = ttk.Frame(settings_frame)
         settings_controls.pack(fill="x", padx=8, pady=(8, 2))
-        tk.Label(settings_controls, text="KSP folder", width=12, anchor="w").pack(
+        ttk.Label(
+            settings_controls, text="KSP FOLDER", width=12, anchor="w"
+        ).pack(
             side="left"
         )
         self.ksp_root_var = tk.StringVar(value=self.settings.get("ksp_root", ""))
-        self.ksp_root_entry = tk.Entry(
+        self.ksp_root_entry = ttk.Entry(
             settings_controls, textvariable=self.ksp_root_var
         )
         self.ksp_root_entry.pack(side="left", fill="x", expand=True, padx=(0, 6))
         self.ksp_root_entry.bind("<Return>", self._commit_ksp_root)
         self.ksp_root_entry.bind("<FocusOut>", self._commit_ksp_root)
-        tk.Button(
+        ttk.Button(
             settings_controls, text="Browse...", command=self._browse_ksp_root
         ).pack(side="right")
-        self.ksp_root_status = tk.Label(
-            settings_frame, anchor="w", justify="left", fg="#666"
+        self.ksp_root_status = ttk.Label(
+            settings_frame,
+            anchor="w",
+            justify="left",
+            foreground=THEME["slate_dim"],
         )
-        self.ksp_root_status.pack(fill="x", padx=9, pady=(0, 8))
+        self.ksp_root_status.pack(fill="x", padx=9, pady=(0, 4))
+
+        services = ttk.Frame(
+            settings_frame, style="Card.TFrame", padding=(14, 12)
+        )
+        services.pack(fill="x", padx=9, pady=(2, 8))
+        services_header = ttk.Frame(services, style="CardInner.TFrame")
+        services_header.pack(fill="x", pady=(0, 6))
+        ttk.Label(
+            services_header,
+            text="MISSION CONTROL KSP SERVICES",
+            anchor="w",
+            style="CardTitle.TLabel",
+        ).pack(side="left")
+        self.service_summary = ttk.Label(
+            services_header,
+            text="Checking...",
+            foreground=THEME["slate_dim"],
+            anchor="e",
+            style="Card.TLabel",
+        )
+        self.service_summary.pack(side="right")
+
+        self.service_status_labels = {}
+        for folder, title in SERVICE_DLLS:
+            row = ttk.Frame(services, style="CardInner.TFrame")
+            row.pack(fill="x", pady=2)
+            ttk.Label(row, text=title, anchor="w", style="Card.TLabel").pack(
+                side="left", fill="x", expand=True
+            )
+            status = ttk.Label(
+                row,
+                text="Checking...",
+                width=20,
+                anchor="e",
+                style="Card.TLabel",
+            )
+            status.pack(side="right")
+            self.service_status_labels[folder] = status
+
+        service_buttons = ttk.Frame(services, style="CardInner.TFrame")
+        service_buttons.pack(fill="x", pady=(10, 0))
+        self.install_services_button = ttk.Button(
+            service_buttons,
+            text="Install / Repair",
+            state="disabled",
+            command=self._install_or_repair_services,
+            style="Accent.TButton",
+        )
+        self.install_services_button.pack(side="left")
+        ttk.Button(
+            service_buttons,
+            text="Refresh status",
+            command=self._refresh_service_status,
+        ).pack(side="left", padx=(6, 0))
+        self.open_gamedata_button = ttk.Button(
+            service_buttons,
+            text="Open GameData",
+            state="disabled",
+            command=self._open_gamedata,
+        )
+        self.open_gamedata_button.pack(side="right")
+        self.open_packaged_dlls_button = ttk.Button(
+            service_buttons,
+            text="Open Packaged DLLs",
+            state="normal" if PACKAGED_GAMEDATA.is_dir() else "disabled",
+            command=self._open_packaged_dlls,
+        )
+        self.open_packaged_dlls_button.pack(side="right", padx=(0, 6))
         self._refresh_ksp_root_status()
 
         components = discover_components()
@@ -412,24 +1024,37 @@ class App:
             for component in components:
                 self._add_component(component)
         else:
-            empty = tk.LabelFrame(root, text="Components")
-            empty.pack(fill="x", padx=10, pady=6)
-            tk.Label(
+            empty = ttk.LabelFrame(root, text="COMPONENTS")
+            empty.pack(fill="x", padx=14, pady=6)
+            ttk.Label(
                 empty,
                 text="No supported Python components were found beside this launcher.",
                 anchor="w",
             ).pack(fill="x", padx=10, pady=12)
 
-        log_frame = tk.LabelFrame(root, text="Log")
-        log_frame.pack(fill="both", expand=True, padx=10, pady=6)
+        settings_frame.pack(fill="x", padx=14, pady=6)
+
+        log_frame = ttk.LabelFrame(root, text="MISSION LOG")
+        log_frame.pack(fill="both", expand=True, padx=14, pady=(6, 12))
         self.logbox = scrolledtext.ScrolledText(
             log_frame,
-            height=12,
+            height=10,
             state="disabled",
             wrap="word",
-            font=("Consolas", 9),
+            font=UI_FONT,
+            background=THEME["input"],
+            foreground=THEME["amber"],
+            insertbackground=THEME["cyan"],
+            selectbackground="#24485a",
+            selectforeground="#eef3f8",
+            borderwidth=0,
+            relief="flat",
+            padx=8,
+            pady=7,
         )
-        self.logbox.pack(fill="both", expand=True, padx=6, pady=6)
+        self.logbox.pack(fill="both", expand=True, padx=7, pady=7)
+
+        self._apply_initial_window_geometry()
 
         if components:
             names = ", ".join(component["script"] for component in components)
@@ -442,6 +1067,20 @@ class App:
             self.root.after(300, lambda: self._start_update_check(use_cache=True))
         else:
             self.update_status.config(text="Automatic update checks are off")
+        self.root.after(700, self._maybe_show_changelog)
+
+    def _apply_initial_window_geometry(self):
+        self.root.update_idletasks()
+        width, height = calculate_initial_window_size(
+            self.root.winfo_screenwidth(),
+            self.root.winfo_screenheight(),
+            self.root.winfo_reqwidth(),
+            self.root.winfo_reqheight(),
+        )
+        self.root.minsize(min(900, width), min(640, height))
+        x = max(0, (self.root.winfo_screenwidth() - width) // 2)
+        y = max(0, (self.root.winfo_screenheight() - height) // 3)
+        self.root.geometry(f"{width}x{height}+{x}+{y}")
 
     def _add_component(self, component):
         script = HERE / component["script"]
@@ -452,22 +1091,22 @@ class App:
             component["name"], script, self._enqueue, environment_provider
         )
 
-        frame = tk.LabelFrame(self.root, text=component["title"])
-        frame.pack(fill="x", padx=10, pady=6)
+        frame = ttk.LabelFrame(self.root, text=component["title"].upper())
+        frame.pack(fill="x", padx=14, pady=6)
 
-        controls = tk.Frame(frame)
+        controls = ttk.Frame(frame)
         controls.pack(fill="x", padx=8, pady=(8, 2))
 
-        status = tk.Label(
+        status = ttk.Label(
             controls,
             text="\u25cb stopped",
-            fg="#888",
+            foreground=THEME["slate_dim"],
             width=14,
             anchor="w",
         )
         status.pack(side="left")
 
-        button = tk.Button(
+        button = ttk.Button(
             controls,
             text="Start",
             width=9,
@@ -478,16 +1117,16 @@ class App:
         button.pack(side="left", padx=4)
 
         if component["dashboard"] and DASHBOARD.is_file():
-            tk.Button(
+            ttk.Button(
                 controls,
                 text="Open dashboard",
                 command=self._open_dashboard,
             ).pack(side="left", padx=4)
 
-        tk.Label(
+        ttk.Label(
             frame,
             text=component["description"],
-            fg="#555",
+            foreground=THEME["slate"],
             anchor="w",
             justify="left",
         ).pack(fill="x", padx=9, pady=(0, 8))
@@ -512,16 +1151,151 @@ class App:
                 text += " - Notes mod detected"
             else:
                 text += " - Notes mod not detected (optional)"
-            self.ksp_root_status.config(text=text, fg="#2a8a3a")
+            self.ksp_root_status.config(text=text, foreground=THEME["green"])
         elif raw:
             self.ksp_root_status.config(
-                text="Choose the KSP folder that contains GameData.", fg="#b05040"
+                text="Choose the KSP folder that contains GameData.",
+                foreground=THEME["warn"],
             )
         else:
             self.ksp_root_status.config(
                 text="Optional: configure this to enable the Notes ship-log drawer.",
-                fg="#666",
+                foreground=THEME["slate_dim"],
             )
+        if hasattr(self, "service_status_labels"):
+            self._refresh_service_status()
+
+    def _refresh_service_status(self):
+        root = resolve_ksp_root(self.ksp_root_var.get())
+        inventory = service_inventory(self.ksp_root_var.get())
+        presentation = {
+            "unconfigured": ("KSP folder required", THEME["slate_dim"]),
+            "package_missing": ("Not in this package", THEME["warn"]),
+            "missing": ("Missing", THEME["warn"]),
+            "different": ("Repair available", THEME["amber"]),
+            "current": ("Current", THEME["green"]),
+        }
+        counts = {}
+        for item in inventory:
+            counts[item["status"]] = counts.get(item["status"], 0) + 1
+            text, color = presentation[item["status"]]
+            self.service_status_labels[item["folder"]].config(
+                text=text, foreground=color
+            )
+
+        needs_install = counts.get("missing", 0) + counts.get("different", 0)
+        package_missing = counts.get("package_missing", 0)
+        if root is None:
+            summary_text = "Choose a KSP folder"
+            summary_color = THEME["slate_dim"]
+        elif package_missing:
+            summary_text = "Package incomplete"
+            summary_color = THEME["warn"]
+        elif needs_install:
+            summary_text = f"{needs_install} service update(s) ready"
+            summary_color = THEME["amber"]
+        else:
+            summary_text = "All services current"
+            summary_color = THEME["green"]
+        self.service_summary.config(text=summary_text, foreground=summary_color)
+        self.install_services_button.config(
+            text=(
+                f"Install / Repair ({needs_install})"
+                if needs_install
+                else "Install / Repair"
+            ),
+            state=(
+                "normal"
+                if root is not None and needs_install and not package_missing
+                else "disabled"
+            ),
+        )
+        self.open_gamedata_button.config(
+            state="normal" if root is not None else "disabled"
+        )
+
+    def _install_or_repair_services(self):
+        if not self._save_ksp_root():
+            return
+        inventory = service_inventory(self.ksp_root_var.get())
+        changes = [
+            item
+            for item in inventory
+            if item["status"] in {"missing", "different"}
+        ]
+        if not changes:
+            messagebox.showinfo(
+                "KSP services",
+                "All packaged Mission Control service DLLs are already current.",
+                parent=self.root,
+            )
+            return
+
+        action_lines = "\n".join(
+            f"  - {item['title']}: "
+            + ("install" if item["status"] == "missing" else "replace")
+            for item in changes
+        )
+        confirmed = messagebox.askyesno(
+            "Install / Repair KSP services",
+            "Close Kerbal Space Program before continuing.\n\n"
+            "The launcher will make these changes:\n"
+            f"{action_lines}\n\n"
+            "Existing DLLs will be backed up. No other GameData files "
+            "will be changed.\n\nContinue?",
+            parent=self.root,
+            icon="warning",
+        )
+        if not confirmed:
+            return
+
+        try:
+            result = install_service_dlls(self.ksp_root_var.get())
+        except PermissionError as exc:
+            self._enqueue("services", f"install denied: {exc}")
+            messagebox.showerror(
+                "KSP services",
+                "Windows denied access to the KSP GameData folder. Check the "
+                "folder permissions or run the launcher as administrator.",
+                parent=self.root,
+            )
+            return
+        except (OSError, ValueError, RuntimeError) as exc:
+            self._enqueue("services", f"install failed: {exc}")
+            messagebox.showerror("KSP services", str(exc), parent=self.root)
+            self._refresh_service_status()
+            return
+
+        self._refresh_service_status()
+        installed = ", ".join(result["installed"])
+        backup = result["backup_dir"]
+        details = f"Installed and verified: {installed}."
+        if backup is not None:
+            details += f"\n\nBackups: {backup}"
+        self._enqueue("services", details.replace("\n\n", " "))
+        messagebox.showinfo("KSP services", details, parent=self.root)
+
+    def _open_gamedata(self):
+        root = resolve_ksp_root(self.ksp_root_var.get())
+        if root is None:
+            return
+        self._open_folder(root / "GameData", "GameData")
+
+    def _open_packaged_dlls(self):
+        self._open_folder(PACKAGED_GAMEDATA, "packaged DLLs")
+
+    def _open_folder(self, path, description):
+        path = Path(path)
+        if not path.is_dir():
+            self._enqueue("services", f"{description} folder not found at {path}")
+            return
+        try:
+            if os.name == "nt":
+                os.startfile(path)
+            else:
+                webbrowser.open(path.as_uri())
+        except OSError as exc:
+            self._enqueue("services", f"couldn't open {description}: {exc}")
 
     def _save_ksp_root(self):
         raw = self.ksp_root_var.get().strip()
@@ -579,11 +1353,23 @@ class App:
             if cached is not None:
                 self._apply_release_status(cached)
                 return
+            cached_app_version = self.update_state.get("app_version")
+            if (
+                isinstance(cached_app_version, str)
+                and cached_app_version != APP_VERSION
+            ):
+                self._enqueue(
+                    "updates",
+                    f"launcher changed from v{cached_app_version} to "
+                    f"v{APP_VERSION}; bypassing the 24-hour cache.",
+                )
 
         self.update_generation += 1
         generation = self.update_generation
         self.update_checking = True
-        self.update_status.config(text="Checking GitHub for updates…", fg="#666")
+        self.update_status.config(
+            text="Checking GitHub for updates...", foreground=THEME["slate"]
+        )
         self.check_updates_button.config(state="disabled")
 
         def worker():
@@ -615,7 +1401,7 @@ class App:
                 else:
                     self.update_status.config(
                         text="Couldn’t check for updates (offline is OK)",
-                        fg="#666",
+                        foreground=THEME["slate_dim"],
                     )
                     self._enqueue("updates", f"update check unavailable: {result}")
         except queue.Empty:
@@ -631,7 +1417,7 @@ class App:
         if status == "available":
             self.update_status.config(
                 text=f"Update available: {tag_name}",
-                fg="#1a5fb4",
+                foreground=THEME["cyan"],
             )
             self._enqueue(
                 "updates",
@@ -640,12 +1426,12 @@ class App:
         elif status == "development":
             self.update_status.config(
                 text=f"Development build—newer than published {tag_name}",
-                fg="#8a6d1d",
+                foreground=THEME["amber"],
             )
         else:
             self.update_status.config(
                 text=f"Mission Control is up to date ({tag_name})",
-                fg="#2a8a3a",
+                foreground=THEME["green"],
             )
 
     def _toggle_automatic_updates(self):
@@ -660,13 +1446,164 @@ class App:
         self.update_generation += 1
         self.update_checking = False
         self.check_updates_button.config(state="normal")
-        self.update_status.config(text="Automatic update checks are off", fg="#666")
+        self.update_status.config(
+            text="Automatic update checks are off",
+            foreground=THEME["slate_dim"],
+        )
 
     def _save_update_state(self):
         try:
             save_update_state(self.update_state, self.update_state_path)
         except OSError as exc:
             self._enqueue("updates", f"couldn't save update preferences: {exc}")
+
+    def _maybe_show_changelog(self):
+        changelog = load_changelog(self.changelog_path)
+        current_notes = extract_version_changelog(changelog, APP_VERSION)
+        if should_show_changelog(
+            self.update_state,
+            APP_VERSION,
+            changelog_available=bool(current_notes),
+        ):
+            self._show_changelog(current_version_only=True)
+
+    def _show_changelog(self, current_version_only=False):
+        changelog = load_changelog(self.changelog_path)
+        if not changelog:
+            messagebox.showerror(
+                "Changelog",
+                "The changelog is not available in this package.",
+                parent=self.root,
+            )
+            return
+
+        current_notes = extract_version_changelog(changelog, APP_VERSION)
+        content = current_notes if current_version_only and current_notes else changelog
+        heading = (
+            f"What's new in v{APP_VERSION}"
+            if current_version_only and current_notes
+            else "Mission Control changelog"
+        )
+
+        if self.changelog_dialog is not None:
+            try:
+                if self.changelog_dialog.winfo_exists():
+                    self._populate_changelog(heading, content)
+                    self.changelog_dialog.deiconify()
+                    self.changelog_dialog.lift()
+                    self.changelog_dialog.focus_set()
+                    return
+            except tk.TclError:
+                self.changelog_dialog = None
+
+        dialog = tk.Toplevel(self.root)
+        self.changelog_dialog = dialog
+        dialog.title(f"Changelog - {APP_NAME}")
+        dialog.transient(self.root)
+        dialog.geometry("720x520")
+        dialog.minsize(580, 380)
+        dialog.configure(background=THEME["bg"])
+
+        body = ttk.Frame(dialog, padding=(16, 14))
+        body.pack(fill="both", expand=True, padx=1, pady=1)
+        self.changelog_heading = ttk.Label(
+            body,
+            text=heading,
+            anchor="w",
+            style="DialogTitle.TLabel",
+        )
+        self.changelog_heading.pack(fill="x", pady=(0, 8))
+
+        self.changelog_text = scrolledtext.ScrolledText(
+            body,
+            wrap="word",
+            state="disabled",
+            font=UI_FONT,
+            background=THEME["input"],
+            foreground=THEME["amber"],
+            insertbackground=THEME["cyan"],
+            selectbackground="#24485a",
+            selectforeground="#eef3f8",
+            borderwidth=1,
+            relief="solid",
+            padx=10,
+            pady=8,
+        )
+        self.changelog_text.pack(fill="both", expand=True)
+        self.changelog_text.tag_configure(
+            "heading",
+            font=(UI_FONT_FAMILY, 11, "bold"),
+            foreground=THEME["cyan"],
+            spacing1=8,
+            spacing3=4,
+        )
+        self.changelog_text.tag_configure(
+            "bullet",
+            foreground=THEME["amber"],
+            lmargin1=10,
+            lmargin2=28,
+            spacing3=3,
+        )
+
+        footer = ttk.Frame(body)
+        footer.pack(fill="x", pady=(10, 0))
+        self.show_changelog_var = tk.BooleanVar(
+            value=self.update_state.get("show_changelog_on_update", True) is not False
+        )
+        CheckXControl(
+            footer,
+            self.show_changelog_var,
+            "SHOW WHAT'S NEW AFTER FUTURE UPDATES",
+            self._toggle_changelog_on_update,
+            panel=True,
+        ).pack(side="left")
+        ttk.Button(
+            footer, text="Close", width=9, command=self._close_changelog
+        ).pack(side="right")
+
+        dialog.protocol("WM_DELETE_WINDOW", self._close_changelog)
+        self._populate_changelog(heading, content)
+
+        self.update_state["last_changelog_version"] = APP_VERSION
+        self.update_state.setdefault("show_changelog_on_update", True)
+        self._save_update_state()
+
+        dialog.update_idletasks()
+        x = self.root.winfo_rootx() + max(
+            0, (self.root.winfo_width() - dialog.winfo_width()) // 2
+        )
+        y = self.root.winfo_rooty() + max(
+            0, (self.root.winfo_height() - dialog.winfo_height()) // 2
+        )
+        dialog.geometry(f"{dialog.winfo_width()}x{dialog.winfo_height()}+{x}+{y}")
+        dialog.grab_set()
+        dialog.focus_set()
+
+    def _populate_changelog(self, heading, content):
+        self.changelog_heading.config(text=heading)
+        widget = self.changelog_text
+        widget.config(state="normal")
+        widget.delete("1.0", "end")
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                widget.insert("end", stripped.lstrip("# ") + "\n", "heading")
+            elif stripped.startswith("- "):
+                widget.insert("end", "\u2022 " + stripped[2:] + "\n", "bullet")
+            else:
+                widget.insert("end", line + "\n")
+        widget.config(state="disabled")
+        widget.yview_moveto(0)
+
+    def _toggle_changelog_on_update(self):
+        self.update_state["show_changelog_on_update"] = self.show_changelog_var.get()
+        self._save_update_state()
+
+    def _close_changelog(self):
+        dialog = self.changelog_dialog
+        self.changelog_dialog = None
+        if dialog is not None:
+            dialog.destroy()
 
     def _open_latest_release(self):
         if not self.latest_release_url:
@@ -705,33 +1642,36 @@ class App:
         dialog.title(f"About {APP_NAME}")
         dialog.transient(self.root)
         dialog.resizable(False, False)
+        dialog.configure(background=THEME["bg"])
 
-        body = tk.Frame(dialog, padx=18, pady=16)
-        body.pack(fill="both", expand=True)
-        tk.Label(
+        body = ttk.Frame(dialog, padding=(18, 16))
+        body.pack(fill="both", expand=True, padx=1, pady=1)
+        ttk.Label(
             body,
-            text=APP_NAME,
-            font=("TkDefaultFont", 13, "bold"),
+            text=APP_NAME.upper(),
+            style="DialogTitle.TLabel",
         ).pack(anchor="w")
-        tk.Label(body, text=f"Version {APP_VERSION}").pack(anchor="w", pady=(2, 10))
-        tk.Label(body, text=f"Created by {APP_AUTHOR}").pack(anchor="w")
-        tk.Label(body, text="Released under the MIT License").pack(anchor="w")
+        ttk.Label(
+            body, text=f"Version {APP_VERSION}", style="Amber.TLabel"
+        ).pack(anchor="w", pady=(2, 10))
+        ttk.Label(body, text=f"Created by {APP_AUTHOR}").pack(anchor="w")
+        ttk.Label(body, text="Released under the MIT License").pack(anchor="w")
 
-        link = tk.Label(
+        link = ttk.Label(
             body,
             text=PROJECT_URL,
-            fg="#1a5fb4",
             cursor="hand2",
+            style="Link.TLabel",
         )
         link.pack(anchor="w", pady=(10, 12))
         link.bind("<Button-1>", lambda _event: self._open_project_page())
 
-        buttons = tk.Frame(body)
+        buttons = ttk.Frame(body)
         buttons.pack(fill="x")
-        tk.Button(buttons, text="Open GitHub", command=self._open_project_page).pack(
-            side="left"
-        )
-        tk.Button(buttons, text="Close", width=8, command=dialog.destroy).pack(
+        ttk.Button(
+            buttons, text="Open GitHub", command=self._open_project_page
+        ).pack(side="left")
+        ttk.Button(buttons, text="Close", width=8, command=dialog.destroy).pack(
             side="right"
         )
 
@@ -749,10 +1689,12 @@ class App:
     def _refresh(self):
         for backend, status, button in self.backend_rows:
             if backend.running():
-                status.config(text="\u25cf running", fg="#2a8a3a")
+                status.config(text="\u25cf running", foreground=THEME["green"])
                 button.config(text="Stop")
             else:
-                status.config(text="\u25cb stopped", fg="#888")
+                status.config(
+                    text="\u25cb stopped", foreground=THEME["slate_dim"]
+                )
                 button.config(text="Start")
         self.root.after(500, self._refresh)
 

--- a/ksp_mission_dashboard.html
+++ b/ksp_mission_dashboard.html
@@ -1056,7 +1056,7 @@
 </aside>
 
 <footer class="project-footer" aria-label="Project information">
-  <span>Woobie's Mission Control v0.2.2</span><span class="sep">·</span>
+  <span>Woobie's Mission Control v0.2.3</span><span class="sep">·</span>
   <span>by SacredWoobie</span><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control" target="_blank" rel="noopener noreferrer">GitHub</a><span class="sep">·</span>
   <a href="https://github.com/SacredWoobie/woobies-mission-control/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>

--- a/tests/test_dll_install.py
+++ b/tests/test_dll_install.py
@@ -1,0 +1,209 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ksp_dashboard_app as app
+
+
+class DllInstallRepairTests(unittest.TestCase):
+    def make_layout(self, root):
+        ksp_root = root / "KSP"
+        package = root / "package" / "GameData"
+        (ksp_root / "GameData").mkdir(parents=True)
+        for index, (folder, _title) in enumerate(app.SERVICE_DLLS):
+            source = package / folder / f"{folder}.dll"
+            source.parent.mkdir(parents=True)
+            source.write_bytes(f"packaged-{index}".encode("ascii"))
+        return ksp_root, package
+
+    def test_inventory_distinguishes_current_different_and_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ksp_root, package = self.make_layout(root)
+            first, second, _third = app.SERVICE_DLLS
+            first_source = package / first[0] / f"{first[0]}.dll"
+            first_target = ksp_root / "GameData" / first[0] / f"{first[0]}.dll"
+            first_target.parent.mkdir(parents=True)
+            first_target.write_bytes(first_source.read_bytes())
+            second_target = (
+                ksp_root / "GameData" / second[0] / f"{second[0]}.dll"
+            )
+            second_target.parent.mkdir(parents=True)
+            second_target.write_bytes(b"older-build")
+
+            statuses = {
+                item["folder"]: item["status"]
+                for item in app.service_inventory(ksp_root, package)
+            }
+            self.assertEqual(statuses[first[0]], "current")
+            self.assertEqual(statuses[second[0]], "different")
+            self.assertEqual(statuses[app.SERVICE_DLLS[2][0]], "missing")
+
+    def test_install_updates_only_needed_dlls_and_creates_backup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ksp_root, package = self.make_layout(root)
+            unchanged_folder = app.SERVICE_DLLS[0][0]
+            changed_folder = app.SERVICE_DLLS[1][0]
+            unchanged_source = (
+                package / unchanged_folder / f"{unchanged_folder}.dll"
+            )
+            unchanged_target = (
+                ksp_root
+                / "GameData"
+                / unchanged_folder
+                / f"{unchanged_folder}.dll"
+            )
+            unchanged_target.parent.mkdir(parents=True)
+            unchanged_target.write_bytes(unchanged_source.read_bytes())
+            changed_target = (
+                ksp_root / "GameData" / changed_folder / f"{changed_folder}.dll"
+            )
+            changed_target.parent.mkdir(parents=True)
+            changed_target.write_bytes(b"previous-copy")
+            backup_root = root / "backups"
+
+            result = app.install_service_dlls(
+                ksp_root,
+                package,
+                backup_root,
+                running_process_provider=lambda: [],
+            )
+
+            self.assertNotIn(unchanged_folder, result["installed"])
+            self.assertIn(changed_folder, result["installed"])
+            self.assertIn(app.SERVICE_DLLS[2][0], result["installed"])
+            self.assertEqual(
+                changed_target.read_bytes(),
+                (package / changed_folder / f"{changed_folder}.dll").read_bytes(),
+            )
+            backup = (
+                result["backup_dir"]
+                / changed_folder
+                / f"{changed_folder}.dll"
+            )
+            self.assertEqual(backup.read_bytes(), b"previous-copy")
+            self.assertFalse(
+                (result["backup_dir"] / unchanged_folder).exists()
+            )
+
+    def test_running_ksp_blocks_all_changes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ksp_root, package = self.make_layout(root)
+            with self.assertRaisesRegex(RuntimeError, "Close KSP"):
+                app.install_service_dlls(
+                    ksp_root,
+                    package,
+                    root / "backups",
+                    running_process_provider=lambda: ["KSP_x64.exe"],
+                )
+            self.assertFalse(
+                (ksp_root / "GameData" / app.SERVICE_DLLS[0][0]).exists()
+            )
+
+    def test_process_parser_detects_only_supported_ksp_executables(self):
+        output = (
+            '"explorer.exe","100","Console","1","10,000 K"\n'
+            '"KSP_x64.exe","200","Console","1","2,000,000 K"\n'
+            '"NotKSP.exe","300","Console","1","20,000 K"\n'
+        )
+        self.assertEqual(
+            app.running_ksp_processes(lambda: output),
+            ["KSP_x64.exe"],
+        )
+
+    def test_mid_install_failure_restores_every_original_dll(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ksp_root, package = self.make_layout(root)
+            originals = {}
+            for index, (folder, _title) in enumerate(app.SERVICE_DLLS):
+                target = ksp_root / "GameData" / folder / f"{folder}.dll"
+                target.parent.mkdir(parents=True)
+                originals[target] = f"original-{index}".encode("ascii")
+                target.write_bytes(originals[target])
+
+            real_replace = app.os.replace
+            replace_calls = [0]
+
+            def fail_second_replace(source, target):
+                replace_calls[0] += 1
+                if replace_calls[0] == 2:
+                    raise OSError("injected replacement failure")
+                return real_replace(source, target)
+
+            with mock.patch.object(
+                app.os, "replace", side_effect=fail_second_replace
+            ):
+                with self.assertRaisesRegex(OSError, "injected"):
+                    app.install_service_dlls(
+                        ksp_root,
+                        package,
+                        root / "backups",
+                        running_process_provider=lambda: [],
+                    )
+
+            for target, original in originals.items():
+                self.assertEqual(target.read_bytes(), original)
+            self.assertFalse(
+                list((ksp_root / "GameData").rglob("*.woobie-install.tmp"))
+            )
+
+    def test_rollback_failure_reports_manual_restoration_requirement(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ksp_root, package = self.make_layout(root)
+            for index, (folder, _title) in enumerate(app.SERVICE_DLLS):
+                target = ksp_root / "GameData" / folder / f"{folder}.dll"
+                target.parent.mkdir(parents=True)
+                target.write_bytes(f"original-{index}".encode("ascii"))
+
+            backup_root = (root / "backups").resolve()
+            game_data = (ksp_root / "GameData").resolve()
+            real_replace = app.os.replace
+            real_copy2 = app.shutil.copy2
+            replace_calls = [0]
+
+            def fail_second_replace(source, target):
+                replace_calls[0] += 1
+                if replace_calls[0] == 2:
+                    raise OSError("injected replacement failure")
+                return real_replace(source, target)
+
+            def fail_backup_restore(source, target, *args, **kwargs):
+                source = Path(source).resolve()
+                target = Path(target).resolve()
+                if source.is_relative_to(backup_root) and target.is_relative_to(
+                    game_data
+                ):
+                    raise OSError("injected restoration failure")
+                return real_copy2(source, target, *args, **kwargs)
+
+            with mock.patch.object(
+                app.os, "replace", side_effect=fail_second_replace
+            ), mock.patch.object(
+                app.shutil, "copy2", side_effect=fail_backup_restore
+            ):
+                with self.assertRaises(app.ServiceRollbackError) as caught:
+                    app.install_service_dlls(
+                        ksp_root,
+                        package,
+                        backup_root,
+                        running_process_provider=lambda: [],
+                    )
+
+            message = str(caught.exception)
+            self.assertIn("rollback was incomplete", message)
+            self.assertIn("Manual restoration may be required", message)
+            self.assertIn(str(backup_root), message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_launcher_settings.py
+++ b/tests/test_launcher_settings.py
@@ -5,8 +5,8 @@ import unittest
 from pathlib import Path
 
 
-DASHBOARD = Path(__file__).resolve().parents[1] / "Dashboard"
-sys.path.insert(0, str(DASHBOARD))
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
 
 import ksp_dashboard_app
 

--- a/tests/test_notes_telemetry.py
+++ b/tests/test_notes_telemetry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 
-DASHBOARD = Path(__file__).resolve().parents[1] / "Dashboard"
+DASHBOARD = Path(__file__).resolve().parents[1]
 sys.modules.setdefault("krpc", types.ModuleType("krpc"))
 sys.path.insert(0, str(DASHBOARD))
 

--- a/tests/test_update_changelog.py
+++ b/tests/test_update_changelog.py
@@ -1,0 +1,96 @@
+import sys
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ksp_dashboard_app as app
+
+
+class UpdateAndChangelogTests(unittest.TestCase):
+    def test_font_choice_uses_explicit_fallback_order(self):
+        self.assertEqual(
+            app.choose_ui_font_family(["Arial", "Cascadia Code", "Consolas"]),
+            "Cascadia Code",
+        )
+        self.assertEqual(
+            app.choose_ui_font_family(["Arial", "Consolas"]),
+            "Consolas",
+        )
+        self.assertEqual(app.choose_ui_font_family(["Arial"]), "TkFixedFont")
+
+    def test_initial_window_size_is_roomy_and_screen_bounded(self):
+        self.assertEqual(
+            app.calculate_initial_window_size(2560, 1440, 706, 801),
+            (960, 820),
+        )
+        self.assertEqual(
+            app.calculate_initial_window_size(1366, 768, 706, 801),
+            (960, 648),
+        )
+        self.assertEqual(
+            app.calculate_initial_window_size(800, 600, 706, 801),
+            (720, 520),
+        )
+
+    def test_fresh_cache_is_scoped_to_launcher_version(self):
+        now = time.time()
+        state = {
+            "app_version": app.APP_VERSION,
+            "last_checked": now,
+            "tag_name": "v0.2.2",
+            "html_url": (
+                "https://github.com/SacredWoobie/"
+                "woobies-mission-control/releases/tag/v0.2.2"
+            ),
+        }
+        self.assertIsNotNone(app.get_fresh_cached_release(state, now=now))
+        state["app_version"] = "0.2.2"
+        self.assertIsNone(app.get_fresh_cached_release(state, now=now))
+
+    def test_extract_version_changelog_returns_only_requested_section(self):
+        changelog = """# Changelog
+
+## v0.2.3 - New work
+
+- First item.
+- Second item.
+
+## v0.2.2 - Previous work
+
+- Older item.
+"""
+        section = app.extract_version_changelog(changelog, "0.2.3")
+        self.assertIn("v0.2.3", section)
+        self.assertIn("First item", section)
+        self.assertNotIn("v0.2.2", section)
+        self.assertNotIn("Older item", section)
+
+    def test_whats_new_is_once_per_version_and_optional(self):
+        self.assertTrue(app.should_show_changelog({}, "0.2.3", True))
+        self.assertFalse(
+            app.should_show_changelog(
+                {"last_changelog_version": "0.2.3"}, "0.2.3", True
+            )
+        )
+        self.assertFalse(
+            app.should_show_changelog(
+                {"show_changelog_on_update": False}, "0.2.3", True
+            )
+        )
+        self.assertFalse(app.should_show_changelog({}, "0.2.3", False))
+
+    def test_wip_package_contains_current_version_notes(self):
+        path = app.find_changelog_path()
+        self.assertIsNotNone(path)
+        section = app.extract_version_changelog(
+            app.load_changelog(path), app.APP_VERSION
+        )
+        self.assertIn("Guided KSP service maintenance", section)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -71,7 +71,7 @@ class UpdateCheckerTests(unittest.TestCase):
         self.assertEqual(captured["timeout"], 2)
         self.assertEqual(
             captured["request"].get_header("User-agent"),
-            "Woobies-Mission-Control/0.2.2",
+            f"Woobies-Mission-Control/{ksp_dashboard_app.APP_VERSION}",
         )
         self.assertEqual(
             captured["request"].get_header("Accept"),
@@ -79,7 +79,11 @@ class UpdateCheckerTests(unittest.TestCase):
         )
 
     def test_cache_must_be_recent_and_valid(self):
-        state = dict(VALID_RELEASE, app_version="0.2.2", last_checked=1000)
+        state = dict(
+            VALID_RELEASE,
+            app_version=ksp_dashboard_app.APP_VERSION,
+            last_checked=1000,
+        )
         self.assertEqual(
             ksp_dashboard_app.get_fresh_cached_release(
                 state,
@@ -107,7 +111,7 @@ class UpdateCheckerTests(unittest.TestCase):
     def test_update_state_round_trip(self):
         state = dict(
             VALID_RELEASE,
-            app_version="0.2.2",
+            app_version=ksp_dashboard_app.APP_VERSION,
             last_checked=1234,
             check_enabled=False,
         )

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -108,6 +108,7 @@ $sourceFiles = @(
     @{ Source = 'LICENSE'; Destination = 'LICENSE' },
     @{ Source = 'QUICKSTART.txt'; Destination = 'QUICKSTART.txt' },
     @{ Source = 'README.md'; Destination = 'README.md' },
+    @{ Source = 'CHANGELOG.md'; Destination = 'CHANGELOG.md' },
     @{ Source = 'docs/CONTROL_PAD_PROTOCOL.md'; Destination = 'docs/CONTROL_PAD_PROTOCOL.md' },
     @{ Source = 'docs/images/dashboard-overview.png'; Destination = 'docs/images/dashboard-overview.png' },
     @{ Source = 'docs/images/docking-alignment.png'; Destination = 'docs/images/docking-alignment.png' },


### PR DESCRIPTION
## What changed

- adds validated KSP installation selection and guided install/repair for the three packaged kRPC service DLLs
- compares DLLs by SHA-256, blocks replacement while KSP is running, backs up originals, verifies staged copies, and rolls back failed installs
- adds packaged-DLL/GameData shortcuts, version-scoped update checks, first-start changelog display, and permanent changelog controls
- refreshes the launcher with a dashboard-inspired theme, clearer status controls, reordered sections, and screen-aware sizing
- updates v0.2.3 documentation, changelog packaging, dashboard metadata, and automated coverage

## Why

The launcher already knows the KSP installation path, so v0.2.3 uses that information to make service DLL maintenance safer and easier while preserving a manual path for users who prefer drag-and-drop installation.

## User impact

Users can identify missing or outdated Mission Control service DLLs and repair only the affected files. Existing DLLs are backed up before replacement, and the launcher refuses to modify GameData while KSP is running.

## Validation

- 38 Python unit tests pass
- launcher and companion modules pass compilation/import checks
- publisher produced and audited the v0.2.3 ZIP with exactly three expected DLLs
- clean extracted-package bootstrap and launcher smoke test passed
- installed KSP DLL hashes match the candidate package