### PR TITLE
Keep release source assets behind product ZIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable public changes will be recorded here.
 
 ## Unreleased
 
+- Stage corresponding-source release assets under the established `.zz-00`
+  name so the normal product ZIP remains first without a post-upload rename.
+
 ## v0.4.3 - Flight systems and science operations
 
 - Made Flight transfer-readiness details collapsible while keeping the live

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -263,11 +263,33 @@ class ReleaseContractTests(unittest.TestCase):
             ],
         )
         zip_name = "Woobies-Mission-Control-v0.4.3.zip"
+        checksum_name = f"{zip_name}.sha256"
         release_image_names = [
             f"Woobies-Mission-Control-v0.4.3.{name}" for name in image_names
         ]
+        source_archive_name = (
+            "Woobies-Mission-Control-v0.4.3.zz-00-"
+            "KRPC.WoobiesMechJeb-0.8.6-source.zip"
+        )
         self.assertEqual(
-            sorted([zip_name, *release_image_names], key=str.casefold)[0], zip_name
+            sorted(
+                [
+                    zip_name,
+                    checksum_name,
+                    source_archive_name,
+                    *release_image_names,
+                ],
+                key=str.casefold,
+            ),
+            [
+                zip_name,
+                checksum_name,
+                source_archive_name,
+                *release_image_names,
+            ],
+        )
+        self.assertIn(
+            '"$packageName.zz-00-$($_.SourceArchive)"', publish_script
         )
         self.assertIn("$zipPath, $checksumPath", publish_script)
         self.assertIn(

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -148,11 +148,17 @@ $releaseImagePaths = @(
     $activeReleaseImages |
         ForEach-Object { Join-Path $OutputDirectory $_.Name }
 )
-$sourceArchiveOutputPaths = @(
+$sourceArchiveAssets = @(
     $manifest.Services |
         Where-Object { $_.ContainsKey('SourceArchive') } |
-        ForEach-Object { Join-Path $OutputDirectory $_.SourceArchive }
+        ForEach-Object {
+            @{
+                Source = $_.SourceArchive
+                OutputPath = Join-Path $OutputDirectory "$packageName.zz-00-$($_.SourceArchive)"
+            }
+        }
 )
+$sourceArchiveOutputPaths = @($sourceArchiveAssets | ForEach-Object { $_.OutputPath })
 foreach ($path in @($stageRoot, $zipPath, $checksumPath, $notesPath) + $releaseImagePaths + $sourceArchiveOutputPaths) {
     Assert-SafeChildPath -Parent $OutputDirectory -Child $path
 }
@@ -346,8 +352,14 @@ foreach ($companion in $serviceCompanionInputs) {
 }
 foreach ($sourceArchive in $sourceArchiveInputs) {
     Copy-AllowlistedFile -SourceRoot $sourceArchiveRoot -StageRoot $stageRoot -Entry $sourceArchive
+    $sourceArchiveAsset = $sourceArchiveAssets |
+        Where-Object { $_.Source -eq $sourceArchive.Source } |
+        Select-Object -First 1
+    if (-not $sourceArchiveAsset) {
+        throw "No release asset path was defined for source archive $($sourceArchive.Source)."
+    }
     Copy-Item -LiteralPath (Join-Path $sourceArchiveRoot $sourceArchive.Source) `
-        -Destination (Join-Path $OutputDirectory $sourceArchive.Source) -Force
+        -Destination $sourceArchiveAsset.OutputPath -Force
 }
 
 $webTarget = Join-Path $stageRoot 'Dashboard\web'


### PR DESCRIPTION
## Summary
- stage corresponding-source release assets directly under the established .zz-00 public name
- preserve the raw SOURCE archive path inside the product ZIP and its immutable bytes
- lock the complete ZIP, checksum, source, and screenshot ordering into the release contract

## Validation
- 265 Python tests
- 313 frontend tests plus strict TypeScript/Vite build
- package-only assembly, allowlist audit, ZIP audit, and checksum generation
- independent exact-diff audit: PASS