### PR TITLE
Order v0.3.0 release assets

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -70,6 +70,8 @@ The packager:
 - checks each staged DLL's assembly version and SHA-256;
 - creates an unpacked allowlisted package under `release-output`;
 - creates the ZIP, checksum, generated build information, and release notes;
+- stages five curated standalone screenshot assets using names that sort after
+  the ZIP and checksum in GitHub's release asset list;
 - audits the ZIP for missing files and forbidden source/build artifacts.
 
 The end-user package contains the compiled `Dashboard\web` directory, never
@@ -101,5 +103,8 @@ After committing, pushing, and confirming that `main` matches `origin/main`:
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.ps1 -Version 0.3.0 -CreateDraftRelease
 ```
 
-This creates a draft GitHub Release and uploads the ZIP and checksum. Review
-the draft, its generated notes, and final screenshots before publishing it.
+This creates a draft GitHub Release and uploads the ZIP, checksum, and five
+curated screenshots. The screenshot filenames use a `.zz-01` through `.zz-05`
+suffix so `Woobies-Mission-Control-v0.3.0.zip` remains the first release asset.
+Review the draft, its generated notes, asset ordering, and final screenshots
+before publishing it.

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -83,6 +83,34 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertTrue(required.issubset(actual))
         self.assertFalse(any(" " in name or "&" in name for name in actual))
 
+    def test_release_assets_sort_zip_before_curated_images(self):
+        publish_script = (ROOT / "tools" / "Publish-Release.ps1").read_text(
+            encoding="utf-8"
+        )
+        image_names = re.findall(
+            r'Name = "\$packageName\.([^\"]+\.png)"', publish_script
+        )
+
+        self.assertEqual(
+            image_names,
+            [
+                "zz-01-flight-dashboard.png",
+                "zz-02-mission-control.png",
+                "zz-03-vab-editor.png",
+                "zz-04-launcher.png",
+                "zz-05-notes-drawer.png",
+            ],
+        )
+        zip_name = "Woobies-Mission-Control-v0.3.0.zip"
+        release_image_names = [
+            f"Woobies-Mission-Control-v0.3.0.{name}" for name in image_names
+        ]
+        self.assertEqual(
+            sorted([zip_name, *release_image_names], key=str.casefold)[0], zip_name
+        )
+        self.assertIn("$zipPath, $checksumPath", publish_script)
+        self.assertIn(") + $releaseImagePaths + @(", publish_script)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -117,7 +117,15 @@ $stageRoot = Join-Path $OutputDirectory $packageName
 $zipPath = Join-Path $OutputDirectory "$packageName.zip"
 $checksumPath = Join-Path $OutputDirectory "$packageName.zip.sha256"
 $notesPath = Join-Path $OutputDirectory "release-notes-v$Version.md"
-foreach ($path in @($stageRoot, $zipPath, $checksumPath, $notesPath)) {
+$releaseImages = @(
+    @{ Source = 'docs/images/v0.3.0/flight-dashboard-landscape.png'; Name = "$packageName.zz-01-flight-dashboard.png" },
+    @{ Source = 'docs/images/v0.3.0/mission-control-landscape.png'; Name = "$packageName.zz-02-mission-control.png" },
+    @{ Source = 'docs/images/v0.3.0/editor-vab-landscape.png'; Name = "$packageName.zz-03-vab-editor.png" },
+    @{ Source = 'docs/images/v0.3.0/launcher.png'; Name = "$packageName.zz-04-launcher.png" },
+    @{ Source = 'docs/images/v0.3.0/notes-drawer.png'; Name = "$packageName.zz-05-notes-drawer.png" }
+)
+$releaseImagePaths = @($releaseImages | ForEach-Object { Join-Path $OutputDirectory $_.Name })
+foreach ($path in @($stageRoot, $zipPath, $checksumPath, $notesPath) + $releaseImagePaths) {
     Assert-SafeChildPath -Parent $OutputDirectory -Child $path
 }
 
@@ -147,6 +155,15 @@ $sourceFiles = @(
 Write-Step 'Checking release metadata and source inputs'
 foreach ($file in $sourceFiles) {
     Assert-RequiredFile (Join-Path $repoRoot $file.Source)
+}
+foreach ($image in $releaseImages) {
+    Assert-RequiredFile (Join-Path $repoRoot $image.Source)
+    if ([System.StringComparer]::OrdinalIgnoreCase.Compare(
+        [System.IO.Path]::GetFileName($zipPath),
+        $image.Name
+    ) -ge 0) {
+        throw "Release image '$($image.Name)' must sort after '$([System.IO.Path]::GetFileName($zipPath))'."
+    }
 }
 
 if ($builderReleaseSetPath) {
@@ -234,7 +251,7 @@ New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 if (Test-Path -LiteralPath $stageRoot) {
     Remove-Item -LiteralPath $stageRoot -Recurse -Force
 }
-foreach ($path in @($zipPath, $checksumPath, $notesPath)) {
+foreach ($path in @($zipPath, $checksumPath, $notesPath) + $releaseImagePaths) {
     if (Test-Path -LiteralPath $path) {
         Remove-Item -LiteralPath $path -Force
     }
@@ -288,6 +305,12 @@ if (-not $notesMatch.Success) {
 }
 $notes = $notesMatch.Groups['body'].Value.Trim() + [Environment]::NewLine
 [System.IO.File]::WriteAllText($notesPath, $notes, [System.Text.UTF8Encoding]::new($false))
+
+foreach ($image in $releaseImages) {
+    $source = Join-Path $repoRoot $image.Source
+    $destination = Join-Path $OutputDirectory $image.Name
+    Copy-Item -LiteralPath $source -Destination $destination -Force
+}
 
 Write-Step 'Auditing the unpacked package'
 $stageFiles = @(Get-ChildItem -LiteralPath $stageRoot -Recurse -File)
@@ -348,6 +371,10 @@ Write-Host "  Unpacked: $stageRoot"
 Write-Host "  ZIP:      $zipPath"
 Write-Host "  SHA-256:  $($hash.Hash.ToLowerInvariant())"
 Write-Host "  Notes:    $notesPath"
+Write-Host '  Images:'
+foreach ($imagePath in $releaseImagePaths) {
+    Write-Host "             $imagePath"
+}
 
 if (-not $CreateDraftRelease) {
     Write-Host "`nPackage-only run complete. Nothing was published to GitHub." -ForegroundColor Yellow
@@ -358,7 +385,8 @@ if (-not $CreateDraftRelease) {
 Write-Step 'Creating draft GitHub release'
 $releaseArguments = @(
     'release', 'create', "v$Version",
-    $zipPath, $checksumPath,
+    $zipPath, $checksumPath
+) + $releaseImagePaths + @(
     '--repo', $Repository,
     '--target', $Target,
     '--title', "Woobie's Mission Control v$Version",


### PR DESCRIPTION
## What changed

- stage the five curated v0.3.0 screenshots as standalone release assets
- name screenshots with ordered `.zz-01` through `.zz-05` suffixes
- upload the ZIP and checksum before the ordered screenshots
- document and test the expected GitHub asset ordering

## Why

GitHub displays uploaded release assets by filename. The v0.2.3 launcher image sorted above the package ZIP because its `-launcher` suffix came before `.zip`. The new names retain the normal package filename while making every standalone screenshot sort beneath it.

## User impact

The v0.3.0 release asset list begins with:

1. `Woobies-Mission-Control-v0.3.0.zip`
2. `Woobies-Mission-Control-v0.3.0.zip.sha256`
3. five curated screenshot assets in intentional order

The ZIP contents and end-user installation layout are unchanged.

## Validation

- 85 Python tests passed
- 32 Vitest tests passed
- TypeScript type-check and Vite production build passed
- unpacked package and ZIP audits passed
- generated release assets were sorted locally and the package ZIP was first