### PR TITLE
Reconcile dashboard CSS foundation and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python runtime
+    runs-on: windows-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: |
+            requirements-dashboard.txt
+            requirements-panel.txt
+      - name: Install runtime dependencies
+        run: python -m pip install -r requirements-dashboard.txt -r requirements-panel.txt
+      - name: Run Python tests
+        run: python -m unittest discover -s tests -p "test_*.py"
+
+  frontend:
+    name: Frontend and browser compatibility
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+      - name: Set up pnpm and Node.js
+        uses: pnpm/setup@v2
+        with:
+          version: 11.16.0
+          runtime: node@24
+          cache: true
+          cache-dependency-path: frontend/pnpm-lock.yaml
+          package-json-file: frontend/package.json
+          install: false
+      - name: Install locked dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run frontend checks
+        run: pnpm check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable public changes will be recorded here.
 
 ## Unreleased
 
-_No changes yet._
+- Reconciled the dashboard CSS foundation across both active production
+  stylesheets: repaired undefined custom-property references, promoted repeated
+  exact palette values into shared semantic roles, and added a dependency-free
+  CSS contract that prevents those roles from drifting back into raw literals.
+- Raised the minimum dashboard text size to 8 px and moved operational copy off
+  the low-contrast decorative slate role while preserving its use for borders,
+  strokes, fills, and other intentionally receding non-text detail.
+- Added GitHub continuous integration for the Python runtime suite and the
+  locked frontend CSS, unit, type/build, Chrome, and Edge checks.
 
 ## v0.5.0 - Flight dashboard workspaces
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Woobie's Mission Control combines a Python 3.14 loopback runtime with a
+React/TypeScript dashboard. Keep changes scoped, preserve the read-only mission
+safety boundaries described in the README, and include enough validation for a
+reviewer to reproduce the result.
+
+## Local checks
+
+Run the Python suite from the repository root with the project environment:
+
+```powershell
+.\.venv\Scripts\python.exe -m unittest discover -s tests -p "test_*.py"
+```
+
+Install and check the dashboard with Node.js 24 and the pnpm version declared in
+`frontend/package.json`:
+
+```powershell
+cd frontend
+pnpm install --frozen-lockfile
+pnpm check
+```
+
+`pnpm check` runs the CSS contract, Vitest suite, strict TypeScript/Vite build,
+and Chrome/Edge browser compatibility suite. Use `pnpm test:css`,
+`pnpm test:unit`, `pnpm build`, or `pnpm test:browser` for focused iteration,
+but run the complete command before requesting review.
+
+## Dashboard CSS changes
+
+The tracked [dashboard UI/UX guidelines](docs/DASHBOARD_UI_GUIDELINES.md) are
+the design authority. For palette or typography work:
+
+1. Search both `frontend/src/styles.css` and
+   `frontend/src/resonantOrbit/resonantOrbit.css`; both ship in production.
+2. Reuse a semantic token only when its role matches. Before introducing a new
+   token, audit every exact literal occurrence and name the token for the role
+   shared by those selectors.
+3. Keep the 8 px text floor and use `--slate-muted-text` or a stronger token for
+   readable secondary copy. Reserve `--slate-dim` for non-text decoration.
+4. Leave one-off gradients, alpha overlays, shadows, instrument/SVG geometry,
+   and data-visualization endpoints local when no honest shared role exists.
+5. Run `pnpm test:css`, then inspect deterministic Flight, Editor, and Mission
+   Overview fixtures at the applicable `1920x889`, `1280x800`, and `1080x1920`
+   viewports. Record overflow and distinguish fixture evidence from live KSP.
+
+Do not use raw-literal counts, `!important` counts, or the absence of `rem` units
+as automatic defect tests. Each can be legitimate; change it with selector-level
+evidence and rendered review.
+
+## Pull-request evidence
+
+Summarize the affected behavior and report the exact local checks that passed.
+For UI changes, include the scenes, states, viewports, overflow observations,
+and browser families exercised. Note any manual or live-KSP acceptance still
+outstanding rather than treating fixtures as equivalent.
+
+GitHub Actions runs two read-only jobs on pull requests and pushes to `main`:
+`Python runtime` and `Frontend and browser compatibility`. After the workflow's
+first successful run on the default branch, repository administrators should
+configure both job names as required branch-protection checks. The workflow
+does not publish releases or modify a KSP installation.

--- a/README.md
+++ b/README.md
@@ -185,13 +185,20 @@ contains the full setup, planning, compatibility, and troubleshooting guides.
 
 Production Python source lives at the repository root. React and TypeScript
 source lives under `frontend`; fixtures, Vite, and the mock server are
-development tools rather than end-user dependencies.
+development tools rather than end-user dependencies. See
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the complete local and CI checks and
+[`docs/DASHBOARD_UI_GUIDELINES.md`](docs/DASHBOARD_UI_GUIDELINES.md) for the
+tracked dashboard design contract.
 
 ```powershell
 .\scripts\dashboard-dev.ps1 start
 .\scripts\dashboard-dev.ps1 stop
+cd frontend
+pnpm install --frozen-lockfile
+pnpm check
+cd ..
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Build-Frontend.ps1 -InstallDependencies -StageRuntimeWeb
-python -m unittest discover -s tests -p "test_*.py"
+.\.venv\Scripts\python.exe -m unittest discover -s tests -p "test_*.py"
 ```
 
 For repeatable UI work without KSP, `tools\Mock Mission Control.bat` serves the

--- a/docs/DASHBOARD_UI_GUIDELINES.md
+++ b/docs/DASHBOARD_UI_GUIDELINES.md
@@ -36,10 +36,12 @@ density.
 
 - Operational titles, roles, deadlines, values, and decision text must remain
   readable in the actual browser. Use 10-12 px as the normal compact range;
-  reserve 8-9 px text for truly secondary captions and metadata.
-- Use `--slate` or brighter text for supporting information a user must read.
-  `--slate-dim` is for information that can safely recede, not for squeezing
-  more apparent hierarchy out of required copy.
+  reserve 8-9 px text for truly secondary captions and metadata. Eight pixels
+  is the absolute floor for rendered dashboard text; do not evade it with a
+  shorthand declaration or a scene-specific stylesheet.
+- Use `--slate-muted-text` or a stronger semantic text token for supporting
+  information a user must read. `--slate-dim` is reserved for decorative
+  borders, strokes, fills, and other non-text detail that can safely recede.
 - Preserve the dashboard's semantic palette: cyan for active state and primary
   operational controls, amber for time-sensitive or emphasized values, green
   for available/success/recovery state, and red for warnings or destructive
@@ -48,6 +50,29 @@ density.
   countdowns should scan vertically rather than drift with content length.
 - Reformat numeric values through units and precision before truncating them.
   Do not ellipsize a number whose magnitude or unit affects a decision.
+
+### CSS foundation and reuse
+
+- `frontend/src/styles.css` owns the shared `:root` palette used by both active
+  production stylesheets. `resonantOrbit/resonantOrbit.css` consumes those
+  roles rather than defining a parallel palette.
+- Name shared colors for their job, not their hue or the component that first
+  needed them. Current reusable roles include primary/value/muted text,
+  control surfaces, instrument surfaces, accent borders, success borders, and
+  error text. Keep warning and destructive roles distinct even when their
+  values are visually related.
+- Promote a raw color only after checking every exact use across both active
+  stylesheets and confirming one honest semantic role. Preserve local literals
+  for gradients, alpha overlays, shadows, SVG/instrument geometry, and
+  data-visualization endpoints when a global role would be misleading.
+- Do not mechanically collapse near colors, replace all raw literals, or remove
+  `!important`. Each can encode state, cascade, opacity, or instrument geometry;
+  change it only with selector-level evidence and rendered review.
+- `pnpm test:css` is the executable contract. It rejects undefined custom
+  properties, direct reuse of migrated literals, undersized pixel text,
+  low-contrast `--slate-dim` text, and regressions in selected semantic-token
+  contrast pairs. Expand it incrementally when a new role is fully migrated;
+  do not turn current literal counts into a brittle pass/fail target.
 
 ### Layout and responsive behavior
 
@@ -192,7 +217,9 @@ Before calling dashboard UI work complete:
 1. Confirm the first glance answers the scene's primary user question and that
    every visual element communicates real information.
 2. Remove redundant copy and verify required secondary text remains readable in
-   Chrome rather than relying only on declared CSS sizes.
+   Chrome rather than relying only on declared CSS sizes. Run `pnpm test:css`
+   before rendered review so undefined tokens, migrated literals, the 8 px text
+   floor, and selected contrast contracts fail early.
 3. Exercise normal, dense, long-label, loading, empty, unavailable, offline,
    error, and missing-optional-field fixtures applicable to the change.
 4. Inspect `1920x889`, `1280x800`, and `1080x1920`; measure document and panel

--- a/docs/DASHBOARD_UI_GUIDELINES.md
+++ b/docs/DASHBOARD_UI_GUIDELINES.md
@@ -68,11 +68,14 @@ density.
 - Do not mechanically collapse near colors, replace all raw literals, or remove
   `!important`. Each can encode state, cascade, opacity, or instrument geometry;
   change it only with selector-level evidence and rendered review.
-- `pnpm test:css` is the executable contract. It rejects undefined custom
-  properties, direct reuse of migrated literals, undersized pixel text,
-  low-contrast `--slate-dim` text, and regressions in selected semantic-token
-  contrast pairs. Expand it incrementally when a new role is fully migrated;
-  do not turn current literal counts into a brittle pass/fail target.
+- `pnpm test:css` is the executable lexical contract. Across the two app
+  stylesheets it rejects references whose property name has no declaration or
+  runtime allowlist entry, direct reuse of migrated literals, direct and
+  `clamp()` pixel minima below 8 px, `--slate-dim` text declarations, and
+  regressions in selected opaque semantic-token contrast pairs. It does not
+  prove selector scope, inheritance, computed styles, alpha/gradient contrast,
+  or semantic correctness. Expand it incrementally when a new role is fully
+  migrated; do not turn current literal counts into a brittle pass/fail target.
 
 ### Layout and responsive behavior
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -76,14 +76,17 @@ pnpm test:browser
 ```
 
 The CSS contract reads both production stylesheets without network access. It
-checks custom-property declarations and references, prevents migrated palette
-values from drifting back into raw literals, enforces the 8 px operational text
-floor, keeps the low-contrast `--slate-dim` role out of text colors, and checks
-selected semantic text tokens against the panel background. When adding a
-shared token, audit the exact literal across both stylesheets and add it to the
-contract only after every compatible use is migrated. Keep local gradients,
-alpha overlays, shadows, SVG/instrument colors, and data-visualization endpoints
-local when they do not share one honest role.
+lexically checks property names against declarations/runtime entries, prevents
+migrated palette values from drifting back into raw literals, enforces direct
+and `clamp()` pixel minima at the 8 px operational text floor, keeps the
+low-contrast `--slate-dim` role out of text declarations, and checks selected
+opaque semantic text tokens against the panel background. It cannot prove
+selector scope, inheritance, computed styles, alpha/gradient contrast, or
+semantic correctness, so rendered review remains required. When adding a shared
+token, audit the exact literal across both stylesheets and add it to the contract
+only after every compatible use is migrated. Keep local gradients, alpha
+overlays, shadows, SVG/instrument colors, and data-visualization endpoints local
+when they do not share one honest role.
 
 The repository wrapper also audits the production result for development-only
 UI:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -64,8 +64,29 @@ the same populated telemetry on the production loopback port `8090`.
 pnpm check
 ```
 
-This runs Vitest, TypeScript checking, and the Vite production build. The
-repository wrapper also audits the result for development-only UI:
+This runs the CSS contract, Vitest, strict TypeScript/Vite production build,
+and the maintained Chrome/Edge compatibility suite. Use the narrower commands
+while iterating:
+
+```powershell
+pnpm test:css
+pnpm test:unit
+pnpm build
+pnpm test:browser
+```
+
+The CSS contract reads both production stylesheets without network access. It
+checks custom-property declarations and references, prevents migrated palette
+values from drifting back into raw literals, enforces the 8 px operational text
+floor, keeps the low-contrast `--slate-dim` role out of text colors, and checks
+selected semantic text tokens against the panel background. When adding a
+shared token, audit the exact literal across both stylesheets and add it to the
+contract only after every compatible use is migrated. Keep local gradients,
+alpha overlays, shadows, SVG/instrument colors, and data-visualization endpoints
+local when they do not share one honest role.
+
+The repository wrapper also audits the production result for development-only
+UI:
 
 ```powershell
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Build-Frontend.ps1 -InstallDependencies
@@ -79,6 +100,13 @@ developer drawer, and use relative assets so the Python telemetry process can
 serve them from `http://127.0.0.1:8090/`.
 
 Generated `node_modules`, `dist`, `.dev`, and coverage directories are ignored.
+
+Pull requests and pushes to `main` run the same locked frontend check plus the
+Python runtime suite in `.github/workflows/ci.yml`. A green local build is useful
+iteration evidence; the CI run is the shared merge evidence. After the workflow
+first succeeds on the default branch, repository administrators should make
+both job names required in branch protection as described in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ## UI review matrix
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "test": "vitest run",
+    "test": "pnpm test:css && pnpm test:unit",
+    "test:css": "node ./scripts/check-css-contract.mjs",
+    "test:unit": "vitest run",
     "test:browser": "playwright test",
     "check": "pnpm test && pnpm build && pnpm test:browser",
     "preview": "vite preview"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "woobies-mission-control-dashboard",
   "private": true,
   "version": "0.5.0",
+  "packageManager": "pnpm@11.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/scripts/check-css-contract.mjs
+++ b/frontend/scripts/check-css-contract.mjs
@@ -110,8 +110,9 @@ export function collectPixelFontSizes(source) {
     const property = match[1].toLowerCase();
     const value = match[2];
     const sizeMatch = property === "font-size"
-      ? value.match(/^\s*(\d*\.?\d+)px\b/i)
-      : value.match(/(?:^|\s)(\d*\.?\d+)px(?:\s*\/|\s|$)/i);
+      ? value.match(/^\s*(\d*\.?\d+)px\b/i) ?? value.match(/^\s*clamp\(\s*(\d*\.?\d+)px\b/i)
+      : value.match(/(?:^|\s)(\d*\.?\d+)px(?:\s*\/|\s|$)/i)
+        ?? value.match(/(?:^|\s)clamp\(\s*(\d*\.?\d+)px\b/i);
     if (!sizeMatch) continue;
     sizes.push({ index: match.index, pixels: Number.parseFloat(sizeMatch[1]) });
   }
@@ -175,10 +176,15 @@ export function checkCssContract(sources) {
 
   const rootSource = sources.find((source) => source.file === "src/styles.css");
   const rootBlock = rootSource?.text.match(/:root\s*\{([\s\S]*?)\}/)?.[1] ?? "";
-  const rootColors = new Map(
+  const rootStart = rootSource?.text.indexOf(rootBlock) ?? -1;
+  const rootColorDefinitions = new Map(
     [...rootBlock.matchAll(/(--[a-z0-9-]+)\s*:\s*(#[0-9a-f]{3}|#[0-9a-f]{6})\s*;/gi)]
-      .map((match) => [match[1], expandHex(match[2])]),
+      .map((match) => [match[1], {
+        line: lineNumberAt(rootSource.text, rootStart + match.index),
+        literal: expandHex(match[2]),
+      }]),
   );
+  const rootColors = new Map([...rootColorDefinitions].map(([name, definition]) => [name, definition.literal]));
 
   for (const token of canonicalLiteralTokens) {
     const literal = rootColors.get(token);
@@ -190,7 +196,8 @@ export function checkCssContract(sources) {
       const masked = maskCommentsAndStrings(source.text);
       const lines = masked.split("\n");
       lines.forEach((line, index) => {
-        if (/^\s*--[a-z0-9-]+\s*:/i.test(line)) return;
+        const definition = rootColorDefinitions.get(token);
+        if (source.file === rootSource?.file && index + 1 === definition?.line) return;
         const literals = [...line.matchAll(/#[0-9a-f]{3}(?:[0-9a-f]{3})?\b/gi)].map((match) => expandHex(match[0]));
         if (literals.includes(literal)) {
           failures.push(`${source.file}:${index + 1} uses ${literal} directly; use var(${token}).`);

--- a/frontend/scripts/check-css-contract.mjs
+++ b/frontend/scripts/check-css-contract.mjs
@@ -45,6 +45,8 @@ const contrastContracts = [
   { foreground: "--error-text-muted", background: "--panel", minimum: 4.5 },
 ];
 
+const minimumPixelFontSize = 8;
+
 export function maskCommentsAndStrings(source) {
   let output = "";
   let state = "code";
@@ -101,6 +103,21 @@ export function lineNumberAt(source, index) {
   return source.slice(0, index).split("\n").length;
 }
 
+export function collectPixelFontSizes(source) {
+  const masked = maskCommentsAndStrings(source);
+  const sizes = [];
+  for (const match of masked.matchAll(/\b(font-size|font)\s*:\s*([^;{}]+)/gi)) {
+    const property = match[1].toLowerCase();
+    const value = match[2];
+    const sizeMatch = property === "font-size"
+      ? value.match(/^\s*(\d*\.?\d+)px\b/i)
+      : value.match(/(?:^|\s)(\d*\.?\d+)px(?:\s*\/|\s|$)/i);
+    if (!sizeMatch) continue;
+    sizes.push({ index: match.index, pixels: Number.parseFloat(sizeMatch[1]) });
+  }
+  return sizes;
+}
+
 function expandHex(value) {
   const normalized = value.toLowerCase();
   if (/^#[0-9a-f]{3}$/.test(normalized)) {
@@ -143,6 +160,17 @@ export function checkCssContract(sources) {
   for (const reference of references) {
     if (declarations.has(reference.name) || runtimeCustomProperties.has(reference.name)) continue;
     failures.push(`${reference.file}:${lineNumberAt(reference.text, reference.index)} references undefined ${reference.name}.`);
+  }
+
+  for (const source of sources) {
+    for (const size of collectPixelFontSizes(source.text)) {
+      if (size.pixels >= minimumPixelFontSize) continue;
+      failures.push(`${source.file}:${lineNumberAt(source.text, size.index)} sets ${size.pixels}px text; the operational text floor is ${minimumPixelFontSize}px.`);
+    }
+    const masked = maskCommentsAndStrings(source.text);
+    for (const match of masked.matchAll(/(?:^|[;{])\s*color\s*:\s*var\(\s*--slate-dim\s*\)/gim)) {
+      failures.push(`${source.file}:${lineNumberAt(source.text, match.index)} uses low-contrast --slate-dim for text; use --slate-muted-text or a stronger semantic text token.`);
+    }
   }
 
   const rootSource = sources.find((source) => source.file === "src/styles.css");

--- a/frontend/scripts/check-css-contract.mjs
+++ b/frontend/scripts/check-css-contract.mjs
@@ -1,0 +1,192 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cssFiles = [
+  "src/styles.css",
+  "src/resonantOrbit/resonantOrbit.css",
+];
+
+// These properties are supplied by React style objects rather than CSS.
+const runtimeCustomProperties = new Set([
+  "--contract-depth",
+  "--flight-fixed-region-width",
+  "--flight-tabbed-region-width",
+]);
+
+// Literal enforcement is deliberately incremental. Add a token here only
+// after every ordinary use of its exact color has migrated to var(...).
+const canonicalLiteralTokens = new Set([
+  "--danger",
+]);
+
+const contrastContracts = [
+  { foreground: "--slate-muted-text", background: "--panel", minimum: 4.5 },
+  { foreground: "--slate", background: "--panel", minimum: 4.5 },
+  { foreground: "--text-primary", background: "--panel", minimum: 4.5 },
+  { foreground: "--cyan", background: "--panel", minimum: 4.5 },
+  { foreground: "--amber", background: "--panel", minimum: 4.5 },
+  { foreground: "--warn", background: "--panel", minimum: 4.5 },
+  { foreground: "--danger", background: "--panel", minimum: 4.5 },
+];
+
+export function maskCommentsAndStrings(source) {
+  let output = "";
+  let state = "code";
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+    const next = source[index + 1];
+    if (state === "code" && character === "/" && next === "*") {
+      output += "  ";
+      index += 1;
+      state = "comment";
+    } else if (state === "comment" && character === "*" && next === "/") {
+      output += "  ";
+      index += 1;
+      state = "code";
+    } else if (state === "code" && (character === "\"" || character === "'")) {
+      output += " ";
+      state = character === "\"" ? "double-quote" : "single-quote";
+    } else if (
+      (state === "double-quote" && character === "\"")
+      || (state === "single-quote" && character === "'")
+    ) {
+      output += " ";
+      state = "code";
+    } else if ((state === "double-quote" || state === "single-quote") && character === "\\") {
+      output += " ";
+      if (index + 1 < source.length) {
+        output += source[index + 1] === "\n" ? "\n" : " ";
+        index += 1;
+      }
+    } else if (state === "code") {
+      output += character;
+    } else {
+      output += character === "\n" ? "\n" : " ";
+    }
+  }
+  return output;
+}
+
+export function collectCustomProperties(source) {
+  const masked = maskCommentsAndStrings(source);
+  const declarations = new Map();
+  const references = [];
+  for (const match of masked.matchAll(/(--[a-z0-9-]+)\s*:/gi)) {
+    if (!declarations.has(match[1])) declarations.set(match[1], []);
+    declarations.get(match[1]).push(match.index);
+  }
+  for (const match of masked.matchAll(/var\(\s*(--[a-z0-9-]+)(?:\s*,[^)]*)?\)/gi)) {
+    references.push({ name: match[1], index: match.index });
+  }
+  return { declarations, references };
+}
+
+export function lineNumberAt(source, index) {
+  return source.slice(0, index).split("\n").length;
+}
+
+function expandHex(value) {
+  const normalized = value.toLowerCase();
+  if (/^#[0-9a-f]{3}$/.test(normalized)) {
+    return `#${[...normalized.slice(1)].map((character) => character.repeat(2)).join("")}`;
+  }
+  return normalized;
+}
+
+function channelLuminance(value) {
+  const channel = value / 255;
+  return channel <= 0.04045
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+export function contrastRatio(foreground, background) {
+  const luminance = (hex) => {
+    const value = expandHex(hex).slice(1);
+    const channels = [0, 2, 4].map((offset) => channelLuminance(Number.parseInt(value.slice(offset, offset + 2), 16)));
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  };
+  const first = luminance(foreground);
+  const second = luminance(background);
+  return (Math.max(first, second) + 0.05) / (Math.min(first, second) + 0.05);
+}
+
+export function checkCssContract(sources) {
+  const failures = [];
+  const declarations = new Map();
+  const references = [];
+  for (const source of sources) {
+    const collected = collectCustomProperties(source.text);
+    for (const [name, indexes] of collected.declarations) {
+      if (!declarations.has(name)) declarations.set(name, []);
+      declarations.get(name).push(...indexes.map((index) => ({ file: source.file, index, text: source.text })));
+    }
+    references.push(...collected.references.map((reference) => ({ ...reference, file: source.file, text: source.text })));
+  }
+
+  for (const reference of references) {
+    if (declarations.has(reference.name) || runtimeCustomProperties.has(reference.name)) continue;
+    failures.push(`${reference.file}:${lineNumberAt(reference.text, reference.index)} references undefined ${reference.name}.`);
+  }
+
+  const rootSource = sources.find((source) => source.file === "src/styles.css");
+  const rootBlock = rootSource?.text.match(/:root\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+  const rootColors = new Map(
+    [...rootBlock.matchAll(/(--[a-z0-9-]+)\s*:\s*(#[0-9a-f]{3}|#[0-9a-f]{6})\s*;/gi)]
+      .map((match) => [match[1], expandHex(match[2])]),
+  );
+
+  for (const token of canonicalLiteralTokens) {
+    const literal = rootColors.get(token);
+    if (!literal) {
+      failures.push(`Canonical literal token ${token} must be defined as an opaque hex color in :root.`);
+      continue;
+    }
+    for (const source of sources) {
+      const masked = maskCommentsAndStrings(source.text);
+      const lines = masked.split("\n");
+      lines.forEach((line, index) => {
+        if (/^\s*--[a-z0-9-]+\s*:/i.test(line)) return;
+        const literals = [...line.matchAll(/#[0-9a-f]{3}(?:[0-9a-f]{3})?\b/gi)].map((match) => expandHex(match[0]));
+        if (literals.includes(literal)) {
+          failures.push(`${source.file}:${index + 1} uses ${literal} directly; use var(${token}).`);
+        }
+      });
+    }
+  }
+
+  for (const contract of contrastContracts) {
+    const foreground = rootColors.get(contract.foreground);
+    const background = rootColors.get(contract.background);
+    if (!foreground || !background) continue;
+    const ratio = contrastRatio(foreground, background);
+    if (ratio + Number.EPSILON < contract.minimum) {
+      failures.push(`${contract.foreground} contrast against ${contract.background} is ${ratio.toFixed(2)}:1; expected at least ${contract.minimum.toFixed(1)}:1.`);
+    }
+  }
+
+  return {
+    declarations: declarations.size,
+    failures,
+    references: references.length,
+  };
+}
+
+function run() {
+  const sources = cssFiles.map((file) => ({
+    file,
+    text: fs.readFileSync(path.join(frontendRoot, file), "utf8"),
+  }));
+  const result = checkCssContract(sources);
+  if (result.failures.length > 0) {
+    console.error("CSS contract check failed:");
+    result.failures.forEach((failure) => console.error(`- ${failure}`));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`CSS contract check passed (${cssFiles.length} files, ${result.declarations} declared properties, ${result.references} references).`);
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) run();

--- a/frontend/scripts/check-css-contract.mjs
+++ b/frontend/scripts/check-css-contract.mjs
@@ -18,17 +18,31 @@ const runtimeCustomProperties = new Set([
 // Literal enforcement is deliberately incremental. Add a token here only
 // after every ordinary use of its exact color has migrated to var(...).
 const canonicalLiteralTokens = new Set([
+  "--accent-border",
+  "--accent-border-hover",
+  "--amber-accent",
+  "--control-surface",
+  "--control-surface-hover",
   "--danger",
+  "--error-text",
+  "--error-text-muted",
+  "--instrument-surface",
+  "--success-border",
+  "--text-primary",
+  "--text-value",
 ]);
 
 const contrastContracts = [
   { foreground: "--slate-muted-text", background: "--panel", minimum: 4.5 },
   { foreground: "--slate", background: "--panel", minimum: 4.5 },
   { foreground: "--text-primary", background: "--panel", minimum: 4.5 },
+  { foreground: "--text-value", background: "--panel", minimum: 4.5 },
   { foreground: "--cyan", background: "--panel", minimum: 4.5 },
   { foreground: "--amber", background: "--panel", minimum: 4.5 },
   { foreground: "--warn", background: "--panel", minimum: 4.5 },
   { foreground: "--danger", background: "--panel", minimum: 4.5 },
+  { foreground: "--error-text", background: "--panel", minimum: 4.5 },
+  { foreground: "--error-text-muted", background: "--panel", minimum: 4.5 },
 ];
 
 export function maskCommentsAndStrings(source) {

--- a/frontend/scripts/check-css-contract.test.mjs
+++ b/frontend/scripts/check-css-contract.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   checkCssContract,
+  collectPixelFontSizes,
   collectCustomProperties,
   contrastRatio,
   maskCommentsAndStrings,
@@ -29,5 +30,23 @@ describe("CSS contract checker", () => {
   it("calculates stable WCAG contrast ratios", () => {
     expect(contrastRatio("#748197", "#0f151f")).toBeCloseTo(4.65, 2);
     expect(contrastRatio("#4a5568", "#0f151f")).toBeCloseTo(2.43, 2);
+  });
+
+  it("finds undersized font-size and font shorthand declarations", () => {
+    const source = `.ok { font-size: 8px; }\n.too-small { font: 700 7px/1 var(--mono); }\n/* .ignored { font-size: 6px; } */`;
+
+    expect(collectPixelFontSizes(source).map((size) => size.pixels)).toEqual([8, 7]);
+    const result = checkCssContract([{ file: "src/styles.css", text: `:root { --panel: #0f151f; --danger: #f87171; }\n${source}` }]);
+    expect(result.failures).toContain("src/styles.css:3 sets 7px text; the operational text floor is 8px.");
+  });
+
+  it("reserves slate-dim for non-text decoration", () => {
+    const result = checkCssContract([{
+      file: "src/styles.css",
+      text: `:root { --panel: #0f151f; --danger: #f87171; --slate-dim: #4a5568; }\n.label { color: var(--slate-dim); }\n.rule { border-color: var(--slate-dim); }`,
+    }]);
+
+    expect(result.failures).toContain("src/styles.css:2 uses low-contrast --slate-dim for text; use --slate-muted-text or a stronger semantic text token.");
+    expect(result.failures.some((failure) => failure.includes("src/styles.css:3"))).toBe(false);
   });
 });

--- a/frontend/scripts/check-css-contract.test.mjs
+++ b/frontend/scripts/check-css-contract.test.mjs
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   checkCssContract,
@@ -6,6 +9,12 @@ import {
   contrastRatio,
   maskCommentsAndStrings,
 } from "./check-css-contract.mjs";
+
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const productionSources = ["src/styles.css", "src/resonantOrbit/resonantOrbit.css"].map((file) => ({
+  file,
+  text: fs.readFileSync(path.join(frontendRoot, file), "utf8"),
+}));
 
 describe("CSS contract checker", () => {
   it("ignores comments and quoted text while preserving line positions", () => {
@@ -33,11 +42,12 @@ describe("CSS contract checker", () => {
   });
 
   it("finds undersized font-size and font shorthand declarations", () => {
-    const source = `.ok { font-size: 8px; }\n.too-small { font: 700 7px/1 var(--mono); }\n/* .ignored { font-size: 6px; } */`;
+    const source = `.ok { font-size: 8px; }\n.too-small { font: 700 7px/1 var(--mono); }\n.responsive { font-size: clamp(7px, 1vw, 10px); }\n/* .ignored { font-size: 6px; } */`;
 
-    expect(collectPixelFontSizes(source).map((size) => size.pixels)).toEqual([8, 7]);
+    expect(collectPixelFontSizes(source).map((size) => size.pixels)).toEqual([8, 7, 7]);
     const result = checkCssContract([{ file: "src/styles.css", text: `:root { --panel: #0f151f; --danger: #f87171; }\n${source}` }]);
     expect(result.failures).toContain("src/styles.css:3 sets 7px text; the operational text floor is 8px.");
+    expect(result.failures).toContain("src/styles.css:4 sets 7px text; the operational text floor is 8px.");
   });
 
   it("reserves slate-dim for non-text decoration", () => {
@@ -48,5 +58,19 @@ describe("CSS contract checker", () => {
 
     expect(result.failures).toContain("src/styles.css:2 uses low-contrast --slate-dim for text; use --slate-muted-text or a stronger semantic text token.");
     expect(result.failures.some((failure) => failure.includes("src/styles.css:3"))).toBe(false);
+  });
+
+  it("passes the complete production stylesheet contract", () => {
+    expect(checkCssContract(productionSources).failures).toEqual([]);
+  });
+
+  it("rejects a migrated literal reintroduced through a local alias", () => {
+    const mutated = productionSources.map((source) => source.file === "src/resonantOrbit/resonantOrbit.css"
+      ? { ...source, text: `${source.text}\n.regression { --local-border: #315166; border-color: var(--local-border); }` }
+      : source);
+
+    expect(checkCssContract(mutated).failures.some(
+      (failure) => failure.includes("uses #315166 directly; use var(--accent-border)."),
+    )).toBe(true);
   });
 });

--- a/frontend/scripts/check-css-contract.test.mjs
+++ b/frontend/scripts/check-css-contract.test.mjs
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkCssContract,
+  collectCustomProperties,
+  contrastRatio,
+  maskCommentsAndStrings,
+} from "./check-css-contract.mjs";
+
+describe("CSS contract checker", () => {
+  it("ignores comments and quoted text while preserving line positions", () => {
+    const source = `/* var(--comment-only) */\n.demo::after { content: "var(--string-only)"; color: var(--real); }`;
+    const masked = maskCommentsAndStrings(source);
+    const properties = collectCustomProperties(source);
+
+    expect(masked.split("\n")).toHaveLength(2);
+    expect(properties.references.map((reference) => reference.name)).toEqual(["--real"]);
+  });
+
+  it("reports undefined properties but accepts CSS and runtime declarations", () => {
+    const result = checkCssContract([{
+      file: "src/styles.css",
+      text: `:root { --panel: #0f151f; --danger: #f87171; }\n.a { color: var(--missing); }\n.b { margin-left: var(--contract-depth); }`,
+    }]);
+
+    expect(result.failures).toContain("src/styles.css:2 references undefined --missing.");
+    expect(result.failures.some((failure) => failure.includes("--contract-depth"))).toBe(false);
+  });
+
+  it("calculates stable WCAG contrast ratios", () => {
+    expect(contrastRatio("#748197", "#0f151f")).toBeCloseTo(4.65, 2);
+    expect(contrastRatio("#4a5568", "#0f151f")).toBeCloseTo(2.43, 2);
+  });
+});

--- a/frontend/src/resonantOrbit/resonantOrbit.css
+++ b/frontend/src/resonantOrbit/resonantOrbit.css
@@ -1,6 +1,6 @@
-.resonant-rail-tab { border-color: #74552d; color: var(--amber); background: #211a12; }
+.resonant-rail-tab { border-color: var(--amber-accent); color: var(--amber); background: #211a12; }
 .resonant-rail-tab:hover, .resonant-rail-tab[aria-expanded="true"] { border-color: var(--amber-dim); color: #ffd498; background: #2b2115; }
-.delta-v-rail-tab { border-color: #74552d; color: var(--amber); background: #211a12; }
+.delta-v-rail-tab { border-color: var(--amber-accent); color: var(--amber); background: #211a12; }
 .delta-v-rail-tab:hover, .delta-v-rail-tab[aria-expanded="true"] { border-color: var(--amber-dim); color: #ffd498; background: #2b2115; }
 .delta-v-rail-icon { display: flex; width: 29px; height: 28px; align-items: center; justify-content: center; flex: 0 0 29px; flex-direction: column; line-height: 1; text-transform: none; }
 .delta-v-rail-icon b { font: 700 12px var(--mono); letter-spacing: -.08em; }
@@ -14,12 +14,12 @@
 .app-shell:has(.resonant-drawer) .dev-drawer-shell { opacity: 0; pointer-events: none; transform: translateX(-100%); }
 
 .resonant-drawer-backdrop { position: fixed; z-index: 11; inset: 0; border: 0; background: rgba(0,0,0,.58); cursor: default; }
-.resonant-drawer { position: fixed; z-index: 12; top: 0; right: 0; display: grid; grid-template-rows: auto minmax(0,1fr) auto; width: min(980px,94vw); height: 100vh; color: #d7e2ee; background: #081018; border-left: 1px solid var(--rule-bright); box-shadow: -24px 0 70px rgba(0,0,0,.55); }
+.resonant-drawer { position: fixed; z-index: 12; top: 0; right: 0; display: grid; grid-template-rows: auto minmax(0,1fr) auto; width: min(980px,94vw); height: 100vh; color: var(--text-primary); background: #081018; border-left: 1px solid var(--rule-bright); box-shadow: -24px 0 70px rgba(0,0,0,.55); }
 .resonant-drawer > header { display: flex; justify-content: space-between; gap: 18px; padding: 16px 18px; border-bottom: 1px solid var(--rule); background: linear-gradient(90deg,rgba(78,201,224,.05),transparent 55%); }
 .resonant-drawer > header span, .resonant-result-head span { color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
 .resonant-drawer > header h2 { margin: 3px 0 0; color: var(--amber); font-size: 16px; letter-spacing: .08em; text-transform: uppercase; }
 .resonant-drawer > header p { margin: 5px 0 0; color: var(--slate); font-size: 10px; }
-.resonant-drawer > header button { align-self: start; padding: 0 4px; border: 0; color: #d7e2ee; background: transparent; cursor: pointer; font-size: 22px; }
+.resonant-drawer > header button { align-self: start; padding: 0 4px; border: 0; color: var(--text-primary); background: transparent; cursor: pointer; font-size: 22px; }
 .resonant-drawer > header > button,
 .delta-v-header-actions > button:last-child { display: grid; width: 24px; min-width: 24px; height: 24px; padding: 0; place-items: center; }
 .resonant-drawer-body { min-height: 0; overflow: auto; }
@@ -34,14 +34,14 @@
 .resonant-save-fields { display: grid; min-width: min(520px,70vw); grid-template-columns: minmax(220px,1fr) auto; align-items: end; gap: 10px; }
 .resonant-save-fields label { display: grid; gap: 4px; }
 .resonant-save-fields label > span { color: var(--slate); font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-.resonant-save-fields input { min-height: 36px; padding: 7px 9px; border: 1px solid var(--rule-bright); outline: 0; color: #d7e2ee; background: #060c12; font: 10px var(--mono); }
+.resonant-save-fields input { min-height: 36px; padding: 7px 9px; border: 1px solid var(--rule-bright); outline: 0; color: var(--text-primary); background: #060c12; font: 10px var(--mono); }
 .resonant-save-fields input:focus { border-color: var(--cyan); }
 .resonant-save-fields small { padding-bottom: 10px; color: var(--green); font-size: 9px; }
 
 .resonant-controls { display: grid; grid-template-columns: minmax(150px,1.2fr) 88px minmax(155px,1fr) minmax(210px,1.25fr); gap: 10px; align-items: end; padding: 14px 16px; border-bottom: 1px solid var(--rule); }
 .resonant-controls label, .resonant-advanced label { display: grid; gap: 6px; min-width: 0; }
 .resonant-controls label > span, .resonant-controls legend, .resonant-advanced label > span { color: var(--slate); font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-.resonant-controls input, .resonant-controls select, .resonant-advanced input { width: 100%; min-height: 36px; padding: 7px 9px; border: 1px solid var(--rule-bright); border-radius: 0; outline: 0; color: #d7e2ee; background: #060c12; font: 11px var(--mono); }
+.resonant-controls input, .resonant-controls select, .resonant-advanced input { width: 100%; min-height: 36px; padding: 7px 9px; border: 1px solid var(--rule-bright); border-radius: 0; outline: 0; color: var(--text-primary); background: #060c12; font: 11px var(--mono); }
 .resonant-controls input:focus, .resonant-controls select:focus, .resonant-advanced input:focus { border-color: var(--cyan); }
 .resonant-controls fieldset { margin: 0; padding: 0; border: 0; }
 .resonant-controls legend { margin-bottom: 6px; }
@@ -61,7 +61,7 @@
 .resonant-library { margin: 12px 16px; border: 1px solid var(--rule); background: #070d13; }
 .resonant-library > header { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 12px; border-bottom: 1px solid var(--rule); }
 .resonant-library > header > div { display: flex; align-items: center; gap: 7px; color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .1em; }
-.resonant-library > header strong { display: grid; min-width: 22px; height: 18px; padding: 0 4px; place-items: center; border: 1px solid #315166; color: #d7e2ee; }
+.resonant-library > header strong { display: grid; min-width: 22px; height: 18px; padding: 0 4px; place-items: center; border: 1px solid var(--accent-border); color: var(--text-primary); }
 .resonant-library > header p { margin: 0; color: var(--slate); font-size: 9px; }
 .resonant-library-empty { padding: 14px 12px; color: var(--slate-muted-text); font-size: 9px; }
 .resonant-library-list { display: grid; max-height: 230px; overflow: auto; }
@@ -70,7 +70,7 @@
 .resonant-library-list article.pinned { box-shadow: inset 2px 0 var(--green); background: rgba(126,231,135,.04); }
 .resonant-library-list article > div:first-child { min-width: 0; }
 .resonant-library-list article > div:first-child strong, .resonant-library-list article > div:first-child span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.resonant-library-list article > div:first-child strong { color: #d7e2ee; font-size: 10px; }
+.resonant-library-list article > div:first-child strong { color: var(--text-primary); font-size: 10px; }
 .resonant-library-list article > div:first-child span { margin-top: 4px; color: var(--slate); font-size: 9px; text-transform: uppercase; }
 .resonant-library-actions { display: flex; gap: 5px; }
 .resonant-library-actions button { min-height: 29px; padding: 5px 8px; border: 1px solid var(--rule-bright); color: var(--cyan); background: #0c141e; cursor: pointer; font: 9px var(--mono); text-transform: uppercase; }
@@ -104,14 +104,14 @@
 
 .resonant-results { padding: 14px 16px 17px; }
 .resonant-result-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 11px; }
-.resonant-result-head h3 { margin: 3px 0 0; color: #d7e2ee; font-size: 14px; }
+.resonant-result-head h3 { margin: 3px 0 0; color: var(--text-primary); font-size: 14px; }
 .resonant-result-head > strong { padding: 5px 7px; border: 1px solid; font-size: 9px; letter-spacing: .08em; }
 .resonant-result-head > strong.nominal { color: var(--green); border-color: rgba(126,231,135,.35); }
 .resonant-result-head > strong.warning { color: var(--amber); border-color: rgba(255,180,84,.45); }
 .resonant-result-head > strong.danger { color: var(--warn); border-color: rgba(255,107,91,.45); }
 .resonant-result-grid { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 7px; }
-.resonant-result-grid article { min-width: 0; min-height: 86px; padding: 10px; border: 1px solid var(--rule); border-top-color: #315166; background: rgba(15,21,31,.75); }
-.resonant-result-grid article.delta { border-top-color: #74552d; }
+.resonant-result-grid article { min-width: 0; min-height: 86px; padding: 10px; border: 1px solid var(--rule); border-top-color: var(--accent-border); background: rgba(15,21,31,.75); }
+.resonant-result-grid article.delta { border-top-color: var(--amber-accent); }
 .resonant-result-grid article > span { display: block; margin-bottom: 7px; color: var(--slate); font-size: 9px; letter-spacing: .07em; text-transform: uppercase; }
 .resonant-result-grid article > strong { display: block; overflow: hidden; color: var(--cyan); font-size: clamp(14px,1.8vw,20px); text-overflow: ellipsis; white-space: nowrap; }
 .resonant-result-grid article.delta > strong { color: var(--amber); }
@@ -148,21 +148,21 @@
 .delta-v-controls label > span, .delta-v-controls legend { display: flex; height: 11px; align-items: center; margin: 0; color: var(--slate); font-size: 9px; font-weight: 700; line-height: 11px; letter-spacing: .08em; text-transform: uppercase; }
 .delta-v-controls label > .delta-v-field-heading { justify-content: space-between; gap: 8px; }
 .delta-v-field-heading small { min-width: 0; min-height: 0; overflow: hidden; color: var(--slate-muted-text); font-size: 9px; font-weight: 400; line-height: 1; letter-spacing: 0; text-overflow: ellipsis; text-transform: none; white-space: nowrap; }
-.delta-v-field-heading small.delta-v-input-error { color: #e4a79f; }
+.delta-v-field-heading small.delta-v-input-error { color: var(--error-text); }
 .delta-v-controls legend { margin-bottom: 5px; }
 .delta-v-transfer-mode + small { display: block; margin-top: 3px; }
-.delta-v-controls select, .delta-v-controls input[type="number"] { width: 100%; min-height: 36px; padding: 7px 9px; border: 1px solid var(--rule-bright); border-radius: 0; outline: 0; color: #d7e2ee; background: #060c12; font: 11px var(--mono); }
+.delta-v-controls select, .delta-v-controls input[type="number"] { width: 100%; min-height: 36px; padding: 7px 9px; border: 1px solid var(--rule-bright); border-radius: 0; outline: 0; color: var(--text-primary); background: #060c12; font: 11px var(--mono); }
 .delta-v-controls select:focus, .delta-v-controls input[type="number"]:focus { border-color: var(--cyan); }
 .delta-v-controls input[aria-invalid="true"] { border-color: var(--warn); }
 .delta-v-controls small { min-height: 11px; color: var(--slate-muted-text); font-size: 9px; line-height: 1.25; }
-.delta-v-controls small.delta-v-input-error { color: #e4a79f; }
+.delta-v-controls small.delta-v-input-error { color: var(--error-text); }
 .delta-v-parking-altitude > small { overflow: visible; text-overflow: clip; white-space: normal; }
 .delta-v-stop-builder.editing { padding: 6px; border: 1px solid rgba(255,180,84,.45); background: rgba(255,180,84,.035); }
 .delta-v-empty-stop { display: grid; min-height: 58px; grid-column: 2 / -1; align-content: center; gap: 5px; padding: 7px 10px; border: 1px dashed #294657; background: #070d13; }
 .delta-v-empty-stop span { color: var(--slate); font-size: 9px; letter-spacing: .08em; }
 .delta-v-empty-stop strong { color: var(--slate-muted-text); font-size: 9px; font-weight: 400; }
 .delta-v-add-stop-row { display: flex; min-height: 44px; margin-top: 16px; align-self: start; align-items: center; justify-self: end; gap: 6px; }
-.delta-v-add-stop-row button { min-height: 30px; padding: 5px 10px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 9px var(--mono); letter-spacing: .04em; text-transform: uppercase; }
+.delta-v-add-stop-row button { min-height: 30px; padding: 5px 10px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-add-stop-row button:hover, .delta-v-add-stop-row button:focus-visible { border-color: var(--cyan); background: #102633; }
 .delta-v-add-stop-row button.secondary { border-color: var(--rule-bright); color: var(--slate); background: #0c141e; }
 .delta-v-add-stop-row button:disabled { opacity: .4; cursor: not-allowed; }
@@ -173,31 +173,31 @@
 .delta-v-plan-library-list article.pinned { box-shadow: inset 2px 0 var(--green); background: rgba(126,231,135,.04); }
 .delta-v-plan-library-list article.loaded { border-color: #3a697d; background: rgba(78,201,224,.055); }
 .delta-v-plan-library-list article > div:first-child { display: grid; min-width: 0; gap: 2px; }
-.delta-v-plan-library-list article strong { overflow: hidden; color: #d7e2ee; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.delta-v-plan-library-list article strong { overflow: hidden; color: var(--text-primary); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-plan-library-list article span { overflow: hidden; color: var(--slate); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-plan-library-actions { display: flex; gap: 4px; }
-.delta-v-plan-library-actions button { min-height: 27px; padding: 4px 7px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 8px var(--mono); }
+.delta-v-plan-library-actions button { min-height: 27px; padding: 4px 7px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 8px var(--mono); }
 .delta-v-plan-library-actions button.active { border-color: rgba(126,231,135,.45); color: var(--green); }
-.delta-v-plan-library-actions button.delete { border-color: #573b43; color: #e4a79f; background: #120b0f; }
+.delta-v-plan-library-actions button.delete { border-color: #573b43; color: var(--error-text); background: #120b0f; }
 .delta-v-plan-library-actions button:disabled { opacity: .65; cursor: default; }
 .delta-v-error { margin-bottom: 0; }
 .delta-v-output { display: grid; min-height: min(360px,100%); flex: 1; grid-template-columns: minmax(0,1fr); grid-template-rows: auto minmax(0,1fr); grid-template-areas: "summary" "route"; gap: 8px; padding: 9px 16px 11px; overflow: hidden; }
 .delta-v-summary { display: grid; grid-area: summary; grid-template-columns: minmax(270px,.65fr) minmax(0,1.35fr); grid-template-areas: "budget-head budget-head" "budget-total budget-stats"; gap: 6px; min-width: 0; }
 .delta-v-summary > header { display: flex; grid-area: budget-head; align-items: center; justify-content: space-between; gap: 10px; }
 .delta-v-summary > header span, .delta-v-route > header span { color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .12em; }
-.delta-v-summary > header h3 { margin: 3px 0 0; color: #d7e2ee; font-size: 14px; }
+.delta-v-summary > header h3 { margin: 3px 0 0; color: var(--text-primary); font-size: 14px; }
 .delta-v-summary > header > strong { padding: 5px 7px; border: 1px solid rgba(126,231,135,.35); color: var(--green); font-size: 9px; letter-spacing: .06em; }
 .delta-v-save-bar { display: grid; grid-area: budget-save; grid-template-columns: minmax(180px,1fr) auto auto; align-items: end; gap: 6px; }
 .delta-v-save-bar label { display: grid; gap: 3px; }
 .delta-v-save-bar label > span { color: var(--slate); font-size: 8px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-.delta-v-save-bar input { width: 100%; min-height: 29px; padding: 5px 8px; border: 1px solid var(--rule-bright); outline: 0; color: #d7e2ee; background: #060c12; font: 9px var(--mono); }
+.delta-v-save-bar input { width: 100%; min-height: 29px; padding: 5px 8px; border: 1px solid var(--rule-bright); outline: 0; color: var(--text-primary); background: #060c12; font: 9px var(--mono); }
 .delta-v-save-bar input:focus { border-color: var(--cyan); }
-.delta-v-save-bar button { min-height: 29px; padding: 5px 9px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 9px var(--mono); }
+.delta-v-save-bar button { min-height: 29px; padding: 5px 9px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); }
 .delta-v-save-actions { display: flex; min-width: 0; gap: 6px; }
 .delta-v-save-actions button { flex: 1 1 auto; }
 .delta-v-save-bar small { grid-column: 1 / -1; align-self: center; color: var(--green); font-size: 9px; }
-.delta-v-save-bar small.error { color: #e4a79f; }
-.delta-v-total { grid-area: budget-total; padding: 12px 15px; border: 1px solid #74552d; border-left: 3px solid var(--amber); background: linear-gradient(100deg,rgba(255,180,84,.09),rgba(15,21,31,.78)); }
+.delta-v-save-bar small.error { color: var(--error-text); }
+.delta-v-total { grid-area: budget-total; padding: 12px 15px; border: 1px solid var(--amber-accent); border-left: 3px solid var(--amber); background: linear-gradient(100deg,rgba(255,180,84,.09),rgba(15,21,31,.78)); }
 .delta-v-total > span, .delta-v-stat-grid span { display: block; color: var(--slate); font-size: 9px; letter-spacing: .07em; text-transform: uppercase; }
 .delta-v-total > strong { display: block; margin-top: 6px; color: var(--amber); font-size: clamp(24px,3vw,34px); letter-spacing: -.035em; }
 .delta-v-total > small, .delta-v-stat-grid small { display: block; margin-top: 5px; color: var(--slate-muted-text); font-size: 9px; }
@@ -213,23 +213,23 @@
 .delta-v-route-timing > div { min-width: 0; padding: 2px 12px; border-right: 1px solid var(--rule); }
 .delta-v-route-timing > div:last-child { border-right: 0; }
 .delta-v-route-timing span { display: block; color: var(--slate); font-size: 8px; font-weight: 400; letter-spacing: .07em; text-transform: uppercase; }
-.delta-v-route-timing strong { display: block; overflow: hidden; margin-top: 3px; color: #d7e2ee; font-size: 10px; font-weight: 600; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
+.delta-v-route-timing strong { display: block; overflow: hidden; margin-top: 3px; color: var(--text-primary); font-size: 10px; font-weight: 600; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-route-window-actions { display: flex; min-width: 0; align-items: center; justify-content: flex-end; gap: 7px; }
 .delta-v-route-window-actions > span { color: var(--amber); font-size: 8px; letter-spacing: .04em; text-align: right; white-space: nowrap; }
-.delta-v-route-window-actions button { min-height: 29px; padding: 5px 9px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 9px var(--mono); letter-spacing: .04em; white-space: nowrap; }
+.delta-v-route-window-actions button { min-height: 29px; padding: 5px 9px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); letter-spacing: .04em; white-space: nowrap; }
 .delta-v-route-window-actions button:hover:not(:disabled), .delta-v-route-window-actions button:focus-visible { border-color: var(--cyan); background: #102633; }
 .delta-v-route-window-actions button:disabled { opacity: .4; cursor: not-allowed; }
-.delta-v-route-window-error { margin: 0; padding: 6px 13px; border-bottom: 1px solid rgba(201,104,91,.35); color: #e4a79f; background: rgba(201,104,91,.07); font-size: 9px; }
+.delta-v-route-window-error { margin: 0; padding: 6px 13px; border-bottom: 1px solid rgba(201,104,91,.35); color: var(--error-text); background: rgba(201,104,91,.07); font-size: 9px; }
 .delta-v-route-list { min-height: 0; flex: 1; overflow-x: hidden; overflow-y: auto; }
 .delta-v-leg { display: grid; grid-template-columns: 38px minmax(0,1fr) auto; align-items: center; gap: 11px; min-height: 66px; padding: 9px 13px 9px 8px; border-bottom: 1px solid var(--rule); }
 .delta-v-leg:last-child { border-bottom: 0; }
 .delta-v-leg-marker { position: relative; display: grid; align-self: stretch; place-items: center; }
-.delta-v-leg-marker span { position: relative; z-index: 1; display: grid; width: 31px; height: 31px; place-items: center; border: 1px solid #315166; border-radius: 50%; color: var(--cyan); background: #09131b; font-size: 9px; }
-.delta-v-leg-marker i { position: absolute; top: -10px; bottom: -10px; left: 50%; border-left: 1px dotted #315166; }
+.delta-v-leg-marker span { position: relative; z-index: 1; display: grid; width: 31px; height: 31px; place-items: center; border: 1px solid var(--accent-border); border-radius: 50%; color: var(--cyan); background: #09131b; font-size: 9px; }
+.delta-v-leg-marker i { position: absolute; top: -10px; bottom: -10px; left: 50%; border-left: 1px dotted var(--accent-border); }
 .delta-v-route-list > .delta-v-leg:first-child .delta-v-leg-marker i { top: 37px; }
 .delta-v-leg > div:nth-child(2) { min-width: 0; }
 .delta-v-leg > div:nth-child(2) strong, .delta-v-leg > div:nth-child(2) small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.delta-v-leg > div:nth-child(2) strong { color: #d7e2ee; font-size: 12px; }
+.delta-v-leg > div:nth-child(2) strong { color: var(--text-primary); font-size: 12px; }
 .delta-v-leg > div:nth-child(2) small { margin-top: 4px; color: var(--slate); font-size: 10px; }
 .delta-v-leg-options { display: flex; flex-wrap: wrap; gap: 4px 9px; margin-top: 6px; }
 .delta-v-leg-options label { display: inline-flex; align-items: center; gap: 5px; min-width: 0; color: #9eb9c2; font-size: 10px; line-height: 1.25; cursor: pointer; }
@@ -237,21 +237,21 @@
 .delta-v-landing-options { align-items: end; }
 .delta-v-leg-options .delta-v-inline-reserve { display: grid; grid-template-columns: minmax(115px,auto) 125px; align-items: center; gap: 7px; cursor: default; }
 .delta-v-inline-reserve > span { color: var(--slate); font-size: 10px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
-.delta-v-inline-reserve .resonant-input-unit input { width: 100%; min-height: 27px; padding: 4px 47px 4px 7px; border: 1px solid var(--rule-bright); color: #d7e2ee; background: #060c12; font: 9px var(--mono); }
+.delta-v-inline-reserve .resonant-input-unit input { width: 100%; min-height: 27px; padding: 4px 47px 4px 7px; border: 1px solid var(--rule-bright); color: var(--text-primary); background: #060c12; font: 9px var(--mono); }
 .delta-v-inline-reserve .resonant-input-unit > span { top: 7px; right: 29px; font-size: 9px; }
 .delta-v-leg:has(.delta-v-leg-options) { min-height: 72px; }
 .delta-v-leg.editing-stop { box-shadow: inset 2px 0 var(--amber); background: rgba(255,180,84,.035); }
 .delta-v-leg-side { display: grid; min-width: 90px; align-self: stretch; align-content: center; justify-items: end; gap: 5px; }
 .delta-v-leg-side > b { color: var(--cyan); font-size: 13px; text-align: right; white-space: nowrap; }
 .delta-v-route-stop-actions { display: flex; justify-content: flex-end; gap: 4px; }
-.delta-v-route-stop-actions button { min-height: 25px; padding: 2px 6px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 8px var(--mono); }
-.delta-v-route-stop-actions button:last-child { width: 25px; min-width: 25px; padding: 0; border-color: #573b43; color: #e4a79f; background: #120b0f; font-size: 13px; }
+.delta-v-route-stop-actions button { min-height: 25px; padding: 2px 6px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 8px var(--mono); }
+.delta-v-route-stop-actions button:last-child { width: 25px; min-width: 25px; padding: 0; border-color: #573b43; color: var(--error-text); background: #120b0f; font-size: 13px; }
 .delta-v-route-stop-actions button:hover, .delta-v-route-stop-actions button:focus-visible { border-color: currentColor; }
 .delta-v-leg-copy, .delta-v-leg-primary { min-width: 0; }
 .delta-v-leg-copy.with-stay,
 .delta-v-leg-copy.with-calculated-stay { display: grid; grid-template-columns: minmax(270px,.72fr) minmax(330px,1fr); align-items: center; gap: 18px; }
 .delta-v-leg-primary > strong, .delta-v-leg-primary > small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.delta-v-leg-primary > strong { color: #d7e2ee; font-size: 12px; }
+.delta-v-leg-primary > strong { color: var(--text-primary); font-size: 12px; }
 .delta-v-leg-primary > small { margin-top: 4px; color: var(--slate); font-size: 10px; }
 .delta-v-leg-primary > .delta-v-leg-note { line-height: 1.35; white-space: normal; }
 .delta-v-leg-advisories { display: flex; flex-wrap: wrap; align-items: center; gap: 4px 6px; margin-top: 4px; }
@@ -261,10 +261,10 @@
 .delta-v-leg-advisories > .delta-v-thermal-note { border: 1px solid rgba(255,180,84,.42); color: var(--amber); background: rgba(255,180,84,.07); }
 .delta-v-leg-advisories > .delta-v-thermal-note.not-detected { border-color: rgba(255,107,91,.48); color: #ff9b8f; background: rgba(255,107,91,.08); }
 .delta-v-leg-heading { display: flex; align-items: center; gap: 8px; }
-.delta-v-porkchop-button { min-height: 24px; flex: 0 0 auto; padding: 3px 6px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 9px var(--mono); letter-spacing: .06em; }
+.delta-v-porkchop-button { min-height: 24px; flex: 0 0 auto; padding: 3px 6px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); letter-spacing: .06em; }
 .delta-v-porkchop-button:hover, .delta-v-porkchop-button:focus-visible { border-color: var(--cyan); background: #102633; }
 .delta-v-leg-timeline { color: #9fcbd4 !important; }
-.delta-v-leg-timeline.conflict { color: #e4a79f !important; }
+.delta-v-leg-timeline.conflict { color: var(--error-text) !important; }
 .delta-v-leg.ascent .delta-v-leg-side > b, .delta-v-leg.deorbit .delta-v-leg-side > b, .delta-v-leg.landing .delta-v-leg-side > b { color: var(--amber); }
 .delta-v-leg.transfer .delta-v-leg-side > b { color: var(--slate); }
 .delta-v-leg.custom { background: rgba(255,180,84,.035); box-shadow: inset 2px 0 rgba(255,180,84,.55); }
@@ -275,35 +275,35 @@
 .delta-v-custom-actions .resonant-input-unit > span { top: 9px; right: 29px; font-size: 9px; }
 .delta-v-custom-actions button { width: 28px; height: 28px; border: 1px solid #6c3e3e; color: #e59898; background: #1c1010; cursor: pointer; font-size: 15px; }
 .delta-v-add-step { position: relative; z-index: 3; height: 0; }
-.delta-v-add-step::before { position: absolute; z-index: 1; top: -16px; bottom: -16px; left: 27px; border-left: 1px dotted #315166; content: ""; }
+.delta-v-add-step::before { position: absolute; z-index: 1; top: -16px; bottom: -16px; left: 27px; border-left: 1px dotted var(--accent-border); content: ""; }
 .delta-v-add-step button { position: absolute; z-index: 2; top: -11px; left: 16px; display: grid; width: 22px; min-width: 22px !important; height: 22px; min-height: 22px !important; padding: 0 0 1px; place-items: center; border: 1px solid #49677a; border-radius: 50%; color: var(--cyan); background: #0c1821; cursor: pointer; font: 15px/1 var(--mono); }
 .delta-v-add-step button:hover, .delta-v-add-step button:focus-visible { border-color: var(--cyan); color: #d8f8ff; background: #153143; }
 
 .delta-v-stay-control { display: grid; width: 100%; max-width: 420px; grid-template-columns: minmax(150px,auto) auto; align-items: center; gap: 8px; padding: 5px 7px; border: 1px solid rgba(78,201,224,.35); background: rgba(78,201,224,.045); }
 .delta-v-stay-control > span { color: #b9cbd7; font-size: 9px; font-weight: 700; }
 .delta-v-stay-control > div { display: flex; align-items: center; gap: 4px; }
-.delta-v-stay-control button { display: grid; width: 27px; height: 27px; padding: 0; place-items: center; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 13px var(--mono); }
+.delta-v-stay-control button { display: grid; width: 27px; height: 27px; padding: 0; place-items: center; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 13px var(--mono); }
 .delta-v-stay-control button:disabled { opacity: .35; cursor: default; }
 .delta-v-stay-control label { display: flex; align-items: center; gap: 5px; color: var(--slate); font-size: 9px; }
-.delta-v-stay-control input { width: 54px; min-height: 27px; padding: 3px 5px; border: 1px solid #294657; color: #d7e2ee; background: #0a141c; font: 9px var(--mono); text-align: right; }
+.delta-v-stay-control input { width: 54px; min-height: 27px; padding: 3px 5px; border: 1px solid #294657; color: var(--text-primary); background: #0a141c; font: 9px var(--mono); text-align: right; }
 .delta-v-calculated-stay { display: grid; width: 100%; max-width: 420px; min-height: 48px; align-content: center; gap: 3px; padding: 7px 10px; border: 1px solid rgba(255,180,84,.38); background: rgba(255,180,84,.045); }
 .delta-v-calculated-stay > span { color: var(--amber); font-size: 9px; font-weight: 700; letter-spacing: .08em; }
 .delta-v-calculated-stay > strong { color: #e3edf2; font-size: 13px; font-variant-numeric: tabular-nums; }
 .delta-v-calculated-stay > small { overflow: hidden; color: var(--slate); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.delta-v-timeline-conflict { margin: 0; padding: 7px 13px; border-bottom: 1px solid rgba(201,104,91,.35); color: #e4a79f; background: rgba(201,104,91,.07); font-size: 9px; }
+.delta-v-timeline-conflict { margin: 0; padding: 7px 13px; border-bottom: 1px solid rgba(201,104,91,.35); color: var(--error-text); background: rgba(201,104,91,.07); font-size: 9px; }
 
 .porkchop-modal-backdrop { position: fixed; z-index: 1100; inset: 0; display: grid; padding: 28px; place-items: center; background: rgba(2,6,9,.84); }
-.porkchop-modal { display: flex; width: min(900px,calc(100vw - 56px)); max-height: calc(100vh - 56px); min-height: 0; flex-direction: column; overflow: auto; border: 1px solid #315166; background: #070d13; box-shadow: 0 20px 60px rgba(0,0,0,.52); }
+.porkchop-modal { display: flex; width: min(900px,calc(100vw - 56px)); max-height: calc(100vh - 56px); min-height: 0; flex-direction: column; overflow: auto; border: 1px solid var(--accent-border); background: #070d13; box-shadow: 0 20px 60px rgba(0,0,0,.52); }
 .porkchop-modal > header { display: flex; flex: 0 0 auto; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 15px; border-bottom: 1px solid var(--rule); background: linear-gradient(90deg,rgba(78,201,224,.09),transparent); }
 .porkchop-modal > header div { display: grid; gap: 3px; }
 .porkchop-modal > header span { color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .14em; }
 .porkchop-modal > header h3 { margin: 0; color: #e1eaf0; font-size: 14px; }
-.porkchop-modal > header button { width: 29px; height: 29px; border: 1px solid #315166; color: var(--slate); background: #0a141c; cursor: pointer; font: 18px var(--mono); }
+.porkchop-modal > header button { width: 29px; height: 29px; border: 1px solid var(--accent-border); color: var(--slate); background: #0a141c; cursor: pointer; font: 18px var(--mono); }
 .porkchop-constraint { margin: 0; padding: 8px 15px; border-bottom: 1px solid var(--rule); color: #b9cbd7; background: rgba(255,180,84,.055); font-size: 9px; }
 .porkchop-empty { display: grid; min-height: 300px; padding: 30px; place-content: center; justify-items: center; gap: 9px; text-align: center; }
-.porkchop-empty strong { color: #d7e2ee; font-size: 13px; }
+.porkchop-empty strong { color: var(--text-primary); font-size: 13px; }
 .porkchop-empty small { max-width: 460px; color: var(--slate); font-size: 9px; }
-.porkchop-empty button, .porkchop-modal > footer button { min-height: 31px; padding: 6px 11px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 9px var(--mono); }
+.porkchop-empty button, .porkchop-modal > footer button { min-height: 31px; padding: 6px 11px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); }
 .porkchop-plot-shell { display: grid; min-height: 280px; flex: 1 1 420px; grid-template-columns: 24px minmax(0,1fr); grid-template-rows: minmax(240px,1fr) 22px; padding: 14px 16px 0 10px; }
 .porkchop-y-label, .porkchop-x-label { display: grid; place-items: center; color: var(--slate); font: 9px var(--mono); letter-spacing: .1em; }
 .porkchop-y-label { writing-mode: vertical-rl; transform: rotate(180deg); }
@@ -318,7 +318,7 @@
 .porkchop-hover-readout > strong, .porkchop-ideal-readout > strong { width: 100%; color: var(--cyan); font-size: 8px; letter-spacing: .1em; }
 .porkchop-ideal-readout { background: rgba(255,180,84,.04); }
 .porkchop-ideal-readout > strong { color: var(--amber); }
-.porkchop-hover-readout b, .porkchop-ideal-readout b { margin-left: 3px; color: #d7e2ee; }
+.porkchop-hover-readout b, .porkchop-ideal-readout b { margin-left: 3px; color: var(--text-primary); }
 .porkchop-filters { margin: 8px 16px 0; border: 1px solid #294657; background: #09131b; }
 .porkchop-filters > header { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 6px 9px; border-bottom: 1px solid var(--rule); }
 .porkchop-filters > header > div { display: flex; align-items: center; gap: 8px; }
@@ -331,7 +331,7 @@
 .porkchop-filter-grid > label, .porkchop-range-filter { display: grid; min-width: 0; gap: 4px; }
 .porkchop-filter-grid span { color: var(--slate); font-size: 8px; letter-spacing: .07em; }
 .porkchop-cost-filter > div { display: flex; align-items: center; gap: 5px; }
-.porkchop-cost-filter input { width: 82px; min-height: 27px; border: 1px solid #294657; color: #d7e2ee; background: #070d13; font: 9px var(--mono); text-align: right; }
+.porkchop-cost-filter input { width: 82px; min-height: 27px; border: 1px solid #294657; color: var(--text-primary); background: #070d13; font: 9px var(--mono); text-align: right; }
 .porkchop-cost-filter b { color: var(--slate); font: 8px var(--mono); }
 .porkchop-range-filter { grid-template-columns: repeat(2,minmax(0,1fr)); }
 .porkchop-range-filter > span { grid-column: 1 / -1; }
@@ -342,8 +342,8 @@
 .porkchop-evaluation > div { display: grid; gap: 4px; padding: 9px; border-right: 1px solid var(--rule); }
 .porkchop-evaluation > div:last-child { border-right: 0; }
 .porkchop-evaluation span { color: var(--slate); font-size: 9px; letter-spacing: .08em; }
-.porkchop-evaluation strong { color: #d7e2ee; font-size: 10px; }
-.porkchop-error { margin: 8px 16px 0; color: #e4a79f; font-size: 9px; }
+.porkchop-evaluation strong { color: var(--text-primary); font-size: 10px; }
+.porkchop-error { margin: 8px 16px 0; color: var(--error-text); font-size: 9px; }
 .porkchop-modal > footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; }
 .porkchop-modal > footer button:last-child { border-color: var(--cyan); color: #071015; background: var(--cyan); }
 .porkchop-modal button:disabled { opacity: .42; cursor: not-allowed; }
@@ -368,13 +368,13 @@
 .delta-v-save-slot .delta-v-save-bar { align-items: center; }
 .delta-v-save-slot .delta-v-save-bar label { display: grid; min-width: 0; grid-template-columns: auto minmax(0,1fr); align-items: center; gap: 7px; }
 .delta-v-save-slot .delta-v-save-bar label > span { white-space: nowrap; }
-.resonant-drawer > header .delta-v-reset-button { min-height: 28px; padding: 6px 9px; border: 1px solid #74552d; color: var(--amber); background: rgba(255,180,84,.06); font: 9px var(--mono); letter-spacing: .08em; }
+.resonant-drawer > header .delta-v-reset-button { min-height: 28px; padding: 6px 9px; border: 1px solid var(--amber-accent); color: var(--amber); background: rgba(255,180,84,.06); font: 9px var(--mono); letter-spacing: .08em; }
 .resonant-drawer > header .delta-v-reset-button:hover:not(:disabled), .resonant-drawer > header .delta-v-reset-button:focus-visible { border-color: var(--amber); background: rgba(255,180,84,.13); }
 .resonant-drawer > header .delta-v-reset-button:disabled { opacity: .35; cursor: not-allowed; }
-.resonant-drawer > header .delta-v-saved-plans-button { display: flex; min-height: 28px; align-items: center; gap: 7px; padding: 4px 6px 4px 9px; border: 1px solid #315166; color: var(--cyan); background: rgba(78,201,224,.05); font: 9px var(--mono); letter-spacing: .06em; }
+.resonant-drawer > header .delta-v-saved-plans-button { display: flex; min-height: 28px; align-items: center; gap: 7px; padding: 4px 6px 4px 9px; border: 1px solid var(--accent-border); color: var(--cyan); background: rgba(78,201,224,.05); font: 9px var(--mono); letter-spacing: .06em; }
 .resonant-drawer > header .delta-v-saved-plans-button:hover, .resonant-drawer > header .delta-v-saved-plans-button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.11); }
-.resonant-drawer > header .delta-v-saved-plans-button strong { display: grid; min-width: 19px; height: 18px; padding: 0 4px; place-items: center; border-left: 1px solid #315166; color: #d7e2ee; font-size: 9px; }
-.resonant-drawer > header .delta-v-assumptions-button { min-height: 28px; padding: 6px 9px; border: 1px solid #315166; color: var(--cyan); background: rgba(78,201,224,.05); font: 9px var(--mono); letter-spacing: .08em; }
+.resonant-drawer > header .delta-v-saved-plans-button strong { display: grid; min-width: 19px; height: 18px; padding: 0 4px; place-items: center; border-left: 1px solid var(--accent-border); color: var(--text-primary); font-size: 9px; }
+.resonant-drawer > header .delta-v-assumptions-button { min-height: 28px; padding: 6px 9px; border: 1px solid var(--accent-border); color: var(--cyan); background: rgba(78,201,224,.05); font: 9px var(--mono); letter-spacing: .08em; }
 .resonant-drawer > header .delta-v-assumptions-button:hover { border-color: var(--cyan); background: rgba(78,201,224,.11); }
 @media (min-width: 761px) {
   .resonant-drawer.delta-v-drawer > header {
@@ -394,9 +394,9 @@
   }
   .resonant-drawer > header .delta-v-save-bar button {
     padding: 5px 9px;
-    border: 1px solid #315166;
+    border: 1px solid var(--accent-border);
     color: var(--cyan);
-    background: #0b1821;
+    background: var(--control-surface);
     font: 12px var(--mono);
     white-space: nowrap;
   }
@@ -476,42 +476,42 @@
   }
 }
 .delta-v-modal-backdrop { position: absolute; z-index: 20; inset: 0; display: grid; padding: 20px; place-items: center; background: rgba(0,0,0,.72); }
-.delta-v-modal { width: min(620px,92%); max-height: min(640px,88vh); border: 1px solid var(--rule-bright); color: #d7e2ee; background: #081018; box-shadow: 0 20px 65px rgba(0,0,0,.7); }
+.delta-v-modal { width: min(620px,92%); max-height: min(640px,88vh); border: 1px solid var(--rule-bright); color: var(--text-primary); background: #081018; box-shadow: 0 20px 65px rgba(0,0,0,.7); }
 .delta-v-modal > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; padding: 14px 16px; border-bottom: 1px solid var(--rule); }
 .delta-v-modal > header span { color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .12em; }
 .delta-v-modal h3 { margin: 4px 0 0; color: var(--amber); font-size: 15px; text-transform: uppercase; }
-.delta-v-modal > header button { display: grid; width: 24px; min-width: 24px; height: 24px; padding: 0; place-items: center; border: 0; color: #d7e2ee; background: transparent; cursor: pointer; font-size: 21px; }
+.delta-v-modal > header button { display: grid; width: 24px; min-width: 24px; height: 24px; padding: 0; place-items: center; border: 0; color: var(--text-primary); background: transparent; cursor: pointer; font-size: 21px; }
 .delta-v-modal ul { display: grid; max-height: 470px; gap: 10px; margin: 0; padding: 16px 22px 18px 34px; overflow: auto; color: #a9bfca; font-size: 10px; line-height: 1.5; }
 .delta-v-reset-modal { width: min(520px,92%); }
 .delta-v-reset-modal > p { margin: 0; padding: 18px 16px; color: #a9bfca; font-size: 10px; line-height: 1.55; }
 .delta-v-reset-actions { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--rule); background: #080e15; }
-.delta-v-reset-actions button { min-height: 32px; padding: 7px 11px; border: 1px solid #315166; color: var(--cyan); background: rgba(78,201,224,.05); cursor: pointer; font: 9px var(--mono); letter-spacing: .06em; }
+.delta-v-reset-actions button { min-height: 32px; padding: 7px 11px; border: 1px solid var(--accent-border); color: var(--cyan); background: rgba(78,201,224,.05); cursor: pointer; font: 9px var(--mono); letter-spacing: .06em; }
 .delta-v-reset-actions button:hover, .delta-v-reset-actions button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.11); }
-.delta-v-reset-actions button:last-child { border-color: #74552d; color: var(--amber); background: rgba(255,180,84,.08); }
+.delta-v-reset-actions button:last-child { border-color: var(--amber-accent); color: var(--amber); background: rgba(255,180,84,.08); }
 .delta-v-reset-actions button:last-child:hover, .delta-v-reset-actions button:last-child:focus-visible { border-color: var(--amber); background: rgba(255,180,84,.16); }
 .delta-v-plan-library-modal { display: flex; width: min(720px,92%); min-height: 180px; flex-direction: column; overflow: hidden; }
 .delta-v-plan-library-header-actions { display: flex; flex: 0 0 auto; flex-direction: row-reverse; align-items: center; gap: 8px; }
 .delta-v-plan-library-header-actions label { position: relative; display: inline-flex; cursor: pointer; }
 .delta-v-plan-library-header-actions label input { position: absolute; width: 1px; height: 1px; opacity: 0; }
-.delta-v-plan-library-header-actions label span { display: inline-flex; min-height: 24px; align-items: center; padding: 3px 7px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; font-size: 8px; letter-spacing: .07em; }
+.delta-v-plan-library-header-actions label span { display: inline-flex; min-height: 24px; align-items: center; padding: 3px 7px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); font-size: 8px; letter-spacing: .07em; }
 .delta-v-plan-library-header-actions label input:checked + span { border-color: rgba(126,231,135,.48); color: var(--green); background: rgba(126,231,135,.07); }
 .delta-v-plan-library-header-actions label:focus-within span { outline: 1px solid var(--cyan); outline-offset: 2px; }
 .delta-v-plan-library-modal > p { margin: 0; padding: 10px 16px; border-bottom: 1px solid var(--rule); color: var(--slate); font-size: 9px; }
 .delta-v-plan-library-modal > .delta-v-plan-library-empty { display: grid; justify-items: center; gap: 10px; margin: 16px; padding: 28px 16px; text-align: center; }
-.delta-v-plan-library-empty button { min-height: 30px; padding: 5px 9px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 8px var(--mono); }
+.delta-v-plan-library-empty button { min-height: 30px; padding: 5px 9px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 8px var(--mono); }
 .delta-v-plan-library-modal > .delta-v-plan-library-list { min-height: 0; margin: 0; padding: 10px 12px 12px; overflow: auto; }
 .delta-v-plan-library-group { display: grid; gap: 4px; }
 .delta-v-plan-library-group + .delta-v-plan-library-group { margin-top: 8px; }
 .delta-v-plan-library-group-heading { display: flex; align-items: stretch; border-block: 1px solid var(--rule); background: rgba(255,180,84,.045); }
 .delta-v-plan-library-group-heading h4 { min-width: 0; margin: 0; padding: 5px 7px; color: var(--amber); font-size: 9px; letter-spacing: .09em; text-transform: uppercase; }
-.delta-v-plan-library-group-heading button { margin-left: auto; padding: 4px 8px; border: 0; border-left: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font: 8px var(--mono); }
+.delta-v-plan-library-group-heading button { margin-left: auto; padding: 4px 8px; border: 0; border-left: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 8px var(--mono); }
 .resonant-drawer > footer.delta-v-footer { color: var(--slate); }
 .resonant-drawer > footer.delta-v-footer strong { color: var(--cyan); font-size: 9px; letter-spacing: .08em; }
 
-.panel-restore-rail .panel-rail-button-flightOrbitPlan { margin-top: 4px; border-color: #74552d; color: var(--amber); background: #211a12; }
-.panel-restore-rail .panel-rail-button-flightDeltaVPlan, .panel-restore-rail .panel-rail-button-editorDeltaVPlan { margin-top: 4px; border-color: #315166; color: var(--cyan); background: #101c27; }
-.resonant-unpin { padding: 3px 6px; border: 1px solid #74552d; color: var(--amber); background: #1d1710; cursor: pointer; font-size: 9px; text-transform: uppercase; }
-.resonant-edit-plan { padding: 3px 7px; border: 1px solid #315166; color: var(--cyan); background: #0b1821; cursor: pointer; font-size: 9px; text-transform: uppercase; }
+.panel-restore-rail .panel-rail-button-flightOrbitPlan { margin-top: 4px; border-color: var(--amber-accent); color: var(--amber); background: #211a12; }
+.panel-restore-rail .panel-rail-button-flightDeltaVPlan, .panel-restore-rail .panel-rail-button-editorDeltaVPlan { margin-top: 4px; border-color: var(--accent-border); color: var(--cyan); background: #101c27; }
+.resonant-unpin { padding: 3px 6px; border: 1px solid var(--amber-accent); color: var(--amber); background: #1d1710; cursor: pointer; font-size: 9px; text-transform: uppercase; }
+.resonant-edit-plan { padding: 3px 7px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font-size: 9px; text-transform: uppercase; }
 .resonant-editor-plan { display: grid; grid-template-columns: minmax(174px,.85fr) minmax(0,1.55fr); gap: 7px; }
 .resonant-editor-constellation, .resonant-editor-plan-details { min-width: 0; border: 1px solid var(--rule); background: #090f17; }
 .resonant-editor-constellation { position: relative; min-height: 164px; padding: 4px; }
@@ -524,7 +524,7 @@
 .resonant-editor-satellite.release { fill: var(--green); }
 .resonant-editor-satellite-count { position: absolute; left: 9px; bottom: 8px; display: flex; align-items: baseline; gap: 7px; }
 .resonant-editor-satellite-count strong { color: var(--cyan); font-size: 23px; line-height: 1; }
-.resonant-editor-satellite-count span { color: #d7e2ee; font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.resonant-editor-satellite-count span { color: var(--text-primary); font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
 .resonant-editor-plan-details { display: flex; flex-direction: column; }
 .resonant-editor-plan-details > header { display: flex; min-width: 0; padding: 7px 8px; align-items: baseline; justify-content: space-between; gap: 10px; border-bottom: 1px solid var(--rule); }
 .resonant-editor-plan-details > header strong { display: block; overflow: hidden; color: var(--amber); font-size: 12px; letter-spacing: .06em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
@@ -554,7 +554,7 @@
 .resonant-orbit-target-status.in-range { border-color: rgba(126,231,135,.5); color: var(--green); background: rgba(126,231,135,.09); }
 .resonant-flight-guidance { display: grid; grid-template-columns: 30px 1fr; gap: 8px; margin-top: 8px; padding: 9px; border-left: 2px solid var(--amber); background: rgba(255,180,84,.06); }
 .resonant-flight-guidance > span { color: var(--amber); font-size: 16px; }
-.resonant-flight-guidance strong { color: #d7e2ee; font-size: 9px; text-transform: uppercase; }
+.resonant-flight-guidance strong { color: var(--text-primary); font-size: 9px; text-transform: uppercase; }
 .resonant-flight-guidance p { margin: 4px 0 0; color: var(--slate); font-size: 9px; line-height: 1.45; }
 .resonant-editor-guidance { grid-template-columns: max-content minmax(0,1fr); gap: 10px; }
 .resonant-editor-guidance > span { padding-top: 1px; font-size: 12px; font-weight: 700; letter-spacing: .04em; white-space: nowrap; }
@@ -562,7 +562,7 @@
 .resonant-editor-guidance .resonant-deployment-actions button { width: auto; text-transform: uppercase; }
 .resonant-deployment { margin-top: 8px; padding: 9px; border: 1px solid var(--rule); }
 .resonant-deployment > div:first-child { display: flex; justify-content: space-between; color: var(--slate); font-size: 9px; }
-.resonant-deployment > div:first-child strong { color: #d7e2ee; }
+.resonant-deployment > div:first-child strong { color: var(--text-primary); }
 .resonant-progress { height: 4px; margin-top: 7px; background: #17212d; }
 .resonant-progress span { display: block; height: 100%; background: var(--green); transition: width .18s ease; }
 .resonant-deployment-actions { display: flex; gap: 5px; margin-top: 7px; }
@@ -571,7 +571,7 @@
 .resonant-deployment-actions button:last-child { flex: 1; }
 .resonant-deployment-actions button:disabled { opacity: .45; cursor: not-allowed; }
 .delta-v-pinned-identity { display: flex; min-width: 0; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 7px; }
-.delta-v-pinned-identity strong { overflow: hidden; color: #d7e2ee; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.delta-v-pinned-identity strong { overflow: hidden; color: var(--text-primary); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-pinned-identity span { flex: 0 1 auto; color: var(--slate); font-size: 9px; text-align: right; }
 .delta-v-pinned-identity.editor { min-height: 29px; margin-bottom: 7px; padding: 6px 8px; border: 1px solid var(--rule); background: #090f17; }
 .delta-v-pinned-identity.editor strong { color: var(--amber); font-size: 12px; letter-spacing: .04em; text-transform: uppercase; }
@@ -612,7 +612,7 @@
 .delta-v-editor-coverage.unavailable > header strong, .delta-v-editor-coverage.unavailable > footer { color: var(--amber); }
 .delta-v-pinned-progress { display: flex; min-width: 0; margin-top: 7px; padding: 6px 8px; align-items: center; justify-content: space-between; gap: 8px; border: 1px solid var(--rule); background: #090f17; }
 .delta-v-pinned-progress > span { color: var(--slate); font-size: 8px; letter-spacing: .04em; text-transform: uppercase; }
-.delta-v-pinned-progress strong { color: #d7e2ee; font-size: 9px; white-space: nowrap; }
+.delta-v-pinned-progress strong { color: var(--text-primary); font-size: 9px; white-space: nowrap; }
 .delta-v-pinned-progress button { min-width: 58px; padding: 5px 7px; border: 1px solid var(--rule-bright); color: var(--slate); background: #0c141e; cursor: pointer; font: 8px var(--mono); text-transform: uppercase; }
 .delta-v-pinned-comparison { display: flex; min-width: 0; flex-direction: column; padding: 7px 8px; border: 1px solid var(--rule-bright); background: rgba(78,201,224,.04); }
 .delta-v-pinned-comparison header { display: flex; justify-content: space-between; gap: 8px; color: var(--slate); font-size: 8px; letter-spacing: .07em; }
@@ -628,7 +628,7 @@
 .delta-v-pinned-comparison.unavailable { border-color: rgba(255,180,84,.35); }
 .delta-v-pinned-comparison.unavailable header strong { color: var(--amber); }
 .delta-v-pinned-window { margin-top: 7px; padding: 8px; border-left: 2px solid var(--cyan); background: rgba(78,201,224,.055); }
-.delta-v-pinned-window strong { color: #d7e2ee; font-size: 10px; }
+.delta-v-pinned-window strong { color: var(--text-primary); font-size: 10px; }
 .delta-v-pinned-window small { display: block; margin-top: 4px; color: var(--slate); font-size: 9px; }
 .delta-v-launch-target { margin-top: 7px; padding: 8px; border: 1px solid rgba(78,201,224,.34); border-left: 2px solid var(--cyan); background: rgba(78,201,224,.045); }
 .delta-v-launch-target > header { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--slate); font-size: 8px; letter-spacing: .07em; }
@@ -637,7 +637,7 @@
 .delta-v-launch-target-grid > div { min-width: 0; padding: 6px 7px; border: 1px solid var(--rule); background: #090f17; }
 .delta-v-launch-target-grid span, .delta-v-launch-target-grid b, .delta-v-launch-target-grid small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-launch-target-grid span { margin-bottom: 3px; color: var(--slate); font-size: 8px; letter-spacing: .05em; text-transform: uppercase; }
-.delta-v-launch-target-grid b { color: #d7e2ee; font-size: 9px; }
+.delta-v-launch-target-grid b { color: var(--text-primary); font-size: 9px; }
 .delta-v-launch-target-grid small { margin-top: 3px; color: var(--slate); font-size: 8px; }
 .delta-v-progress-suggestion { display: flex; margin-top: 7px; padding: 9px; align-items: center; justify-content: space-between; gap: 10px; border: 1px solid rgba(255,180,84,.48); border-left: 3px solid var(--amber); background: rgba(255,180,84,.07); }
 .delta-v-progress-suggestion > div { min-width: 0; }
@@ -663,7 +663,7 @@
 .delta-v-readiness-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 5px; margin-top: 7px; }
 .delta-v-readiness-grid > div { min-width: 0; padding: 6px 7px; border: 1px solid var(--rule); background: #090f17; }
 .delta-v-readiness-grid span, .delta-v-maneuver-preview span { display: block; margin-bottom: 3px; color: var(--slate); font-size: 8px; letter-spacing: .05em; text-transform: uppercase; }
-.delta-v-readiness-grid b { display: block; overflow: hidden; color: #d7e2ee; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.delta-v-readiness-grid b { display: block; overflow: hidden; color: var(--text-primary); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-readiness-body > p { margin: 6px 0 0; color: var(--slate); font-size: 8px; line-height: 1.35; }
 .delta-v-maneuver-preview { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 5px; margin-top: 7px; }
 .delta-v-maneuver-preview > div { padding: 7px; border: 1px solid rgba(78,201,224,.28); background: rgba(9,15,23,.85); }
@@ -676,19 +676,19 @@
 .delta-v-readiness-issues.blockers li::before { color: #ff9b8f; }
 .delta-v-maneuver-error { color: #ff9b8f !important; }
 .delta-v-maneuver-actions { display: flex; min-height: 28px; margin-top: 7px; }
-.delta-v-maneuver-actions button { flex: 1; min-height: 28px; padding: 5px 8px; border: 1px solid #315166; color: var(--cyan); background: #0a131d; cursor: pointer; font: 8px var(--mono); letter-spacing: .04em; text-transform: uppercase; }
+.delta-v-maneuver-actions button { flex: 1; min-height: 28px; padding: 5px 8px; border: 1px solid var(--accent-border); color: var(--cyan); background: #0a131d; cursor: pointer; font: 8px var(--mono); letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-maneuver-actions button:hover:not(:disabled), .delta-v-maneuver-actions button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.08); }
 .delta-v-maneuver-actions button:disabled { opacity: .42; cursor: not-allowed; }
 .delta-v-maneuver-actions > span { padding: 6px 0; color: var(--green); font-size: 8px; line-height: 1.35; }
 .delta-v-pinned-route-toggle { display: flex; min-height: 30px; margin-top: 7px; padding: 4px 5px 4px 8px; align-items: center; justify-content: space-between; gap: 8px; border: 1px solid var(--rule); background: rgba(9,15,23,.65); }
 .delta-v-pinned-route-toggle > span { color: var(--slate); font-size: 8px; letter-spacing: .05em; text-transform: uppercase; }
-.delta-v-pinned-route-toggle > button { min-height: 26px; padding: 4px 8px; border: 1px solid #315166; color: var(--cyan); background: #0a131d; cursor: pointer; font: 8px var(--mono); letter-spacing: .04em; text-transform: uppercase; }
+.delta-v-pinned-route-toggle > button { min-height: 26px; padding: 4px 8px; border: 1px solid var(--accent-border); color: var(--cyan); background: #0a131d; cursor: pointer; font: 8px var(--mono); letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-pinned-route-toggle > button:hover, .delta-v-pinned-route-toggle > button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.08); }
 .delta-v-editor-route-heading { display: flex; min-height: 26px; margin-top: 7px; padding: 5px 7px; align-items: center; gap: 8px; border: 1px solid var(--rule); background: rgba(9,15,23,.65); }
 .delta-v-editor-route-heading > span { min-width: 0; overflow: hidden; color: var(--slate); font-size: 9px; letter-spacing: .06em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
-.delta-v-editor-route-heading > span b { color: #d7e2ee; font-weight: 600; }
+.delta-v-editor-route-heading > span b { color: var(--text-primary); font-weight: 600; }
 .delta-v-editor-route-heading > strong { margin-left: auto; color: var(--cyan); font-size: 11px; white-space: nowrap; }
-.delta-v-editor-route-heading > button { min-height: 22px; padding: 2px 6px; border: 1px solid #315166; color: var(--cyan); background: #0a131d; cursor: pointer; font: 8px var(--mono); text-transform: uppercase; }
+.delta-v-editor-route-heading > button { min-height: 22px; padding: 2px 6px; border: 1px solid var(--accent-border); color: var(--cyan); background: #0a131d; cursor: pointer; font: 8px var(--mono); text-transform: uppercase; }
 .delta-v-pinned-route { display: grid; gap: 3px; margin-top: 7px; }
 .delta-v-pinned-route > div { display: grid; min-width: 0; gap: 6px; padding: 5px 6px; align-items: center; border: 1px solid var(--rule); background: rgba(9,15,23,.8); }
 .delta-v-pinned-route.flight > div { grid-template-columns: 28px 21px minmax(0,1fr) auto; }
@@ -697,19 +697,19 @@
 .delta-v-pinned-route.editor.expanded { max-height: 204px; overflow-y: auto; overscroll-behavior: contain; scrollbar-gutter: stable; }
 .delta-v-pinned-route.editor > div { min-height: 31px; padding: 5px 7px; grid-template-columns: 25px minmax(0,1fr) auto; border: 0; border-bottom: 1px solid var(--rule); background: transparent; }
 .delta-v-pinned-route.editor > div:last-child { border-bottom: 0; }
-.delta-v-pinned-route.editor .delta-v-pinned-step-number { position: relative; z-index: 0; display: grid; width: 19px; height: 19px; place-items: center; border: 1px solid #315166; border-radius: 50%; color: var(--cyan); background: #0a131d; }
-.delta-v-pinned-route.editor > div:not(:last-child) .delta-v-pinned-step-number::after { position: absolute; top: 18px; left: 8px; z-index: -1; width: 1px; height: 13px; background: #315166; content: ""; }
+.delta-v-pinned-route.editor .delta-v-pinned-step-number { position: relative; z-index: 0; display: grid; width: 19px; height: 19px; place-items: center; border: 1px solid var(--accent-border); border-radius: 50%; color: var(--cyan); background: #0a131d; }
+.delta-v-pinned-route.editor > div:not(:last-child) .delta-v-pinned-step-number::after { position: absolute; top: 18px; left: 8px; z-index: -1; width: 1px; height: 13px; background: var(--accent-border); content: ""; }
 .delta-v-pinned-route.editor .delta-v-pinned-step-copy > strong { font-size: 11px; }
 .delta-v-pinned-route.editor > div > b { font-size: 11px; }
 .delta-v-pinned-route.editor > div > b.assisted { padding: 2px 5px; border: 1px solid rgba(255,180,84,.42); color: var(--amber); background: rgba(255,180,84,.06); font-size: 8px; letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-editor-route-omitted { display: flex; min-height: 29px; padding: 5px 8px 5px 33px; align-items: center; justify-content: space-between; gap: 8px; border: 0; border-bottom: 1px solid var(--rule); color: var(--slate); background: rgba(78,201,224,.035); cursor: pointer; font: 8px var(--mono); letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-editor-route-omitted span { color: var(--cyan); }
-.delta-v-pinned-check { display: grid; width: 28px; height: 28px; padding: 0; place-items: center; border: 1px solid #315166; color: transparent; background: #0a131d; cursor: pointer; }
+.delta-v-pinned-check { display: grid; width: 28px; height: 28px; padding: 0; place-items: center; border: 1px solid var(--accent-border); color: transparent; background: #0a131d; cursor: pointer; }
 .delta-v-pinned-check:hover, .delta-v-pinned-check:focus-visible { border-color: var(--green); color: var(--green); background: rgba(126,231,135,.07); }
 .delta-v-pinned-check span { color: inherit !important; font-size: 11px !important; }
 .delta-v-pinned-step-number { color: var(--slate); font-size: 8px; }
 .delta-v-pinned-step-copy { min-width: 0; }
-.delta-v-pinned-step-copy > strong { display: block; overflow: hidden; color: #d7e2ee; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.delta-v-pinned-step-copy > strong { display: block; overflow: hidden; color: var(--text-primary); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-pinned-step-copy > small { display: flex; min-width: 0; gap: 6px; margin-top: 3px; color: var(--slate); font-size: 8px; }
 .delta-v-pinned-step-copy > small span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-pinned-step-copy > small b { flex: 0 0 auto; color: var(--amber); font-size: 8px; }
@@ -1431,7 +1431,7 @@
 .resonant-orbit-drawer > header .resonant-close-button,
 .resonant-orbit-drawer > header .resonant-header-save-bar button {
   min-height: 34px;
-  border: 1px solid #315166;
+  border: 1px solid var(--accent-border);
   color: var(--cyan);
   background: rgba(78,201,224,.05);
   cursor: pointer;
@@ -1450,8 +1450,8 @@
   height: 20px;
   padding-left: 7px;
   place-items: center;
-  border-left: 1px solid #315166;
-  color: #d7e2ee;
+  border-left: 1px solid var(--accent-border);
+  color: var(--text-primary);
   font-size: 10px;
 }
 .resonant-orbit-drawer > header .resonant-close-button {
@@ -1461,7 +1461,7 @@
   height: 34px;
   padding: 0;
   place-items: center;
-  color: #d7e2ee;
+  color: var(--text-primary);
   background: transparent;
   font-size: 19px;
 }
@@ -1502,7 +1502,7 @@
   padding: 6px 8px;
   border: 1px solid var(--rule-bright);
   outline: 0;
-  color: #d7e2ee;
+  color: var(--text-primary);
   background: #060c12;
   font: 12px var(--mono);
 }

--- a/frontend/src/resonantOrbit/resonantOrbit.css
+++ b/frontend/src/resonantOrbit/resonantOrbit.css
@@ -4,7 +4,7 @@
 .delta-v-rail-tab:hover, .delta-v-rail-tab[aria-expanded="true"] { border-color: var(--amber-dim); color: #ffd498; background: #2b2115; }
 .delta-v-rail-icon { display: flex; width: 29px; height: 28px; align-items: center; justify-content: center; flex: 0 0 29px; flex-direction: column; line-height: 1; text-transform: none; }
 .delta-v-rail-icon b { font: 700 12px var(--mono); letter-spacing: -.08em; }
-.delta-v-rail-icon small { margin-top: 3px; color: var(--amber-dim); font: 700 6px var(--mono); letter-spacing: .12em; }
+.delta-v-rail-icon small { margin-top: 3px; color: var(--amber-dim); font: 700 8px var(--mono); letter-spacing: .12em; }
 .delta-v-rail-tab:hover .delta-v-rail-icon small, .delta-v-rail-tab[aria-expanded="true"] .delta-v-rail-icon small { color: currentColor; }
 .resonant-rail-icon { position: relative; display: block; width: 29px; height: 24px; flex: 0 0 29px; }
 .resonant-rail-icon::before, .resonant-rail-icon::after { position: absolute; box-sizing: border-box; border-radius: 50%; content: ""; transform: rotate(-16deg); }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -10,6 +10,7 @@
   --slate: #7d8ba0;
   --slate-dim: #4a5568;
   --slate-muted-text: #748197;
+  --text-primary: #d7e2ee;
   --green: #7ee787;
   --warn: #ff6b5b;
   --danger: #f87171;
@@ -414,7 +415,7 @@ button { font: inherit; }
 .editor-overview .label { font-size: 9px; }
 .editor-craft { overflow: hidden; margin: 0; color: var(--cyan); font-size: 18px; font-weight: 500; letter-spacing: .03em; line-height: 1.15; text-overflow: ellipsis; white-space: nowrap; }
 .editor-craft-meta, .editor-overview-metric small { overflow: hidden; color: var(--slate); font-size: 10px; font-weight: 500; letter-spacing: .025em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
-.editor-overview-metric strong { overflow: hidden; color: var(--slate-bright); font-size: 18px; font-weight: 500; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
+.editor-overview-metric strong { overflow: hidden; color: var(--text-primary); font-size: 18px; font-weight: 500; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .editor-overview-metric.cost strong { color: var(--amber); }
 .editor-sim-conditions { display: grid; min-width: 0; min-height: 38px; padding: 5px 10px; align-items: center; grid-template-columns: auto auto auto auto auto minmax(210px,1fr) auto; gap: 7px 10px; }
 .editor-sim-title { color: var(--slate); font-size: 9px; font-weight: 600; letter-spacing: .14em; text-transform: uppercase; white-space: nowrap; }
@@ -969,7 +970,7 @@ button { font: inherit; }
   padding: 5px 12px;
   border: 1px solid transparent;
   border-radius: 3px;
-  color: var(--muted);
+  color: var(--slate-muted-text);
   background: transparent;
   cursor: pointer;
   font: inherit;
@@ -989,7 +990,7 @@ button { font: inherit; }
   padding: 24px;
   place-items: center;
   border: 1px dashed #315166;
-  color: var(--muted);
+  color: var(--slate-muted-text);
   background: #0a1119;
   text-align: center;
 }
@@ -1087,10 +1088,10 @@ button { font: inherit; }
   }
 }
 .project-footer { align-items: center; display: flex; flex-wrap: wrap; justify-content: space-between; gap: 4px 16px; max-width: 1180px; margin: 12px auto 2px; padding: 10px 4px 2px; border-top: 1px solid var(--rule); color: var(--slate-dim); font-size: 9px; letter-spacing: .08em; text-align: center; text-transform: uppercase; }
-.planner-persistence-status { color: var(--muted); white-space: nowrap; }
+.planner-persistence-status { color: var(--slate-muted-text); white-space: nowrap; }
 .planner-persistence-status.is-shared { color: var(--green); }
 .planner-persistence-status.is-syncing { color: var(--cyan); }
-.planner-persistence-status.is-error { color: var(--red); }
+.planner-persistence-status.is-error { color: var(--danger); }
 
 /* Datalink, clocks, and comms. */
 .led, .led2 { display: inline-block; width: 9px; height: 9px; border-radius: 50%; background: #333; flex: 0 0 auto; }
@@ -1367,7 +1368,7 @@ button { font: inherit; }
 .heat-loop-control:disabled { cursor: default; opacity: .62; }
 .heat-loop-control.pending { cursor: wait; }
 .heat-command-result { margin-top: 7px; padding: 6px 9px; border: 1px solid var(--rule); border-radius: 3px; color: var(--green); background: var(--panel-2); font-size: 9px; line-height: 1.4; }
-.heat-command-result.error { color: #f87171; }
+.heat-command-result.error { color: var(--danger); }
 .heat-component-list { padding: 0 10px 7px 39px; }
 .heat-component-row { display: grid; min-height: 21px; padding: 3px 0; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 10px; border-top: 1px solid var(--rule); color: #a9bfd3; font-size: 9px; }
 .heat-component-copy { display: flex; min-width: 0; align-items: baseline; gap: 7px; }
@@ -1438,7 +1439,7 @@ button { font: inherit; }
 .rx-detail-back > span:first-child { color: var(--cyan); font-size: 17px; line-height: 1; }
 .rx-detail-back > span:last-child { color: var(--slate-dim); }
 .rx-detail-back:hover, .rx-detail-back:focus-visible { color: var(--cyan); background: #12202c; outline: none; }
-.rx-detail-view.warn .rx-detail-back { color: #f87171; }
+.rx-detail-view.warn .rx-detail-back { color: var(--danger); }
 .rx-scroll { min-height: 0; padding: 7px; overflow-y: auto; border-top: 1px solid var(--rule); outline: 0; overscroll-behavior: contain; scrollbar-gutter: stable; }
 .rx-scroll:focus-visible { box-shadow: inset 0 0 0 1px var(--cyan); }
 .rx-list { display: flex; flex-direction: column; gap: 6px; }
@@ -1458,7 +1459,7 @@ button { font: inherit; }
 .rx-charge-track { height: 5px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: #05080c; }
 .rx-charge-fill { display: block; height: 100%; background: var(--amber); }
 .rx-command-result { padding: 6px 9px; border-top: 1px solid var(--rule); color: var(--green); font-size: 9px; line-height: 1.4; }
-.rx-command-result.error { color: #f87171; }
+.rx-command-result.error { color: var(--danger); }
 .rx-stats { display: grid; margin-top: 6px; grid-template-columns: 1fr 1fr; gap: 2px 12px; }
 .rx-stat { display: flex; min-width: 0; justify-content: space-between; gap: 8px; font-size: 10px; }
 .rx-stat label { color: var(--slate-dim); }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -4,18 +4,28 @@
   --panel-2: #0b1019;
   --rule: #1c2735;
   --rule-bright: #2a3a4e;
+  --accent-border: #315166;
+  --accent-border-hover: #3a6f86;
   --amber: #ffb454;
   --amber-dim: #a9762f;
+  --amber-accent: #74552d;
   --cyan: #4ec9e0;
   --slate: #7d8ba0;
   --slate-dim: #4a5568;
   --slate-muted-text: #748197;
   --text-primary: #d7e2ee;
+  --text-value: #cad4df;
   --green: #7ee787;
+  --success-border: #315d3a;
   --warn: #ff6b5b;
   --danger: #f87171;
+  --error-text: #e4a79f;
+  --error-text-muted: #d7a29c;
   --sky: #2f5c94;
   --ground: #5a3d24;
+  --control-surface: #0b1821;
+  --control-surface-hover: #12202c;
+  --instrument-surface: #05080c;
   --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
   color-scheme: dark;
   color: var(--amber);
@@ -105,7 +115,7 @@ button { font: inherit; }
 .dev-drawer input { width: 100%; padding: 7px 8px; border: 1px solid #4a5561; border-radius: 3px; outline: 0; color: #e2e7ed; background: #11151a; font: 11px var(--mono); }
 .dev-drawer input:focus { border-color: #7ca5b0; box-shadow: 0 0 0 2px rgba(184, 217, 226, .12); }
 .dev-connection-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 5px; }
-.dev-disconnect-button { color: #d7a29c; }
+.dev-disconnect-button { color: var(--error-text-muted); }
 .dev-connect-button:hover, .dev-disconnect-button:hover:not(:disabled), .dev-source-picker button:hover { border-color: #748392; color: #fff; }
 .dev-disconnect-button:disabled { cursor: not-allowed; opacity: .4; }
 .dev-drawer > footer { display: flex; padding: 9px 12px; color: #aeb8c4; font-size: 10px; flex-direction: column; gap: 7px; }
@@ -226,7 +236,7 @@ button { font: inherit; }
   font: 17px/14px var(--mono);
   letter-spacing: 0;
 }
-.panel-hide-button:hover { border-color: #3a6f86; color: var(--cyan); background: #12202c; }
+.panel-hide-button:hover { border-color: var(--accent-border-hover); color: var(--cyan); background: var(--control-surface-hover); }
 .panel-collapse-button {
   display: inline-grid;
   width: 22px;
@@ -236,19 +246,19 @@ button { font: inherit; }
   padding: 0;
   place-items: center;
   flex: 0 0 22px;
-  border: 1px solid #315166;
+  border: 1px solid var(--accent-border);
   border-radius: 2px;
   color: var(--cyan);
-  background: #0b1821;
+  background: var(--control-surface);
   cursor: pointer;
   font: 9px/1 var(--mono);
   letter-spacing: .06em;
 }
-.panel-collapse-button:hover { border-color: #3a6f86; background: #12202c; }
+.panel-collapse-button:hover { border-color: var(--accent-border-hover); background: var(--control-surface-hover); }
 .panel-collapse-chevron { display: block; width: 7px; height: 7px; border-right: 1px solid currentColor; border-bottom: 1px solid currentColor; transform: rotate(45deg); transform-origin: center; }
 .panel-collapsed .panel-collapse-chevron { transform: rotate(135deg); }
 .panel-collapsed > h2 { border-bottom: 0; }
-.datalink-rail-tab:hover { border-color: #3a6f86; color: var(--cyan); background: #152332; }
+.datalink-rail-tab:hover { border-color: var(--accent-border-hover); color: var(--cyan); background: #152332; }
 .dashboard-rail {
   --dashboard-rail-expanded-width: 218px;
   position: fixed;
@@ -292,7 +302,7 @@ button { font: inherit; }
   height: 1px;
   min-width: 5px;
   flex: 1 1 auto;
-  background: #74552d;
+  background: var(--amber-accent);
   content: "";
 }
 .dashboard-rail-section-label span { padding: 0 2px; }
@@ -318,12 +328,12 @@ button { font: inherit; }
   width: var(--dashboard-rail-expanded-width);
 }
 .notes-rail-tab {
-  border: 1px solid #315166;
+  border: 1px solid var(--accent-border);
   border-left: 0;
   color: var(--cyan);
   background: #101c27;
 }
-.notes-rail-tab:hover, .notes-rail-tab[aria-expanded="true"] { border-color: #3a6f86; color: #b8f2fc; background: #152b3a; }
+.notes-rail-tab:hover, .notes-rail-tab[aria-expanded="true"] { border-color: var(--accent-border-hover); color: #b8f2fc; background: #152b3a; }
 .panel-rail-button {
   display: flex;
   box-sizing: border-box;
@@ -372,10 +382,10 @@ button { font: inherit; }
   opacity: 1;
   transform: translateX(0);
 }
-.notes-rail-tab.panel-rail-button { border-color: #315166; color: var(--cyan); background: #101c27; }
+.notes-rail-tab.panel-rail-button { border-color: var(--accent-border); color: var(--cyan); background: #101c27; }
 .dashboard-rail .panel-rail-button,
 .dashboard-rail .notes-rail-tab.panel-rail-button {
-  border-color: #74552d;
+  border-color: var(--amber-accent);
   color: var(--amber);
   background: #211a12;
 }
@@ -390,8 +400,8 @@ button { font: inherit; }
 .dashboard-rail .resonant-rail-icon i {
   box-shadow: 0 0 6px currentColor, 11px -4px 0 -1px var(--amber-dim), 11px -4px 4px -1px var(--amber-dim);
 }
-.panel-restore-rail .panel-rail-button:hover { border-color: #3a6f86; color: var(--cyan); background: #152332; }
-.panel-restore-rail .panel-rail-button-flightNote { margin-top: 4px; border-color: #315166; color: var(--cyan); background: #101c27; }
+.panel-restore-rail .panel-rail-button:hover { border-color: var(--accent-border-hover); color: var(--cyan); background: #152332; }
+.panel-restore-rail .panel-rail-button-flightNote { margin-top: 4px; border-color: var(--accent-border); color: var(--cyan); background: #101c27; }
 .panel-rail-icon { display: block; width: 28px; height: 28px; overflow: visible; flex: 0 0 28px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
 .panel-rail-icon .rail-icon-detail { stroke-width: 1.2; }
 .panel-rail-icon .rail-icon-fill { fill: currentColor; stroke: none; opacity: .75; }
@@ -431,7 +441,7 @@ button { font: inherit; }
 .editor-altitude-presets { display: flex; min-width: 0; gap: 4px; }
 .editor-altitude-presets button, .editor-recalculate { height: 28px; min-height: 28px; padding: 3px 8px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate); background: #09111a; cursor: pointer; font: 8px var(--mono); letter-spacing: .08em; text-transform: uppercase; white-space: nowrap; }
 .editor-altitude-presets button[aria-pressed="true"] { border-color: #225f75; color: var(--cyan); background: #102b39; }
-.editor-altitude-presets button:hover:not(:disabled), .editor-recalculate:hover:not(:disabled) { border-color: #3a6f86; color: var(--cyan); background: #173040; }
+.editor-altitude-presets button:hover:not(:disabled), .editor-recalculate:hover:not(:disabled) { border-color: var(--accent-border-hover); color: var(--cyan); background: #173040; }
 .editor-altitude-presets button:disabled, .editor-recalculate:disabled { cursor: not-allowed; opacity: .45; }
 .editor-sim-feedback { display: flex; min-width: 0; align-items: flex-end; justify-content: center; flex-direction: column; gap: 2px; overflow: hidden; }
 .editor-sim-feedback .editor-state { font-size: 9px; }
@@ -440,7 +450,7 @@ button { font: inherit; }
 .editor-state.ok { color: var(--green); }
 .editor-state.bad { color: var(--warn); }
 .editor-recalculation-note { overflow: hidden; color: var(--slate); font-size: 9px; font-weight: 500; letter-spacing: .015em; text-overflow: ellipsis; white-space: nowrap; }
-.editor-recalculate { border-color: #24485a; color: var(--cyan); background: #12202c; }
+.editor-recalculate { border-color: #24485a; color: var(--cyan); background: var(--control-surface-hover); }
 #editorSummary .body { display: flex; padding: 8px; flex-direction: column; gap: 7px; }
 .editor-summary-content-shell, .editor-summary-content { display: flex; min-width: 0; flex-direction: column; gap: inherit; }
 .editor-summary-state { margin: 12px 0; color: var(--slate); font-size: 10px; letter-spacing: .1em; text-align: center; text-transform: uppercase; }
@@ -466,7 +476,7 @@ button { font: inherit; }
 .editor-resource-list { display: flex; flex-direction: column; gap: 1px; overflow: hidden; border: 1px solid var(--rule); border-radius: 3px; background: var(--rule); }
 .editor-resource-row { display: grid; grid-template-columns: minmax(120px, .8fr) minmax(110px, 1.5fr) minmax(125px, .7fr); gap: 10px; min-height: 30px; padding: 6px 9px; align-items: center; color: var(--slate); background: var(--panel-2); font-size: 9px; letter-spacing: .05em; text-transform: uppercase; }
 .editor-resource-row > span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.editor-resource-meter { height: 8px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: #05080c; }
+.editor-resource-meter { height: 8px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: var(--instrument-surface); }
 .editor-resource-meter > span { display: block; height: 100%; }
 .editor-resource-amount { color: #d5dde7; font-size: 10px; font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; }
 .editor-resource-amount small { color: var(--slate-dim); font: inherit; }
@@ -479,7 +489,7 @@ button { font: inherit; }
 .res-row:last-of-type { border-bottom: 0; }
 .res-name { overflow: hidden; color: var(--slate); font-size: 10px; letter-spacing: .06em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .meter { position: relative; min-width: 0; }
-.meter .track { height: 16px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: #05080c; }
+.meter .track { height: 16px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: var(--instrument-surface); }
 .meter .fill,
 .editor-resource-meter .fill { display: block; height: 100%; background: linear-gradient(90deg, #3c8c53, var(--green)); }
 .meter .fill.mid,
@@ -501,7 +511,7 @@ button { font: inherit; }
   text-shadow: 0 1px 2px #000, 0 0 3px #000;
 }
 .meter .cap .k { color: #c2ccd8; }
-.res-row .meter .cap .k { color: #eef3f8; font-size: 10px; font-weight: 650; text-shadow: 0 0 2px #05080c, 0 0 5px rgba(5,8,12,.95), 0 1px 3px #000; }
+.res-row .meter .cap .k { color: #eef3f8; font-size: 10px; font-weight: 650; text-shadow: 0 0 2px var(--instrument-surface), 0 0 5px rgba(5,8,12,.95), 0 1px 3px #000; }
 
 /* Staging: compact Flight planning surface and detailed Editor table. */
 #stage .body { display: flex; flex-direction: column; gap: 10px; }
@@ -540,7 +550,7 @@ button { font: inherit; }
 .flight-stage-group > span { display: flex; min-width: 0; align-items: baseline; gap: 8px; }
 .flight-stage-group strong { color: var(--cyan); font-size: 10px; font-weight: 600; white-space: nowrap; }
 .flight-stage-group small { overflow: hidden; color: var(--slate-dim); font-size: 8px; letter-spacing: .04em; text-overflow: ellipsis; white-space: nowrap; }
-.flight-stage-group button { min-height: 18px; padding: 1px 7px; border: 1px solid #315166; border-radius: 2px; color: var(--cyan); background: rgba(78,201,224,.05); cursor: pointer; font: 8px var(--mono); font-weight: 700; letter-spacing: .06em; }
+.flight-stage-group button { min-height: 18px; padding: 1px 7px; border: 1px solid var(--accent-border); border-radius: 2px; color: var(--cyan); background: rgba(78,201,224,.05); cursor: pointer; font: 8px var(--mono); font-weight: 700; letter-spacing: .06em; }
 .flight-stage-group button:hover, .flight-stage-group button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.1); outline: none; }
 .stage-table.flight.has-stage-group.expanded .flight-stage-rows { max-height: 92px; overflow-y: auto; scrollbar-gutter: stable; }
 .stage-table.flight .st-row > .sname { padding-left: 8px; text-align: left; }
@@ -559,7 +569,7 @@ button { font: inherit; }
 .standby, .connection-state { display: grid; min-height: 360px; place-content: center; gap: 10px; border: 1px solid var(--rule); border-radius: 4px; color: var(--slate); text-align: center; background: linear-gradient(180deg, var(--panel), var(--panel-2)); }
 .standby strong, .connection-state strong { color: var(--amber); font-size: 34px; letter-spacing: .18em; }
 .connection-state span { max-width: 560px; }
-.standby button, .notes-preview-trigger { border: 1px solid #24485a; border-radius: 3px; color: var(--cyan); background: #12202c; cursor: pointer; font: 11px var(--mono); letter-spacing: .08em; text-transform: uppercase; }
+.standby button, .notes-preview-trigger { border: 1px solid #24485a; border-radius: 3px; color: var(--cyan); background: var(--control-surface-hover); cursor: pointer; font: 11px var(--mono); letter-spacing: .08em; text-transform: uppercase; }
 .standby button { justify-self: center; margin-top: 8px; padding: 6px 12px; }
 .notes-preview-trigger { padding: 4px 8px; }
 
@@ -589,7 +599,7 @@ button { font: inherit; }
 .overview-section-head h2 { margin: 0; color: var(--amber); font-size: 13px; font-weight: 550; letter-spacing: .08em; text-transform: uppercase; }
 .overview-section-actions { display: flex; min-width: 28px; align-items: center; justify-content: flex-end; gap: 8px; }
 .overview-section-actions > strong { min-width: 28px; color: var(--cyan); font-size: 20px; font-weight: 500; text-align: right; }
-.overview-header-button { min-height: 26px; padding: 3px 7px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--cyan); background: #0b1821; cursor: pointer; font: 8px var(--mono); letter-spacing: .04em; white-space: nowrap; }
+.overview-header-button { min-height: 26px; padding: 3px 7px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 8px var(--mono); letter-spacing: .04em; white-space: nowrap; }
 .overview-header-button:hover:not(:disabled), .overview-header-button:focus-visible, .overview-header-button[aria-expanded="true"], .overview-header-button[aria-pressed="true"] { border-color: var(--cyan); background: #102633; outline: 0; }
 .overview-header-button:disabled { opacity: .42; cursor: not-allowed; }
 .overview-alarm-source-buttons { display: flex; align-items: center; gap: 3px; }
@@ -671,7 +681,7 @@ button { font: inherit; }
 .overview-vessel-next-event > header { display: flex; align-items: center; }
 .overview-vessel-next-event > header span { color: var(--slate); font-size: 9px; letter-spacing: .1em; text-transform: uppercase; }
 .overview-vessel-next-event-row { display: grid; min-width: 0; min-height: 52px; padding: 8px 10px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 12px; border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: rgba(5,10,15,.2); }
-.overview-vessel-next-event-row > strong { overflow: hidden; color: #cad4df; font-size: 11px; font-weight: 550; text-overflow: ellipsis; white-space: nowrap; }
+.overview-vessel-next-event-row > strong { overflow: hidden; color: var(--text-value); font-size: 11px; font-weight: 550; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-next-event-row time { display: grid; min-width: 0; gap: 3px; text-align: right; }
 .overview-vessel-next-event-row time strong { color: var(--amber); font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .overview-vessel-next-event-row time span { color: var(--slate-dim); font-size: 9px; font-variant-numeric: tabular-nums; white-space: nowrap; }
@@ -680,7 +690,7 @@ button { font: inherit; }
 .overview-switch-vessel { min-height: 32px; padding: 5px 9px; border: 1px solid var(--cyan); border-radius: 2px; color: #041016; background: var(--cyan); cursor: pointer; font: 9px var(--mono); font-weight: 650; letter-spacing: .04em; }
 .overview-switch-vessel:hover:not(:disabled), .overview-switch-vessel:focus-visible { border-color: #8be9fa; background: #8be9fa; outline: 0; }
 .overview-switch-vessel:disabled { cursor: not-allowed; opacity: .42; }
-.overview-rename-vessel { min-height: 32px; padding: 5px 9px; border: 1px solid #315166; border-radius: 2px; color: var(--slate); background: #0b1821; cursor: pointer; font: 9px var(--mono); letter-spacing: .04em; }
+.overview-rename-vessel { min-height: 32px; padding: 5px 9px; border: 1px solid var(--accent-border); border-radius: 2px; color: var(--slate); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); letter-spacing: .04em; }
 .overview-rename-vessel:hover:not(:disabled), .overview-rename-vessel:focus-visible { border-color: var(--amber); background: #2a1d0e; outline: 0; }
 .overview-rename-vessel:disabled { cursor: not-allowed; opacity: .42; }
 .overview-recover-vessel, .overview-terminate-vessel { min-width: 0; min-height: 32px; width: 100%; padding: 5px 9px; border-radius: 2px; cursor: pointer; font: 9px var(--mono); letter-spacing: .04em; }
@@ -690,15 +700,15 @@ button { font: inherit; }
 .overview-terminate-vessel:hover:not(:disabled), .overview-terminate-vessel:focus-visible { border-color: var(--danger); background: #341717; outline: 0; }
 .overview-recover-vessel:disabled, .overview-terminate-vessel:disabled { cursor: not-allowed; opacity: .42; }
 .overview-vessel-feedback { display: grid; min-width: 0; margin-top: 5px; gap: 3px; }
-.overview-command-error { min-width: 0; color: #d7a29c; font-size: 8px; line-height: 1.35; }
+.overview-command-error { min-width: 0; color: var(--error-text-muted); font-size: 8px; line-height: 1.35; }
 .overview-command-notice { min-width: 0; color: #9ccfc2; font-size: 8px; line-height: 1.35; }
 .overview-vessel-modal-backdrop { z-index: 20; padding: 10px; overflow: auto; background: rgba(2,6,9,.82); }
-.overview-vessel-modal { width: min(480px,100%); border: 1px solid #705128; border-radius: 3px; color: #d7e2ee; background: #081018; box-shadow: 0 16px 45px rgba(0,0,0,.7); }
+.overview-vessel-modal { width: min(480px,100%); border: 1px solid #705128; border-radius: 3px; color: var(--text-primary); background: #081018; box-shadow: 0 16px 45px rgba(0,0,0,.7); }
 .overview-vessel-modal > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; padding: 12px 14px; border-bottom: 1px solid var(--rule); background: linear-gradient(90deg,rgba(255,170,60,.08),transparent); }
 .overview-vessel-modal > header div { display: grid; min-width: 0; gap: 2px; }
 .overview-vessel-modal > header span { color: var(--amber); font-size: 8px; font-weight: 700; letter-spacing: .13em; }
 .overview-vessel-modal > header h3 { margin: 0; overflow: hidden; color: #e1eaf0; font-size: 13px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
-.overview-vessel-modal > header button { display: grid; width: 27px; min-width: 27px; height: 27px; padding: 0; place-items: center; border: 0; color: #d7e2ee; background: transparent; cursor: pointer; font: 21px var(--mono); }
+.overview-vessel-modal > header button { display: grid; width: 27px; min-width: 27px; height: 27px; padding: 0; place-items: center; border: 0; color: var(--text-primary); background: transparent; cursor: pointer; font: 21px var(--mono); }
 .overview-vessel-modal form { display: grid; gap: 10px; padding: 12px 14px 14px; }
 .overview-vessel-modal label { display: grid; gap: 5px; }
 .overview-vessel-modal label > span { color: var(--cyan); font-size: 8px; letter-spacing: .1em; text-transform: uppercase; }
@@ -713,9 +723,9 @@ button { font: inherit; }
 .overview-vessel-type-options svg { width: 22px; height: 22px; fill: none; stroke: currentColor; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
 .overview-vessel-type-options span { overflow: hidden; max-width: 100%; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-modal form > small { color: var(--slate-dim); font-size: 8px; line-height: 1.4; }
-.overview-vessel-modal-error { margin: 0; color: #d7a29c; font-size: 8px; line-height: 1.35; }
+.overview-vessel-modal-error { margin: 0; color: var(--error-text-muted); font-size: 8px; line-height: 1.35; }
 .overview-vessel-modal footer { display: flex; justify-content: flex-end; gap: 8px; margin-top: 2px; }
-.overview-vessel-modal footer button { min-height: 31px; padding: 6px 10px; border: 1px solid #315166; color: var(--slate); background: #0b1821; cursor: pointer; font: 9px var(--mono); }
+.overview-vessel-modal footer button { min-height: 31px; padding: 6px 10px; border: 1px solid var(--accent-border); color: var(--slate); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); }
 .overview-vessel-modal footer button:last-child { border-color: var(--amber); color: #160e04; background: var(--amber); }
 .overview-vessel-modal footer button:disabled { cursor: not-allowed; opacity: .42; }
 .overview-vessel-lifecycle-modal { width: min(440px,100%); }
@@ -728,7 +738,7 @@ button { font: inherit; }
 .overview-vessel-lifecycle-summary, .overview-vessel-uncrewed { margin: 0; color: #bdc8d4; font-size: 9px; line-height: 1.55; }
 .overview-vessel-uncrewed { color: var(--slate); }
 .overview-vessel-recovery-crew, .overview-vessel-termination-crew { padding: 9px 10px; border: 1px solid; border-radius: 2px; }
-.overview-vessel-recovery-crew { border-color: #315d3a; background: rgba(35,78,44,.3); }
+.overview-vessel-recovery-crew { border-color: var(--success-border); background: rgba(35,78,44,.3); }
 .overview-vessel-termination-crew { border-color: #6f3434; background: rgba(92,31,31,.28); }
 .overview-vessel-recovery-crew strong, .overview-vessel-termination-crew strong { display: block; margin-bottom: 6px; font-size: 9px; font-weight: 600; }
 .overview-vessel-recovery-crew strong { color: var(--green); }
@@ -742,8 +752,8 @@ button { font: inherit; }
 .overview-roster-summary-chip { display: flex; min-width: 62px; min-height: 24px; padding: 3px 6px; align-items: center; justify-content: space-between; gap: 7px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate); background: #0b1119; }
 .overview-roster-summary-chip > span { overflow: hidden; font-size: 8px; letter-spacing: .08em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .overview-roster-summary-chip > strong { color: var(--cyan); font-size: 10px; font-weight: 500; }
-.overview-roster-summary-chip.assigned { border-color: #315166; }
-.overview-roster-summary-chip.available { border-color: #315d3a; }
+.overview-roster-summary-chip.assigned { border-color: var(--accent-border); }
+.overview-roster-summary-chip.available { border-color: var(--success-border); }
 .overview-roster-summary-chip.dead, .overview-roster-summary-chip.missing { border-color: #5e4726; }
 .overview-roster-summary-chip.available > strong { color: var(--green); }
 .overview-roster-summary-chip.dead > strong, .overview-roster-summary-chip.missing > strong { color: var(--amber); }
@@ -753,8 +763,8 @@ button { font: inherit; }
 .overview-roster-table thead th:nth-child(2) { width: 18%; }
 .overview-roster-table thead th:nth-child(3), .overview-roster-table td:nth-child(3) { width: 62px; text-align: center; }
 .overview-roster-table thead th:nth-child(5), .overview-roster-table td:nth-child(5) { width: 82px; text-align: right; }
-.overview-roster-status-dot { display: inline-block; width: 7px; height: 7px; margin-right: 7px; border: 1px solid #315166; border-radius: 50%; background: var(--cyan); vertical-align: 1px; }
-.overview-roster-status-dot.available { border-color: #315d3a; background: var(--green); }
+.overview-roster-status-dot { display: inline-block; width: 7px; height: 7px; margin-right: 7px; border: 1px solid var(--accent-border); border-radius: 50%; background: var(--cyan); vertical-align: 1px; }
+.overview-roster-status-dot.available { border-color: var(--success-border); background: var(--green); }
 .overview-roster-status-dot.dead, .overview-roster-status-dot.missing { border-color: #5e4726; background: var(--amber); }
 .overview-roster-name { color: var(--cyan) !important; }
 .honor-row .overview-roster-name { color: #c4a476 !important; }
@@ -771,7 +781,7 @@ button { font: inherit; }
 .overview-list-card { display: grid; min-width: 0; min-height: 56px; padding: 9px 10px; align-items: center; grid-template-columns: minmax(0,1fr) auto auto; gap: 10px; border-bottom: 1px solid var(--rule); }
 .overview-list-card:last-child { border-bottom: 0; }
 .overview-list-card > div { display: flex; min-width: 0; flex-direction: column; gap: 3px; }
-.overview-list-card strong { overflow: hidden; color: #cad4df; font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.overview-list-card strong { overflow: hidden; color: var(--text-value); font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .overview-list-card span { overflow: hidden; color: var(--slate-dim); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
 .overview-contract-list { display: flex; min-height: 0; flex-direction: column; }
 .overview-contract-card { border-bottom: 1px solid var(--rule); background: rgba(5,10,15,.2); }
@@ -782,7 +792,7 @@ button { font: inherit; }
 .overview-contract-chevron { width: 6px; height: 6px; border-right: 1px solid var(--slate); border-bottom: 1px solid var(--slate); transform: rotate(-45deg); transition: transform .14s ease; }
 .overview-contract-card.expanded .overview-contract-chevron { transform: rotate(45deg); }
 .overview-contract-title { min-width: 0; }
-.overview-contract-title strong { display: block; overflow: hidden; color: #cad4df; font-size: 10px; font-weight: 550; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
+.overview-contract-title strong { display: block; overflow: hidden; color: var(--text-value); font-size: 10px; font-weight: 550; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
 .overview-contract-card.expanded .overview-contract-title strong { color: var(--cyan); }
 .overview-contract-time { display: flex; min-width: 0; align-items: flex-end; flex-direction: column; gap: 3px; grid-column: auto; text-align: right; }
 .overview-contract-time strong { color: var(--amber); font-size: 11px; font-weight: 650; font-variant-numeric: tabular-nums; white-space: nowrap; }
@@ -817,7 +827,7 @@ button { font: inherit; }
 .overview-contract-parameters ul { display: grid; margin: 0; padding: 0; list-style: none; gap: 3px; }
 .overview-contract-parameters li { display: grid; min-width: 0; margin-left: calc(var(--contract-depth) * 15px); padding: 8px 10px; align-items: start; grid-template-columns: 9px minmax(0,1fr); gap: 8px; border-left: 2px solid var(--rule-bright); background: rgba(11,20,29,.62); }
 .overview-contract-parameter-status { width: 7px; height: 7px; margin-top: 3px; border: 1px solid #5e4726; border-radius: 50%; background: var(--amber); }
-.overview-contract-parameters li.complete .overview-contract-parameter-status { border-color: #315d3a; background: var(--green); }
+.overview-contract-parameters li.complete .overview-contract-parameter-status { border-color: var(--success-border); background: var(--green); }
 .overview-contract-parameters li.failed .overview-contract-parameter-status { border-color: #71413a; background: #d77366; }
 .overview-contract-parameters li > span:last-child { display: grid; min-width: 0; gap: 2px; }
 .overview-contract-parameters li strong { color: #d4dee7; font-size: 11px; font-weight: 500; line-height: 1.4; }
@@ -834,14 +844,14 @@ button { font: inherit; }
 .overview-transfer-grid { display: grid; min-width: 0; grid-template-columns: repeat(auto-fit,minmax(250px,1fr)); gap: 1px; background: var(--rule); }
 .overview-transfer-card { display: grid; min-width: 0; min-height: 68px; padding: 10px 12px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 14px; background: var(--panel); }
 .overview-transfer-card > div { display: grid; min-width: 0; gap: 4px; }
-.overview-transfer-card strong { overflow: hidden; color: #cad4df; font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.overview-transfer-card strong { overflow: hidden; color: var(--text-value); font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .overview-transfer-card span { overflow: hidden; color: var(--slate-dim); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
 .overview-transfer-card .overview-transfer-origin,
-.overview-transfer-card .overview-transfer-destination { color: #cad4df; font-size: 9px; }
+.overview-transfer-card .overview-transfer-destination { color: var(--text-value); font-size: 9px; }
 .overview-transfer-card.error { background: rgba(201,104,91,.055); }
 .overview-transfer-countdown { justify-items: end; text-align: right; }
 .overview-transfer-countdown strong { color: var(--amber); font-size: 11px; font-variant-numeric: tabular-nums; }
-.overview-transfer-card.error .overview-transfer-countdown strong { color: #e4a79f; }
+.overview-transfer-card.error .overview-transfer-countdown strong { color: var(--error-text); }
 .overview-transfer-countdown span { letter-spacing: .06em; }
 .overview-alarm-time { text-align: right; }
 .overview-alarm-time strong { color: var(--amber); font-variant-numeric: tabular-nums; }
@@ -864,22 +874,22 @@ button { font: inherit; }
 .notes-preview header h2 { margin: 2px 0 0; color: var(--amber); font-size: 14px; letter-spacing: .08em; text-transform: uppercase; }
 .notes-preview header p { margin: 5px 0 0; color: var(--slate); }
 .notes-preview-kicker { color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
-.notes-preview header button { align-self: start; border: 0; color: #d7e2ee; background: transparent; cursor: pointer; font-size: 22px; }
+.notes-preview header button { align-self: start; border: 0; color: var(--text-primary); background: transparent; cursor: pointer; font-size: 22px; }
 .notes-preview-body { min-height: 0; padding: 18px; overflow: auto; }
 .notes-preview-body > strong, .notes-preview-body > span { display: block; }
 .notes-preview-body > strong { color: var(--cyan); }
 .notes-preview-body > span { margin: 4px 0 12px; color: var(--slate); font-size: 10px; }
-.notes-preview-body pre { min-height: 220px; margin: 0; padding: 14px; overflow: auto; border: 1px solid var(--rule); color: #d7e2ee; background: #05090d; font: 10px/1.5 var(--mono); white-space: pre-wrap; }
+.notes-preview-body pre { min-height: 220px; margin: 0; padding: 14px; overflow: auto; border: 1px solid var(--rule); color: var(--text-primary); background: #05090d; font: 10px/1.5 var(--mono); white-space: pre-wrap; }
 .notes-preview footer { padding: 12px 18px; border-top: 1px solid var(--rule); color: var(--slate); font-size: 10px; line-height: 1.45; }
 .notes-drawer-backdrop { position: fixed; z-index: 9; inset: 0; padding: 0; border: 0; background: rgba(2,5,9,.58); cursor: default; }
 .notes-preview.notes-drawer-full { z-index: 10; width: min(980px,94vw); }
 .notes-full-body { display: grid; min-height: 0; overflow: hidden; grid-template-columns: 240px minmax(0,1fr); }
 .notes-browser { display: flex; min-height: 0; padding: 12px; overflow: hidden; border-right: 1px solid var(--rule); background: #071019; flex-direction: column; gap: 8px; }
 .notes-browser-nav { display: grid; align-items: center; grid-template-columns: auto auto auto 1fr; gap: 6px; }
-.notes-browser-nav button, .notes-content-head button, .notes-font-controls button { padding: 5px 8px; border: 1px solid #24485a; border-radius: 3px; color: var(--cyan); background: #12202c; cursor: pointer; font: 9px var(--mono); text-transform: uppercase; }
+.notes-browser-nav button, .notes-content-head button, .notes-font-controls button { padding: 5px 8px; border: 1px solid #24485a; border-radius: 3px; color: var(--cyan); background: var(--control-surface-hover); cursor: pointer; font: 9px var(--mono); text-transform: uppercase; }
 .notes-browser-nav button:disabled, .notes-content-head button:disabled, .notes-font-controls button:disabled { cursor: not-allowed; opacity: .4; }
 .notes-browser-nav span { overflow: hidden; color: var(--slate); font-size: 9px; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
-.notes-search { width: 100%; padding: 7px 8px; border: 1px solid var(--rule-bright); border-radius: 3px; outline: 0; color: #d7e2ee; background: #05090d; font: 10px var(--mono); }
+.notes-search { width: 100%; padding: 7px 8px; border: 1px solid var(--rule-bright); border-radius: 3px; outline: 0; color: var(--text-primary); background: #05090d; font: 10px var(--mono); }
 .notes-search:focus { border-color: var(--cyan); }
 .notes-list { min-height: 0; overflow-y: auto; }
 .notes-list-row { display: grid; margin-bottom: 2px; grid-template-columns: minmax(0,1fr) 28px; gap: 3px; }
@@ -894,7 +904,7 @@ button { font: inherit; }
 .notes-content-head strong, .notes-content-head span { display: block; }
 .notes-content-head strong { color: var(--cyan); font-size: 10px; text-transform: uppercase; }
 .notes-content-head span { margin-top: 3px; overflow: hidden; color: var(--slate-dim); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.notes-log { min-height: 0; margin: 0; padding: 12px; overflow: auto; border: 1px solid var(--rule); border-radius: 3px; color: #d7e2ee; background: #05090d; font-family: var(--mono); line-height: 1.5; white-space: pre-wrap; flex: 1; }
+.notes-log { min-height: 0; margin: 0; padding: 12px; overflow: auto; border: 1px solid var(--rule); border-radius: 3px; color: var(--text-primary); background: #05090d; font-family: var(--mono); line-height: 1.5; white-space: pre-wrap; flex: 1; }
 .notes-empty { display: grid; min-height: 220px; place-content: center; color: var(--slate); text-align: center; }
 .notes-unavailable { display: grid; min-height: 0; padding: 24px; place-content: center; gap: 8px; color: var(--slate); text-align: center; }
 .notes-unavailable strong { color: var(--amber); font-size: 18px; text-transform: uppercase; }
@@ -960,7 +970,7 @@ button { font: inherit; }
   justify-self: end;
   align-self: center;
   gap: 3px;
-  border: 1px solid #315166;
+  border: 1px solid var(--accent-border);
   border-radius: 4px;
   background: #0b141e;
 }
@@ -978,7 +988,7 @@ button { font: inherit; }
   font-weight: 700;
   letter-spacing: .12em;
 }
-.flight-workspace-selector button[aria-selected="true"] { border-color: #3a6f86; color: var(--cyan); background: #142535; }
+.flight-workspace-selector button[aria-selected="true"] { border-color: var(--accent-border-hover); color: var(--cyan); background: #142535; }
 .flight-workspace-selector button:hover { color: var(--cyan); background: #101f2c; }
 .flight-workspace-selector .flight-workspace-rebalance { min-width: 34px; width: 34px; padding-inline: 0; color: var(--amber); font-size: 17px; }
 .flight-workspace-view { position: relative; width: 100%; min-width: 0; }
@@ -989,7 +999,7 @@ button { font: inherit; }
   min-height: 132px;
   padding: 24px;
   place-items: center;
-  border: 1px dashed #315166;
+  border: 1px dashed var(--accent-border);
   color: var(--slate-muted-text);
   background: #0a1119;
   text-align: center;
@@ -1098,7 +1108,7 @@ button { font: inherit; }
 .led.ok, .led2.ok { background: var(--green); box-shadow: 0 0 8px var(--green); }
 .led.wait { background: var(--amber); box-shadow: 0 0 8px var(--amber); }
 .led.bad, .led2.bad { background: var(--warn); box-shadow: 0 0 8px var(--warn); }
-.notes-trigger { margin-left: auto; padding: 5px 10px; border: 1px solid #24485a; border-radius: 3px; color: var(--cyan); background: #12202c; cursor: pointer; font: 10px var(--mono); letter-spacing: .08em; text-transform: uppercase; }
+.notes-trigger { margin-left: auto; padding: 5px 10px; border: 1px solid #24485a; border-radius: 3px; color: var(--cyan); background: var(--control-surface-hover); cursor: pointer; font: 10px var(--mono); letter-spacing: .08em; text-transform: uppercase; }
 .resonant-drawer.datalink-drawer { width: min(560px,94vw); }
 .resonant-drawer-body.datalink-drawer-body { display: flex; padding: 18px; flex-direction: column; gap: 14px; }
 .datalink-status-card { display: grid; min-width: 0; padding: 14px 15px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 10px 16px; border: 1px solid var(--rule-bright); border-left: 3px solid var(--slate-dim); border-radius: 4px; background: linear-gradient(135deg,#101a27,#0a1119); }
@@ -1117,7 +1127,7 @@ button { font: inherit; }
 .datalink-diagnostics > div { display: flex; min-width: 0; min-height: 67px; padding: 11px 12px; justify-content: center; background: var(--panel); flex-direction: column; gap: 6px; }
 .datalink-diagnostics strong { overflow: hidden; color: #d9e4ef; font-size: 12px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .datalink-controls { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 9px; }
-.datalink-controls button { display: flex; min-height: 74px; padding: 11px 12px; border: 1px solid #74552d; border-radius: 3px; color: var(--amber); background: #211a12; cursor: pointer; text-align: left; flex-direction: column; gap: 6px; }
+.datalink-controls button { display: flex; min-height: 74px; padding: 11px 12px; border: 1px solid var(--amber-accent); border-radius: 3px; color: var(--amber); background: #211a12; cursor: pointer; text-align: left; flex-direction: column; gap: 6px; }
 .datalink-controls button:hover:not(:disabled), .datalink-controls button:focus-visible { border-color: var(--amber); background: #2b2115; outline: none; }
 .datalink-controls button.power-off { border-color: #61322e; color: #e9988d; background: #1b1111; }
 .datalink-controls button.power-off:hover:not(:disabled), .datalink-controls button.power-off:focus-visible { border-color: var(--warn); background: #281414; }
@@ -1177,7 +1187,7 @@ button { font: inherit; }
 .annunciator-indicator.acknowledged { border-color: #8d651a; color: #211503; background: linear-gradient(180deg,#ffd75a,#c98716); box-shadow: 0 0 6px rgba(251,191,36,.32), inset 0 0 4px rgba(255,248,194,.28); }
 .annunciator-indicator.new:hover, .annunciator-indicator.new:focus-visible { filter: brightness(1.12); outline: 2px solid var(--cyan); outline-offset: 1px; }
 .annunciator-backdrop { position: fixed; z-index: 1200; inset: 0; display: grid; padding: max(12px,env(safe-area-inset-top)) max(12px,env(safe-area-inset-right)) max(12px,env(safe-area-inset-bottom)) max(12px,env(safe-area-inset-left)); place-items: center; background: rgba(2,6,9,.82); }
-.annunciator-history { display: flex; width: min(620px,100%); max-height: min(760px,92vh); overflow: hidden; border: 1px solid #315166; border-radius: 5px; outline: 0; background: #081019; box-shadow: 0 18px 60px rgba(0,0,0,.62); flex-direction: column; }
+.annunciator-history { display: flex; width: min(620px,100%); max-height: min(760px,92vh); overflow: hidden; border: 1px solid var(--accent-border); border-radius: 5px; outline: 0; background: #081019; box-shadow: 0 18px 60px rgba(0,0,0,.62); flex-direction: column; }
 .annunciator-history > header { display: flex; padding: 13px 16px; align-items: center; justify-content: space-between; gap: 16px; border-bottom: 1px solid var(--rule); background: linear-gradient(135deg,#101c29,#0a1018); }
 .annunciator-history h2 { margin: 3px 0 0; color: var(--cyan); font-size: 16px; font-weight: 500; letter-spacing: .08em; text-transform: uppercase; }
 .annunciator-history > header button { width: 36px; height: 36px; padding: 0; border: 1px solid var(--rule-bright); border-radius: 3px; color: var(--slate); background: #111923; cursor: pointer; font: 24px/1 var(--mono); }
@@ -1257,9 +1267,9 @@ button { font: inherit; }
 .nav-sphere-rim { fill: none; stroke: #0a1119; stroke-width: 2; stroke-opacity: .55; }
 .aircraft { fill: none; stroke: var(--amber); stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; }
 .aircraft-dot { fill: var(--amber); }
-.heading-tape { position: relative; width: 196px; height: 20px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: #05080c; }
+.heading-tape { position: relative; width: 196px; height: 20px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: var(--instrument-surface); }
 .heading-tape svg { display: block; width: 196px; height: 20px; }
-.heading-tape rect { fill: #05080c; }
+.heading-tape rect { fill: var(--instrument-surface); }
 .heading-tape line { stroke: var(--slate-dim); stroke-width: 1; }
 .heading-tape text { fill: var(--slate); font: 7px var(--mono); text-anchor: middle; }
 .heading-tape text.cardinal { fill: var(--cyan); }
@@ -1268,7 +1278,7 @@ button { font: inherit; }
 .attitude-strip > div { display: flex; min-width: 0; padding: 6px 4px 7px; color: var(--cyan); background: var(--panel); align-items: center; flex-direction: column; gap: 3px; font-size: 17px; font-variant-numeric: tabular-nums; }
 .attitude-strip .label { font-size: 8px; }
 .throttle-col { display: flex; width: 44px; min-width: 0; flex-direction: column; align-items: center; gap: 5px; }
-.thr-track { position: relative; width: 20px; min-height: 0; flex: 1 1 auto; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: #05080c; }
+.thr-track { position: relative; width: 20px; min-height: 0; flex: 1 1 auto; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: var(--instrument-surface); }
 .thr-track::after { position: absolute; inset: 0; background: linear-gradient(to bottom,transparent 24.7%,var(--rule) 25%,transparent 25.3%,transparent 49.7%,var(--rule-bright) 50%,transparent 50.3%,transparent 74.7%,var(--rule) 75%,transparent 75.3%); content: ""; pointer-events: none; }
 .thr-fill { position: absolute; right: 0; bottom: 0; left: 0; background: linear-gradient(0deg,var(--amber-dim),var(--amber)); transition: height .12s linear; }
 .thr-pct { color: var(--amber); font-size: 14px; font-variant-numeric: tabular-nums; }
@@ -1309,8 +1319,8 @@ button { font: inherit; }
 .target-clear-button { min-height: 22px; padding: 1px 8px; border: 1px solid #7a5230; border-radius: 2px; color: var(--amber); background: rgba(255,180,84,.06); cursor: pointer; font: 8px var(--mono); font-weight: 700; letter-spacing: .06em; white-space: nowrap; }
 .target-clear-button:hover:not(:disabled), .target-clear-button:focus-visible { border-color: var(--amber); background: rgba(255,180,84,.12); outline: none; }
 .target-clear-button:disabled { cursor: default; opacity: .45; }
-.target-command-feedback { padding: 5px 7px; border: 1px solid #315166; border-radius: 3px; color: #9ccfc2; background: rgba(78,201,224,.04); font-size: 8px; }
-.target-command-feedback.error { border-color: #573239; color: #d7a29c; background: rgba(255,107,91,.04); }
+.target-command-feedback { padding: 5px 7px; border: 1px solid var(--accent-border); border-radius: 3px; color: #9ccfc2; background: rgba(78,201,224,.04); font-size: 8px; }
+.target-command-feedback.error { border-color: #573239; color: var(--error-text-muted); background: rgba(255,107,91,.04); }
 @media (pointer: coarse) {
   .target-clear-button { min-height: 36px; padding-block: 4px; }
   .sci-banked-value,
@@ -1418,7 +1428,7 @@ button { font: inherit; }
 .ec-source-ledger { display: flex; overflow: hidden; border: 1px solid var(--rule); border-radius: 4px; background: var(--rule); flex-direction: column; gap: 1px; }
 .ec-source-row { display: flex; min-width: 0; padding: 7px 10px; align-items: center; gap: 9px; background: var(--panel); }
 .ec-source-button { width: 100%; border: 0; color: inherit; cursor: pointer; font-family: var(--mono); text-align: left; }
-.ec-source-button:hover, .ec-source-button:focus-visible { background: #12202c; outline: none; }
+.ec-source-button:hover, .ec-source-button:focus-visible { background: var(--control-surface-hover); outline: none; }
 .ec-source-drill { width: 10px; flex: 0 0 10px; color: var(--cyan); font-size: 17px; line-height: 1; text-align: center; }
 .ec-source-drill.placeholder { visibility: hidden; }
 .ec-source-row.idle { background: var(--panel-2); }
@@ -1438,7 +1448,7 @@ button { font: inherit; }
 .rx-detail-back { display: grid; width: 100%; min-height: 31px; padding: 5px 9px; border: 0; align-items: center; grid-template-columns: 16px minmax(0,1fr) auto; gap: 6px; color: var(--slate); background: var(--panel); cursor: pointer; font: 10px var(--mono); letter-spacing: .1em; text-align: left; text-transform: uppercase; }
 .rx-detail-back > span:first-child { color: var(--cyan); font-size: 17px; line-height: 1; }
 .rx-detail-back > span:last-child { color: var(--slate-dim); }
-.rx-detail-back:hover, .rx-detail-back:focus-visible { color: var(--cyan); background: #12202c; outline: none; }
+.rx-detail-back:hover, .rx-detail-back:focus-visible { color: var(--cyan); background: var(--control-surface-hover); outline: none; }
 .rx-detail-view.warn .rx-detail-back { color: var(--danger); }
 .rx-scroll { min-height: 0; padding: 7px; overflow-y: auto; border-top: 1px solid var(--rule); outline: 0; overscroll-behavior: contain; scrollbar-gutter: stable; }
 .rx-scroll:focus-visible { box-shadow: inset 0 0 0 1px var(--cyan); }
@@ -1456,7 +1466,7 @@ button { font: inherit; }
 .rx-state.control:disabled { cursor: wait; opacity: .6; }
 .rx-charge-row { display: grid; margin-top: 7px; align-items: center; grid-template-columns: auto minmax(48px,1fr) auto; gap: 7px; color: var(--slate-dim); font-size: 9px; }
 .rx-charge-row strong { color: var(--amber); font-weight: 500; font-variant-numeric: tabular-nums; }
-.rx-charge-track { height: 5px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: #05080c; }
+.rx-charge-track { height: 5px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: var(--instrument-surface); }
 .rx-charge-fill { display: block; height: 100%; background: var(--amber); }
 .rx-command-result { padding: 6px 9px; border-top: 1px solid var(--rule); color: var(--green); font-size: 9px; line-height: 1.4; }
 .rx-command-result.error { color: var(--danger); }
@@ -1521,7 +1531,7 @@ button { font: inherit; }
 .sci-experiment-open > span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sci-experiment-open > span:nth-child(2) { color: var(--slate-dim); font-size: 10px; font-variant-numeric: tabular-nums; }
 .sci-experiment-open > span:last-child { color: var(--cyan); font-size: 16px; line-height: 1; text-align: center; }
-.sci-experiment-open:hover, .sci-experiment-open:focus-visible { color: var(--cyan); background: #12202c; outline: none; }
+.sci-experiment-open:hover, .sci-experiment-open:focus-visible { color: var(--cyan); background: var(--control-surface-hover); outline: none; }
 .sci-content-slot { --sci-content-max: min(250px,35vh); min-height: 0; margin-top: 8px; }
 .sci-content-slot:not(.has-baseline):not(.detail-open) { display: none; }
 .sci-content-slot.detail-open:not(.has-labs) { height: var(--sci-content-max); }
@@ -1556,12 +1566,12 @@ button { font: inherit; }
 .sci-lab-card.danger .sci-lab-caption > div:first-child span:last-child { color: var(--warn); }
 .sci-lab-controls { display: flex; flex: 0 0 auto; align-items: center; justify-content: flex-end; gap: 4px; }
 .sci-research-toggle,
-.sci-transmit-science { height: 25px; min-width: 112px; padding: 4px 7px; border: 1px solid #315166; border-radius: 2px; color: var(--cyan); background: #0b1821; cursor: pointer; font: 8px var(--mono); letter-spacing: .05em; }
+.sci-transmit-science { height: 25px; min-width: 112px; padding: 4px 7px; border: 1px solid var(--accent-border); border-radius: 2px; color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 8px var(--mono); letter-spacing: .05em; }
 .sci-research-toggle { min-width: 96px; }
 .sci-research-toggle:disabled,
 .sci-transmit-science:disabled { cursor: not-allowed; opacity: .38; }
 .sci-alarm-controls { display: flex; flex: 0 0 auto; align-items: center; gap: 4px; }
-.sci-alarm-controls button { height: 25px; border: 1px solid #315166; border-radius: 2px; color: var(--cyan); background: #0b1821; cursor: pointer; font: 8px var(--mono); letter-spacing: .07em; }
+.sci-alarm-controls button { height: 25px; border: 1px solid var(--accent-border); border-radius: 2px; color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 8px var(--mono); letter-spacing: .07em; }
 .sci-alarm-controls button:disabled { cursor: not-allowed; opacity: .38; }
 .sci-alarm-create { min-width: 68px; padding: 4px 7px; }
 .sci-alarm-settings { display: grid; width: 25px; padding: 4px; place-items: center; }
@@ -1569,12 +1579,12 @@ button { font: inherit; }
 .sci-alarm-feedback { margin-top: 7px; padding-top: 6px; border-top: 1px solid var(--rule); color: var(--green); font-size: 8px; line-height: 1.35; }
 .sci-alarm-feedback.error { color: var(--warn); }
 .sci-alarm-modal-backdrop { z-index: 24; padding: 10px; }
-.sci-alarm-modal { width: min(390px,100%); border: 1px solid #315166; border-radius: 4px; color: #d7e2ee; background: #081018; box-shadow: 0 16px 45px rgba(0,0,0,.72); }
+.sci-alarm-modal { width: min(390px,100%); border: 1px solid var(--accent-border); border-radius: 4px; color: var(--text-primary); background: #081018; box-shadow: 0 16px 45px rgba(0,0,0,.72); }
 .sci-alarm-modal > header { display: flex; padding: 12px 14px; align-items: flex-start; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--rule); background: linear-gradient(90deg,rgba(78,210,230,.08),transparent); }
 .sci-alarm-modal > header div { display: grid; gap: 2px; }
 .sci-alarm-modal > header span, .sci-alarm-modal legend { color: var(--cyan); font-size: 8px; letter-spacing: .12em; text-transform: uppercase; }
 .sci-alarm-modal > header h3 { margin: 0; color: #e1eaf0; font-size: 13px; font-weight: 500; }
-.sci-alarm-modal > header button { display: grid; width: 27px; height: 27px; padding: 0; place-items: center; border: 0; color: #d7e2ee; background: transparent; cursor: pointer; font: 21px var(--mono); }
+.sci-alarm-modal > header button { display: grid; width: 27px; height: 27px; padding: 0; place-items: center; border: 0; color: var(--text-primary); background: transparent; cursor: pointer; font: 21px var(--mono); }
 .sci-alarm-modal-body { display: grid; padding: 13px 14px; gap: 10px; }
 .sci-alarm-modal fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
 .sci-alarm-modal legend { margin-bottom: 6px; }
@@ -1586,7 +1596,7 @@ button { font: inherit; }
 .sci-alarm-options button:disabled { cursor: not-allowed; opacity: .35; }
 .sci-alarm-modal-body > small { color: var(--slate); font-size: 8px; line-height: 1.45; }
 .sci-alarm-modal > footer { display: flex; padding: 0 14px 14px; justify-content: flex-end; gap: 7px; }
-.sci-alarm-modal > footer button { min-height: 31px; padding: 6px 10px; border: 1px solid #315166; color: var(--slate); background: #0b1821; cursor: pointer; font: 9px var(--mono); }
+.sci-alarm-modal > footer button { min-height: 31px; padding: 6px 10px; border: 1px solid var(--accent-border); color: var(--slate); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); }
 .sci-alarm-modal > footer button:last-child { border-color: var(--cyan); color: #061115; background: var(--cyan); }
 .sci-lab-empty { padding: 9px 10px; border: 1px solid var(--rule); border-radius: 4px; color: var(--slate); background: var(--panel-2); font-size: 9px; text-align: center; }
 .sci-lab-empty.unavailable { color: var(--slate-muted-text); }
@@ -1595,7 +1605,7 @@ button { font: inherit; }
 .sci-experiment-back { display: grid; width: 100%; min-height: 31px; padding: 5px 9px; align-items: center; grid-template-columns: 16px minmax(0,1fr) auto; gap: 6px; border: 0; color: var(--slate); background: var(--panel); cursor: pointer; font: 10px var(--mono); letter-spacing: .1em; text-align: left; text-transform: uppercase; }
 .sci-experiment-back > span:first-child { color: var(--cyan); font-size: 17px; line-height: 1; }
 .sci-experiment-back > span:last-child { color: var(--slate-dim); font-variant-numeric: tabular-nums; }
-.sci-experiment-back:hover, .sci-experiment-back:focus-visible { color: var(--cyan); background: #12202c; outline: none; }
+.sci-experiment-back:hover, .sci-experiment-back:focus-visible { color: var(--cyan); background: var(--control-surface-hover); outline: none; }
 .sci-experiment-scroll { min-height: 0; padding: 7px; overflow-y: auto; border-top: 1px solid var(--rule); }
 .sci-list { display: flex; flex-direction: column; gap: 5px; }
 .sl-row { display: grid; min-width: 0; padding: 6px 8px; align-items: center; border: 1px solid var(--rule); border-radius: 3px; background: var(--panel); grid-template-columns: minmax(0,1fr) auto; gap: 8px; font-size: 10px; }
@@ -1608,7 +1618,7 @@ button { font: inherit; }
 .tgt-grid .stat { display: flex; min-width: 0; padding: 9px 10px; background: var(--panel); flex-direction: column; gap: 3px; }
 .tgt-grid .stat .v { overflow: hidden; color: var(--amber); font-size: 17px; text-overflow: ellipsis; white-space: nowrap; }
 .dock-wrap { margin-top: 10px; }
-.dock-svg { display: block; width: 100%; max-width: 220px; margin: 0 auto; border: 1px solid var(--rule); border-radius: 4px; background: #05080c; }
+.dock-svg { display: block; width: 100%; max-width: 220px; margin: 0 auto; border: 1px solid var(--rule); border-radius: 4px; background: var(--instrument-surface); }
 .dock-svg text { fill: var(--slate); font: 8px var(--mono); }
 .dock-ring { fill: none; stroke: var(--rule); stroke-width: 1; }
 .dock-ring.bright { stroke: var(--rule-bright); }
@@ -1699,7 +1709,7 @@ button { font: inherit; }
   }
   .inactive-mode .overview-transfer-card > div { gap: 2px; }
   .inactive-mode .overview-transfer-origin { display: none; }
-  .inactive-mode .overview-transfer-destination { color: #cad4df; font-size: 13px; font-weight: 600; }
+  .inactive-mode .overview-transfer-destination { color: var(--text-value); font-size: 13px; font-weight: 600; }
   .inactive-mode .overview-transfer-countdown { justify-items: start; text-align: left; }
   .inactive-mode .overview-transfer-countdown span { display: none; }
   .inactive-mode .overview-data-grid {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -186,7 +186,7 @@ button { font: inherit; }
   padding: 4px 7px 4px 10px;
   border: 1px solid var(--rule);
   border-radius: 4px;
-  color: var(--slate-dim);
+  color: var(--slate-muted-text);
   background: rgba(11, 16, 25, .9);
   font-size: 9px;
   letter-spacing: .12em;
@@ -222,7 +222,7 @@ button { font: inherit; }
   letter-spacing: .22em;
   text-transform: uppercase;
 }
-.panel > h2 .tag { overflow: hidden; color: var(--slate-dim); font-size: 9px; font-weight: 500; letter-spacing: .1em; text-overflow: ellipsis; white-space: nowrap; }
+.panel > h2 .tag { overflow: hidden; color: var(--slate-muted-text); font-size: 9px; font-weight: 500; letter-spacing: .1em; text-overflow: ellipsis; white-space: nowrap; }
 .panel-heading-actions { display: flex; min-width: 0; align-items: center; gap: 7px; }
 .panel-hide-button {
   width: 20px;
@@ -472,19 +472,19 @@ button { font: inherit; }
   filter: saturate(.4);
   opacity: .58;
 }
-.editor-resource-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; color: var(--slate-dim); font-size: 9px; letter-spacing: .08em; text-transform: uppercase; }
+.editor-resource-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; color: var(--slate-muted-text); font-size: 9px; letter-spacing: .08em; text-transform: uppercase; }
 .editor-resource-list { display: flex; flex-direction: column; gap: 1px; overflow: hidden; border: 1px solid var(--rule); border-radius: 3px; background: var(--rule); }
 .editor-resource-row { display: grid; grid-template-columns: minmax(120px, .8fr) minmax(110px, 1.5fr) minmax(125px, .7fr); gap: 10px; min-height: 30px; padding: 6px 9px; align-items: center; color: var(--slate); background: var(--panel-2); font-size: 9px; letter-spacing: .05em; text-transform: uppercase; }
 .editor-resource-row > span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .editor-resource-meter { height: 8px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: var(--instrument-surface); }
 .editor-resource-meter > span { display: block; height: 100%; }
 .editor-resource-amount { color: #d5dde7; font-size: 10px; font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; }
-.editor-resource-amount small { color: var(--slate-dim); font: inherit; }
-.editor-resources-empty { margin: 4px 0; color: var(--slate-dim); font-size: 10px; text-align: center; }
+.editor-resource-amount small { color: var(--slate-muted-text); font: inherit; }
+.editor-resources-empty { margin: 4px 0; color: var(--slate-muted-text); font-size: 10px; text-align: center; }
 
 /* Consumables: production structure and measurements. */
 .col-heads { display: grid; grid-template-columns: minmax(110px,.65fr) minmax(0,1.35fr); gap: 8px; margin-bottom: 4px; }
-.col-heads span { color: var(--slate-dim); font-size: 8px; letter-spacing: .14em; text-transform: uppercase; }
+.col-heads span { color: var(--slate-muted-text); font-size: 8px; letter-spacing: .14em; text-transform: uppercase; }
 .res-row { display: grid; grid-template-columns: minmax(110px,.65fr) minmax(0,1.35fr); gap: 8px; align-items: center; padding: 4px 0; border-bottom: 1px solid var(--rule); }
 .res-row:last-of-type { border-bottom: 0; }
 .res-name { overflow: hidden; color: var(--slate); font-size: 10px; letter-spacing: .06em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
@@ -518,21 +518,21 @@ button { font: inherit; }
 .stage-table { display: flex; margin-top: 2px; flex-direction: column; gap: 1px; overflow: hidden; border: 1px solid var(--rule); border-radius: 3px; background: var(--rule); }
 .st-row { display: grid; gap: 1px; background: var(--rule); }
 .st-row > span { min-width: 0; padding: 4px 8px; overflow: hidden; color: var(--amber); background: var(--panel-2); font-size: 11px; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
-.st-head > span { color: var(--slate-dim); font-size: 8px; letter-spacing: .14em; text-transform: uppercase; }
+.st-head > span { color: var(--slate-muted-text); font-size: 8px; letter-spacing: .14em; text-transform: uppercase; }
 .st-row .sname { color: var(--slate); }
 .st-row.cur > span { color: var(--cyan); background: #0e2029; }
 .stage-table.editor .st-row { grid-template-columns: 72px 1.35fr 1.35fr .85fr .85fr 1fr; }
 .stage-table.editor .st-row > span { padding-block: 6px; font-size: 13px; }
 .stage-table.editor .st-head > span { font-size: 11px; }
 .editor-stage-total-dv { display: inline-flex; align-items: baseline; gap: 11px; }
-.editor-stage-total-label { color: var(--slate-dim); }
+.editor-stage-total-label { color: var(--slate-muted-text); }
 .editor-stage-total-value { display: inline-flex; align-items: baseline; gap: 4px; }
 .editor-stage-total-value small { color: var(--cyan); font: inherit; }
 .editor-stage-total-separator { color: var(--rule-bright); }
 .editor-stage-total-value strong { color: var(--amber); font-size: 12px; font-weight: 600; letter-spacing: 0; text-transform: none; }
 .flight-stage-hero { display: grid; overflow: hidden; border: 1px solid var(--rule); border-radius: 3px; background: var(--rule); grid-template-columns: minmax(0,1.35fr) minmax(116px,.8fr); gap: 1px; }
 .flight-stage-total, .flight-stage-conditions { display: flex; min-width: 0; padding: 10px 11px; background: var(--panel-2); flex-direction: column; gap: 3px; }
-.flight-stage-total > span, .flight-stage-conditions > span, .flight-stage-single span { color: var(--slate-dim); font-size: 8px; letter-spacing: .13em; text-transform: uppercase; }
+.flight-stage-total > span, .flight-stage-conditions > span, .flight-stage-single span { color: var(--slate-muted-text); font-size: 8px; letter-spacing: .13em; text-transform: uppercase; }
 .flight-stage-total strong { overflow: hidden; color: var(--cyan); font-size: 20px; font-weight: 500; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .flight-stage-total small, .flight-stage-conditions small { overflow: hidden; color: var(--slate); font-size: 9px; line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
 .flight-stage-total small:first-of-type { color: var(--amber); font-size: 10px; }
@@ -549,15 +549,15 @@ button { font: inherit; }
 .flight-stage-group { display: grid; min-width: 352px; min-height: 23px; padding: 2px 6px 2px 8px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 8px; background: var(--panel-2); }
 .flight-stage-group > span { display: flex; min-width: 0; align-items: baseline; gap: 8px; }
 .flight-stage-group strong { color: var(--cyan); font-size: 10px; font-weight: 600; white-space: nowrap; }
-.flight-stage-group small { overflow: hidden; color: var(--slate-dim); font-size: 8px; letter-spacing: .04em; text-overflow: ellipsis; white-space: nowrap; }
+.flight-stage-group small { overflow: hidden; color: var(--slate-muted-text); font-size: 8px; letter-spacing: .04em; text-overflow: ellipsis; white-space: nowrap; }
 .flight-stage-group button { min-height: 18px; padding: 1px 7px; border: 1px solid var(--accent-border); border-radius: 2px; color: var(--cyan); background: rgba(78,201,224,.05); cursor: pointer; font: 8px var(--mono); font-weight: 700; letter-spacing: .06em; }
 .flight-stage-group button:hover, .flight-stage-group button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.1); outline: none; }
 .stage-table.flight.has-stage-group.expanded .flight-stage-rows { max-height: 92px; overflow-y: auto; scrollbar-gutter: stable; }
 .stage-table.flight .st-row > .sname { padding-left: 8px; text-align: left; }
 .stage-table.flight .st-row.cur > .sname { box-shadow: inset 3px 0 var(--green); }
-.stage-table.flight .st-row > .dim { color: var(--slate-dim); opacity: .48; }
+.stage-table.flight .st-row > .dim { color: var(--slate-muted-text); opacity: .48; }
 .stage-table.flight .stage-twr.danger { color: var(--danger); }
-.flight-stage-footer, .editor-stage-footer { padding-top: 1px; color: var(--slate-dim); font-size: 9px; letter-spacing: .04em; }
+.flight-stage-footer, .editor-stage-footer { padding-top: 1px; color: var(--slate-muted-text); font-size: 9px; letter-spacing: .04em; }
 .stage-table.editor:focus-visible { outline: 2px solid var(--cyan); outline-offset: 2px; }
 @keyframes staging-active-flash {
   0% { filter: brightness(1); }
@@ -586,7 +586,7 @@ button { font: inherit; }
 .overview-metric-funds { flex: .9 1 150px; }
 .overview-metric-science, .overview-metric-reputation { flex: .6 1 105px; }
 .overview-metric-contracts { flex: 1.5 1 260px; }
-.overview-metrics span, .overview-metrics small { color: var(--slate-dim); font-size: 8px; letter-spacing: .12em; text-transform: uppercase; }
+.overview-metrics span, .overview-metrics small { color: var(--slate-muted-text); font-size: 8px; letter-spacing: .12em; text-transform: uppercase; }
 .overview-metrics strong { overflow: hidden; color: var(--amber); font-size: 20px; font-weight: 500; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .overview-metrics small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .overview-primary-grid { display: grid; min-width: 0; align-items: start; grid-template-columns: minmax(0,1.6fr) minmax(380px,1fr); gap: 12px; }
@@ -595,7 +595,7 @@ button { font: inherit; }
 .overview-side-stack .overview-controls.compact { grid-template-columns: repeat(3,minmax(0,1fr)); }
 .overview-section { min-width: 0; overflow: hidden; border: 1px solid var(--rule); border-radius: 4px; background: linear-gradient(180deg,var(--panel),var(--panel-2)); }
 .overview-section-head { display: flex; min-height: 50px; padding: 9px 12px; align-items: center; justify-content: space-between; gap: 12px; border-bottom: 1px solid var(--rule); }
-.overview-section-head span { color: var(--slate-dim); font-size: 7px; letter-spacing: .16em; }
+.overview-section-head span { color: var(--slate-muted-text); font-size: 8px; letter-spacing: .16em; }
 .overview-section-head h2 { margin: 0; color: var(--amber); font-size: 13px; font-weight: 550; letter-spacing: .08em; text-transform: uppercase; }
 .overview-section-actions { display: flex; min-width: 28px; align-items: center; justify-content: flex-end; gap: 8px; }
 .overview-section-actions > strong { min-width: 28px; color: var(--cyan); font-size: 20px; font-weight: 500; text-align: right; }
@@ -609,27 +609,27 @@ button { font: inherit; }
 .overview-fleet-filter-tray { flex: 0 0 auto; }
 .overview-roster-filter-tray { flex: 0 0 auto; }
 .overview-controls label { display: flex; min-width: 0; flex-direction: column; gap: 3px; }
-.overview-controls label > span { color: var(--slate-dim); font-size: 7px; letter-spacing: .1em; text-transform: uppercase; }
+.overview-controls label > span { color: var(--slate-muted-text); font-size: 8px; letter-spacing: .1em; text-transform: uppercase; }
 .overview-controls input, .overview-controls select, .overview-sort-direction { width: 100%; min-width: 0; height: 28px; padding: 4px 6px; border: 1px solid var(--rule-bright); border-radius: 2px; outline: 0; color: #ccd6e2; background: #080d14; font: 9px var(--mono); }
 .overview-controls input:focus, .overview-controls select:focus, .overview-sort-direction:focus-visible { border-color: var(--cyan); }
 .overview-sort-direction { width: auto; color: var(--cyan); cursor: pointer; }
-.overview-provider-state { align-self: end; padding: 7px 3px; color: var(--slate-dim); font-size: 8px; text-transform: uppercase; white-space: nowrap; }
+.overview-provider-state { align-self: end; padding: 7px 3px; color: var(--slate-muted-text); font-size: 8px; text-transform: uppercase; white-space: nowrap; }
 .overview-table-wrap { min-width: 0; overflow-x: auto; }
 .overview-primary-grid .overview-table-wrap { max-height: clamp(180px,34vh,320px); overflow: auto; overscroll-behavior: contain; }
 .overview-primary-grid .overview-table th { position: sticky; z-index: 1; top: 0; box-shadow: 0 1px 0 var(--rule); }
 .vessel-type-filter { display: flex; min-width: 0; padding: 7px 9px; align-items: center; gap: 3px; overflow-x: auto; border-bottom: 1px solid var(--rule); background: #080d14; scrollbar-width: thin; }
-.vessel-type-filter-label { margin-right: 5px; color: var(--slate-dim); font-size: 7px; letter-spacing: .12em; text-transform: uppercase; white-space: nowrap; }
+.vessel-type-filter-label { margin-right: 5px; color: var(--slate-muted-text); font-size: 8px; letter-spacing: .12em; text-transform: uppercase; white-space: nowrap; }
 .vessel-type-button { position: relative; display: grid; width: 40px; height: 36px; padding: 3px; place-items: center; overflow: hidden; border: 1px solid #243140; border-radius: 2px; color: #607084; background: linear-gradient(180deg,#111923,#080d13); cursor: pointer; flex: 0 0 auto; }
 .vessel-type-button svg { width: 25px; height: 25px; overflow: visible; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
 .vessel-type-button svg text { fill: currentColor; stroke: none; font: 700 12px var(--mono); text-anchor: middle; }
 .vessel-type-button[aria-pressed="true"] { border-color: #39708a; color: var(--cyan); background: linear-gradient(180deg,#173040,#0d1c27); box-shadow: inset 0 0 8px rgba(78,201,224,.08); }
 .vessel-type-button:hover, .vessel-type-button:focus-visible { border-color: var(--cyan); outline: 0; }
 .vessel-type-button:not([aria-pressed="true"]) { opacity: .48; }
-.vessel-type-count { position: absolute; right: 2px; bottom: 1px; min-width: 9px; color: var(--green); font-size: 7px; font-variant-numeric: tabular-nums; line-height: 1; text-align: right; text-shadow: 0 1px 2px #000; }
+.vessel-type-count { position: absolute; right: 2px; bottom: 1px; min-width: 9px; color: var(--green); font-size: 8px; font-variant-numeric: tabular-nums; line-height: 1; text-align: right; text-shadow: 0 1px 2px #000; }
 .vessel-type-all span { color: inherit; font-size: 8px; letter-spacing: .05em; }
 .overview-table { width: 100%; border-collapse: collapse; font-size: 9px; font-variant-numeric: tabular-nums; }
 .overview-table th, .overview-table td { padding: 7px 9px; overflow: hidden; border-bottom: 1px solid var(--rule); text-align: left; text-overflow: ellipsis; white-space: nowrap; }
-.overview-table th { color: var(--slate-dim); background: #080d14; font-size: 7px; font-weight: 500; letter-spacing: .12em; text-transform: uppercase; }
+.overview-table th { color: var(--slate-muted-text); background: #080d14; font-size: 8px; font-weight: 500; letter-spacing: .12em; text-transform: uppercase; }
 .overview-table td { max-width: 190px; color: #aeb9c7; }
 .overview-table td:first-child { color: var(--cyan); }
 .overview-table tbody tr:last-child td { border-bottom: 0; }
@@ -659,14 +659,14 @@ button { font: inherit; }
 .overview-vessel-briefing-copy small { overflow: hidden; color: var(--cyan); font-size: 9px; font-weight: 600; letter-spacing: .05em; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-briefing-type { display: grid; align-self: start; justify-items: end; gap: 5px; }
 .overview-vessel-briefing-type > span:first-child { color: #cbd5df; font-size: 9px; letter-spacing: .08em; text-transform: uppercase; }
-.overview-vessel-briefing-type .overview-detail-badge { padding: 2px 4px; border: 1px solid #5e4726; border-radius: 2px; color: var(--amber); font-size: 7px; letter-spacing: .08em; text-transform: uppercase; }
+.overview-vessel-briefing-type .overview-detail-badge { padding: 2px 4px; border: 1px solid #5e4726; border-radius: 2px; color: var(--amber); font-size: 8px; letter-spacing: .08em; text-transform: uppercase; }
 .overview-vessel-orbit-card { display: grid; min-width: 0; padding: 12px 0; border-bottom: 1px solid var(--rule); }
 .overview-vessel-orbit-data { display: grid; min-width: 0; gap: 8px; }
 .overview-vessel-orbit-data h3 { margin: 0; color: var(--slate); font-size: 9px; font-weight: 500; letter-spacing: .13em; text-transform: uppercase; }
 .overview-vessel-facts { display: grid; min-width: 0; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 0 18px; }
 .overview-vessel-facts > div { display: grid; min-width: 0; min-height: 25px; padding: 4px 2px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 8px; border-bottom: 1px solid rgba(35,58,74,.66); }
 .overview-vessel-facts > div:last-child { border-bottom: 0; }
-.overview-vessel-facts span { overflow: hidden; color: var(--slate-dim); font-size: 8px; letter-spacing: .08em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
+.overview-vessel-facts span { overflow: hidden; color: var(--slate-muted-text); font-size: 8px; letter-spacing: .08em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .overview-vessel-facts strong { overflow: hidden; color: #e4ebf2; font-size: 10px; font-weight: 500; font-variant-numeric: tabular-nums; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-facts-empty { margin: 0; padding: 8px 9px; border: 1px solid var(--rule); color: var(--slate); background: rgba(8,13,20,.48); font-size: 9px; line-height: 1.4; }
 .overview-vessel-crew-summary { display: grid; min-width: 0; padding: 10px 0; gap: 7px; border-bottom: 1px solid var(--rule); }
@@ -676,7 +676,7 @@ button { font: inherit; }
 .overview-vessel-crew-member { display: grid; min-width: 0; padding: 5px 0; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 12px; border-bottom: 1px solid rgba(35,58,74,.42); }
 .overview-vessel-crew-member strong { overflow: hidden; color: #d2dce6; font-size: 11px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-crew-member small { overflow: hidden; max-width: 110px; color: #bcc8d3; font-size: 11px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
-.overview-vessel-crew-summary > p { margin: 0; color: var(--slate-dim); font-size: 7px; }
+.overview-vessel-crew-summary > p { margin: 0; color: var(--slate-muted-text); font-size: 8px; }
 .overview-vessel-next-event { display: grid; min-width: 0; margin-top: 10px; gap: 6px; }
 .overview-vessel-next-event > header { display: flex; align-items: center; }
 .overview-vessel-next-event > header span { color: var(--slate); font-size: 9px; letter-spacing: .1em; text-transform: uppercase; }
@@ -684,7 +684,7 @@ button { font: inherit; }
 .overview-vessel-next-event-row > strong { overflow: hidden; color: var(--text-value); font-size: 11px; font-weight: 550; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-next-event-row time { display: grid; min-width: 0; gap: 3px; text-align: right; }
 .overview-vessel-next-event-row time strong { color: var(--amber); font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.overview-vessel-next-event-row time span { color: var(--slate-dim); font-size: 9px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.overview-vessel-next-event-row time span { color: var(--slate-muted-text); font-size: 9px; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .overview-vessel-actions { display: grid; min-width: 0; margin-top: 16px; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 8px; }
 .overview-vessel-actions.has-lifecycle { grid-template-columns: repeat(3,minmax(0,1fr)); }
 .overview-switch-vessel { min-height: 32px; padding: 5px 9px; border: 1px solid var(--cyan); border-radius: 2px; color: #041016; background: var(--cyan); cursor: pointer; font: 9px var(--mono); font-weight: 650; letter-spacing: .04em; }
@@ -722,7 +722,7 @@ button { font: inherit; }
 .overview-vessel-type-options button[aria-pressed="true"] { border-color: var(--amber); color: var(--amber); background: #2a1d0e; }
 .overview-vessel-type-options svg { width: 22px; height: 22px; fill: none; stroke: currentColor; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
 .overview-vessel-type-options span { overflow: hidden; max-width: 100%; text-overflow: ellipsis; white-space: nowrap; }
-.overview-vessel-modal form > small { color: var(--slate-dim); font-size: 8px; line-height: 1.4; }
+.overview-vessel-modal form > small { color: var(--slate-muted-text); font-size: 8px; line-height: 1.4; }
 .overview-vessel-modal-error { margin: 0; color: var(--error-text-muted); font-size: 8px; line-height: 1.35; }
 .overview-vessel-modal footer { display: flex; justify-content: flex-end; gap: 8px; margin-top: 2px; }
 .overview-vessel-modal footer button { min-height: 31px; padding: 6px 10px; border: 1px solid var(--accent-border); color: var(--slate); background: var(--control-surface); cursor: pointer; font: 9px var(--mono); }
@@ -746,7 +746,7 @@ button { font: inherit; }
 .overview-vessel-recovery-crew ul, .overview-vessel-termination-crew ul { display: grid; max-height: 148px; margin: 0; padding-left: 18px; overflow: auto; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 4px 12px; color: #e0e8ef; font-size: 9px; line-height: 1.35; }
 .overview-vessel-lifecycle-modal.recover footer button:last-child { border-color: var(--green); color: #071208; background: var(--green); }
 .overview-vessel-lifecycle-modal.terminate footer button:last-child { border-color: var(--danger); color: #170707; background: var(--danger); }
-.overview-vessel-detail-empty { display: grid; color: var(--slate-dim); font-size: 9px; place-items: center; text-align: center; }
+.overview-vessel-detail-empty { display: grid; color: var(--slate-muted-text); font-size: 9px; place-items: center; text-align: center; }
 .overview-roster-table-wrap { min-height: 180px; max-height: clamp(220px,38vh,420px); background: #080d14; scrollbar-gutter: stable; overscroll-behavior: contain; }
 .overview-roster-summary { display: flex; min-width: 0; align-items: center; gap: 5px; }
 .overview-roster-summary-chip { display: flex; min-width: 62px; min-height: 24px; padding: 3px 6px; align-items: center; justify-content: space-between; gap: 7px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate); background: #0b1119; }
@@ -769,11 +769,11 @@ button { font: inherit; }
 .overview-roster-name { color: var(--cyan) !important; }
 .honor-row .overview-roster-name { color: #c4a476 !important; }
 .overview-orange-suit-dot { display: inline-block; width: 5px; height: 5px; margin-left: 6px; border: 1px solid #e6a749; border-radius: 50%; background: var(--amber); vertical-align: 1px; }
-.overview-roster-unassigned { color: var(--slate-dim) !important; }
+.overview-roster-unassigned { color: var(--slate-muted-text) !important; }
 .honor-row td { color: #8f8172; }
 .honor-row td:first-child { color: #c4a476; }
 .honor-star { margin-left: 6px; color: var(--amber); font-size: 9px; }
-.overview-empty { margin: 0; padding: 18px; color: var(--slate-dim); font-size: 9px; text-align: center; }
+.overview-empty { margin: 0; padding: 18px; color: var(--slate-muted-text); font-size: 9px; text-align: center; }
 .overview-service-warning { display: flex; min-height: 160px; margin: 0; padding: 22px; align-items: center; justify-content: center; color: var(--slate); text-align: center; flex-direction: column; gap: 7px; }
 .overview-service-warning strong { color: var(--amber); text-transform: uppercase; }
 .overview-service-warning span { max-width: 440px; font-size: 9px; }
@@ -782,7 +782,7 @@ button { font: inherit; }
 .overview-list-card:last-child { border-bottom: 0; }
 .overview-list-card > div { display: flex; min-width: 0; flex-direction: column; gap: 3px; }
 .overview-list-card strong { overflow: hidden; color: var(--text-value); font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
-.overview-list-card span { overflow: hidden; color: var(--slate-dim); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.overview-list-card span { overflow: hidden; color: var(--slate-muted-text); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
 .overview-contract-list { display: flex; min-height: 0; flex-direction: column; }
 .overview-contract-card { border-bottom: 1px solid var(--rule); background: rgba(5,10,15,.2); }
 .overview-contract-card:last-child { border-bottom: 0; }
@@ -796,7 +796,7 @@ button { font: inherit; }
 .overview-contract-card.expanded .overview-contract-title strong { color: var(--cyan); }
 .overview-contract-time { display: flex; min-width: 0; align-items: flex-end; flex-direction: column; gap: 3px; grid-column: auto; text-align: right; }
 .overview-contract-time strong { color: var(--amber); font-size: 11px; font-weight: 650; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.overview-contract-time span { color: var(--slate-dim); font-size: 9px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.overview-contract-time span { color: var(--slate-muted-text); font-size: 9px; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .overview-contract-focus-body { display: grid; min-width: 0; min-height: 0; overflow: hidden; flex: 1 1 auto; grid-template-columns: minmax(240px,.72fr) minmax(0,1.6fr); }
 .overview-contract-focus-list { min-width: 0; min-height: 0; overflow: auto; border-right: 1px solid var(--rule); background: rgba(5,9,14,.4); overscroll-behavior: contain; scrollbar-gutter: stable; }
 .overview-contract-focus-list .overview-contract-card.expanded { border-left: 3px solid var(--cyan); background: rgba(78,201,224,.075); }
@@ -838,14 +838,14 @@ button { font: inherit; }
 .overview-contract-more > p { padding: 11px 12px 13px; }
 .overview-contract-technical > summary span { display: inline-grid; min-width: 20px; min-height: 20px; margin-left: 6px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--amber); place-items: center; }
 .overview-contract-technical-parameters { padding: 10px; }
-.overview-contract-unavailable { color: var(--slate-dim) !important; font-style: italic; }
+.overview-contract-unavailable { color: var(--slate-muted-text) !important; font-style: italic; }
 .transfer-window-body { display: flex; min-width: 0; flex-direction: column; }
 .transfer-window-status { margin: 0; padding: 6px 12px; border-bottom: 1px solid var(--rule); color: var(--amber); background: rgba(78,201,224,.025); font-size: 8px; letter-spacing: .04em; }
 .overview-transfer-grid { display: grid; min-width: 0; grid-template-columns: repeat(auto-fit,minmax(250px,1fr)); gap: 1px; background: var(--rule); }
 .overview-transfer-card { display: grid; min-width: 0; min-height: 68px; padding: 10px 12px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 14px; background: var(--panel); }
 .overview-transfer-card > div { display: grid; min-width: 0; gap: 4px; }
 .overview-transfer-card strong { overflow: hidden; color: var(--text-value); font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
-.overview-transfer-card span { overflow: hidden; color: var(--slate-dim); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.overview-transfer-card span { overflow: hidden; color: var(--slate-muted-text); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
 .overview-transfer-card .overview-transfer-origin,
 .overview-transfer-card .overview-transfer-destination { color: var(--text-value); font-size: 9px; }
 .overview-transfer-card.error { background: rgba(201,104,91,.055); }
@@ -855,7 +855,7 @@ button { font: inherit; }
 .overview-transfer-countdown span { letter-spacing: .06em; }
 .overview-alarm-time { text-align: right; }
 .overview-alarm-time strong { color: var(--amber); font-variant-numeric: tabular-nums; }
-.overview-source { padding: 4px 5px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate) !important; font-size: 7px !important; letter-spacing: .08em; }
+.overview-source { padding: 4px 5px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate) !important; font-size: 8px !important; letter-spacing: .08em; }
 .overview-source.stock { border-color: #385065; color: var(--cyan) !important; }
 .overview-source.kac { border-color: #5e4726; color: var(--amber) !important; }
 .overview-list-card > .overview-alarm-badges { align-items: center; justify-content: flex-start; flex-direction: row; gap: 5px; }
@@ -895,7 +895,7 @@ button { font: inherit; }
 .notes-list-row { display: grid; margin-bottom: 2px; grid-template-columns: minmax(0,1fr) 28px; gap: 3px; }
 .notes-item, .notes-star { min-width: 0; padding: 5px 7px; overflow: hidden; border: 1px solid transparent; border-radius: 2px; color: var(--slate); background: #0b131d; cursor: pointer; font: 9px var(--mono); text-align: left; text-overflow: ellipsis; white-space: nowrap; }
 .notes-item:hover, .notes-item.active { border-color: var(--rule-bright); color: var(--cyan); background: #10202c; }
-.notes-star { padding: 3px; color: var(--slate-dim); text-align: center; }
+.notes-star { padding: 3px; color: var(--slate-muted-text); text-align: center; }
 .notes-star.favorite { color: var(--amber); }
 .notes-item:disabled, .notes-star:disabled { cursor: default; }
 .notes-content { display: flex; min-width: 0; min-height: 0; padding: 14px; overflow: hidden; flex-direction: column; gap: 10px; }
@@ -903,7 +903,7 @@ button { font: inherit; }
 .notes-content-head > div { min-width: 0; }
 .notes-content-head strong, .notes-content-head span { display: block; }
 .notes-content-head strong { color: var(--cyan); font-size: 10px; text-transform: uppercase; }
-.notes-content-head span { margin-top: 3px; overflow: hidden; color: var(--slate-dim); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.notes-content-head span { margin-top: 3px; overflow: hidden; color: var(--slate-muted-text); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
 .notes-log { min-height: 0; margin: 0; padding: 12px; overflow: auto; border: 1px solid var(--rule); border-radius: 3px; color: var(--text-primary); background: #05090d; font-family: var(--mono); line-height: 1.5; white-space: pre-wrap; flex: 1; }
 .notes-empty { display: grid; min-height: 220px; place-content: center; color: var(--slate); text-align: center; }
 .notes-unavailable { display: grid; min-height: 0; padding: 24px; place-content: center; gap: 8px; color: var(--slate); text-align: center; }
@@ -1097,7 +1097,7 @@ button { font: inherit; }
     grid-template-columns: 42px minmax(64px,1fr) minmax(64px,1fr) minmax(86px,1fr) 72px;
   }
 }
-.project-footer { align-items: center; display: flex; flex-wrap: wrap; justify-content: space-between; gap: 4px 16px; max-width: 1180px; margin: 12px auto 2px; padding: 10px 4px 2px; border-top: 1px solid var(--rule); color: var(--slate-dim); font-size: 9px; letter-spacing: .08em; text-align: center; text-transform: uppercase; }
+.project-footer { align-items: center; display: flex; flex-wrap: wrap; justify-content: space-between; gap: 4px 16px; max-width: 1180px; margin: 12px auto 2px; padding: 10px 4px 2px; border-top: 1px solid var(--rule); color: var(--slate-muted-text); font-size: 9px; letter-spacing: .08em; text-align: center; text-transform: uppercase; }
 .planner-persistence-status { color: var(--slate-muted-text); white-space: nowrap; }
 .planner-persistence-status.is-shared { color: var(--green); }
 .planner-persistence-status.is-syncing { color: var(--cyan); }
@@ -1146,9 +1146,9 @@ button { font: inherit; }
 .datalink-event-log li.is-linked::before, .datalink-event-log li.is-fixture::before { background: var(--green); }
 .datalink-event-log li.is-connecting::before { background: var(--amber); }
 .datalink-event-log li.is-retrying::before { background: var(--warn); }
-.datalink-event-log time { color: var(--slate-dim); font-size: 8px; font-variant-numeric: tabular-nums; }
+.datalink-event-log time { color: var(--slate-muted-text); font-size: 8px; font-variant-numeric: tabular-nums; }
 .datalink-event-log li > span { min-width: 0; color: #b8c4d1; font-size: 9px; line-height: 1.35; }
-.datalink-event-empty { margin: 0; padding: 14px 2px; color: var(--slate-dim); font-size: 9px; text-align: center; }
+.datalink-event-empty { margin: 0; padding: 14px 2px; color: var(--slate-muted-text); font-size: 9px; text-align: center; }
 @media (max-width: 540px) {
   .datalink-drawer-body { padding: 12px; }
   .datalink-diagnostics, .datalink-controls { grid-template-columns: minmax(0,1fr); }
@@ -1163,16 +1163,16 @@ button { font: inherit; }
 .clock-primary-row { display: flex; min-width: 0; align-items: baseline; gap: 10px; }
 .clock-primary-row .sub { margin-top: 0; }
 .clockcell .big { color: var(--amber); font-size: 22px; letter-spacing: .04em; font-variant-numeric: tabular-nums; }
-.clockcell .sub { margin-top: 3px; color: var(--slate-dim); font-size: 10px; letter-spacing: .06em; }
+.clockcell .sub { margin-top: 3px; color: var(--slate-muted-text); font-size: 10px; letter-spacing: .06em; }
 .met-cell .big { color: var(--cyan); }
-.calendar-toggle { padding: 0; border: 0; color: var(--slate-dim); background: transparent; cursor: pointer; font: inherit; letter-spacing: inherit; }
+.calendar-toggle { padding: 0; border: 0; color: var(--slate-muted-text); background: transparent; cursor: pointer; font: inherit; letter-spacing: inherit; }
 .calendar-toggle:hover { color: var(--cyan); }
 .comms-strip { display: grid; grid-template-columns: minmax(0,1fr); gap: 1px; border-top: 1px solid var(--rule); background: var(--rule); }
 .comms-strip.remote-tech { grid-template-columns: repeat(2,minmax(0,1fr)); }
 .cs-cell { display: flex; min-width: 0; padding: 8px 12px; background: var(--panel); flex-direction: column; gap: 4px; }
 .cs-status { display: flex; align-items: center; gap: 7px; font-size: 15px; letter-spacing: .04em; }
 .cs-val { overflow: hidden; color: var(--cyan); font-size: 16px; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
-.label-muted { color: var(--slate-dim); }
+.label-muted { color: var(--slate-muted-text); }
 .flight-annunciator { position: relative; display: grid; min-width: 0; padding: 5px 8px; align-items: center; grid-template-columns: 94px minmax(0,1fr); gap: 8px; border-top: 1px solid var(--rule); background: var(--panel); }
 .annunciator-lamp { display: flex; width: 94px; height: 48px; min-width: 94px; padding: 5px 6px; align-items: center; justify-content: center; border: 1px solid #3a4148; border-radius: 3px; color: #65707a; background: linear-gradient(180deg,#171b1e,#0c1013); cursor: pointer; font-family: var(--mono); line-height: 1; flex-direction: column; gap: 4px; }
 .annunciator-lamp span { font-size: 8px; letter-spacing: .16em; }
@@ -1181,7 +1181,7 @@ button { font: inherit; }
 .annunciator-lamp.warning:not(.dark) { border-color: #b74738; color: #200503; background: linear-gradient(180deg,#ff826f,#d84132); box-shadow: 0 0 11px rgba(255,107,91,.62), inset 0 0 7px rgba(255,220,211,.42); }
 .annunciator-lamp:focus-visible { outline: 2px solid var(--cyan); outline-offset: 2px; }
 .annunciator-indicators { display: grid; min-width: 0; align-content: center; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 4px; }
-.annunciator-indicator { min-width: 0; min-height: 22px; padding: 3px 4px; overflow: hidden; border: 1px solid #303944; border-radius: 2px; color: #596572; background: #0b1117; cursor: default; font: 7px var(--mono); font-weight: 700; letter-spacing: .06em; text-overflow: ellipsis; white-space: nowrap; }
+.annunciator-indicator { min-width: 0; min-height: 22px; padding: 3px 4px; overflow: hidden; border: 1px solid #303944; border-radius: 2px; color: var(--slate-muted-text); background: #0b1117; cursor: default; font: 8px var(--mono); font-weight: 700; letter-spacing: .06em; text-overflow: ellipsis; white-space: nowrap; }
 .annunciator-indicator:disabled { opacity: 1; }
 .annunciator-indicator.new { border-color: #b74738; color: #240705; background: linear-gradient(180deg,#ff826f,#d84132); box-shadow: 0 0 8px rgba(255,107,91,.54), inset 0 0 5px rgba(255,220,211,.35); cursor: pointer; }
 .annunciator-indicator.acknowledged { border-color: #8d651a; color: #211503; background: linear-gradient(180deg,#ffd75a,#c98716); box-shadow: 0 0 6px rgba(251,191,36,.32), inset 0 0 4px rgba(255,248,194,.28); }
@@ -1204,8 +1204,8 @@ button { font: inherit; }
 .annunciator-episode.warning .annunciator-episode-head strong { color: var(--warn); }
 .annunciator-episode-head span { color: var(--slate); font-size: 8px; letter-spacing: .1em; text-transform: uppercase; }
 .annunciator-episode p { margin: 6px 0; color: #d6dee8; font-size: 10px; line-height: 1.45; }
-.annunciator-episode small { color: var(--slate-dim); font-size: 8px; letter-spacing: .04em; }
-.annunciator-empty { margin: 0; padding: 14px; border: 1px dashed var(--rule); color: var(--slate-dim); background: #070c12; text-align: center; }
+.annunciator-episode small { color: var(--slate-muted-text); font-size: 8px; letter-spacing: .04em; }
+.annunciator-empty { margin: 0; padding: 14px; border: 1px dashed var(--rule); color: var(--slate-muted-text); background: #070c12; text-align: center; }
 
 /* Flight information rails collapse in place; compact chrome is pointer-aware. */
 :is(.flight-grid,.flight-workspace-shell) .panel-compact > h2 { min-height: 26px; padding: 1px 6px 1px 9px; gap: 8px; font-size: 10px; }
@@ -1243,7 +1243,7 @@ button { font: inherit; }
 .sas-box { display: flex; min-width: 0; min-height: 43px; padding: 8px 10px; border: 1px solid var(--rule); border-radius: 3px; background: var(--panel); align-items: center; justify-content: space-between; gap: 12px; }
 .sas-primary { display: flex; min-width: 0; align-items: baseline; gap: 10px; }
 .sas-val { overflow: hidden; color: var(--green); font-size: 20px; line-height: 1.15; letter-spacing: .02em; text-overflow: ellipsis; white-space: nowrap; }
-.sas-val.off { color: var(--slate-dim); }
+.sas-val.off { color: var(--slate-muted-text); }
 .sas-hint { min-width: 0; overflow: hidden; flex: 0 1 auto; color: var(--slate); font-size: 9px; letter-spacing: .05em; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
 .asc-flight-state { display: flex; min-width: 0; padding-left: 14px; border-left: 1px solid var(--rule); flex-direction: column; gap: 10px; }
 .asc-flight-layout { display: grid; min-width: 0; min-height: 0; flex: 1 1 auto; grid-template-columns: minmax(180px,.92fr) minmax(0,1.5fr); gap: 10px; }
@@ -1253,7 +1253,7 @@ button { font: inherit; }
 .asc-flight-metric.hero { min-height: 88px; border: 0; background: transparent; }
 .asc-flight-value { overflow: hidden; color: var(--amber); font-size: 16px; line-height: 1.1; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .asc-flight-metric.hero .asc-flight-value { font-size: clamp(30px,4.35cqi,40px); }
-.asc-flight-subtitle { overflow: hidden; color: var(--slate-dim); font-size: 9px; letter-spacing: .02em; text-overflow: ellipsis; white-space: nowrap; }
+.asc-flight-subtitle { overflow: hidden; color: var(--slate-muted-text); font-size: 9px; letter-spacing: .02em; text-overflow: ellipsis; white-space: nowrap; }
 .target-metric { position: relative; }
 .target-metric .asc-flight-subtitle { position: absolute; top: 9px; right: 10px; max-width: 48%; text-align: right; }
 .navball-stage { display: grid; width: 100%; min-height: 0; place-items: center; }
@@ -1271,7 +1271,7 @@ button { font: inherit; }
 .heading-tape svg { display: block; width: 196px; height: 20px; }
 .heading-tape rect { fill: var(--instrument-surface); }
 .heading-tape line { stroke: var(--slate-dim); stroke-width: 1; }
-.heading-tape text { fill: var(--slate); font: 7px var(--mono); text-anchor: middle; }
+.heading-tape text { fill: var(--slate); font: 8px var(--mono); text-anchor: middle; }
 .heading-tape text.cardinal { fill: var(--cyan); }
 .heading-tape .tape-pointer { fill: var(--amber); }
 .attitude-strip { display: grid; width: 196px; overflow: hidden; border: 1px solid var(--rule); border-radius: 2px; background: var(--rule); grid-template-columns: repeat(3,minmax(0,1fr)); gap: 1px; }
@@ -1285,7 +1285,7 @@ button { font: inherit; }
 .stats-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; overflow: hidden; border: 1px solid var(--rule); border-radius: 3px; background: var(--rule); }
 .stats-grid .stat { display: flex; min-width: 0; padding: 9px 12px; background: var(--panel); flex-direction: column; gap: 3px; }
 .stats-grid .stat .v { overflow: hidden; color: var(--amber); font-size: 20px; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
-.stat-subtitle { overflow: hidden; color: var(--slate-dim); font-size: 8px; letter-spacing: .03em; text-overflow: ellipsis; white-space: nowrap; }
+.stat-subtitle { overflow: hidden; color: var(--slate-muted-text); font-size: 8px; letter-spacing: .03em; text-overflow: ellipsis; white-space: nowrap; }
 .orbit-rail.stats-grid { grid-template-columns: minmax(0,1fr) minmax(0,1fr) minmax(0,.95fr) minmax(0,1fr) minmax(0,1.18fr) minmax(0,1.18fr) minmax(0,1.18fr); }
 .orbit-rail .stat { justify-content: center; }
 
@@ -1383,7 +1383,7 @@ button { font: inherit; }
 .heat-component-row { display: grid; min-height: 21px; padding: 3px 0; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 10px; border-top: 1px solid var(--rule); color: #a9bfd3; font-size: 9px; }
 .heat-component-copy { display: flex; min-width: 0; align-items: baseline; gap: 7px; }
 .heat-component-copy > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.heat-component-copy small { flex: 0 0 auto; color: #66829d; font-size: 7px; letter-spacing: .08em; text-transform: uppercase; }
+.heat-component-copy small { flex: 0 0 auto; color: #66829d; font-size: 8px; letter-spacing: .08em; text-transform: uppercase; }
 .heat-component-row strong { color: var(--amber); font-weight: 500; font-variant-numeric: tabular-nums; }
 .heat-component-row strong.cooling { color: var(--cyan); }
 .heat-component-row strong.warming { color: var(--amber); }
@@ -1442,12 +1442,12 @@ button { font: inherit; }
 .ec-source-rate > span { text-align: right; }
 .ec-source-output small { color: var(--slate); font-size: 9px; }
 .ec-source-output > small { text-align: right; }
-.ec-source-row.idle :is(.ec-source-copy strong, .ec-source-copy small, .ec-source-output strong, .ec-source-output small) { color: var(--slate-dim); }
+.ec-source-row.idle :is(.ec-source-copy strong, .ec-source-copy small, .ec-source-output strong, .ec-source-output small) { color: var(--slate-muted-text); }
 .rx-detail-view { position: absolute; inset: 0; display: grid; box-sizing: border-box; min-height: 0; overflow: hidden; border: 1px solid var(--rule); border-radius: 4px; background: var(--panel-2); grid-template-rows: auto minmax(0,1fr) auto; }
 .rx-detail-view[hidden], .ec-source-ledger[hidden] { display: none; }
 .rx-detail-back { display: grid; width: 100%; min-height: 31px; padding: 5px 9px; border: 0; align-items: center; grid-template-columns: 16px minmax(0,1fr) auto; gap: 6px; color: var(--slate); background: var(--panel); cursor: pointer; font: 10px var(--mono); letter-spacing: .1em; text-align: left; text-transform: uppercase; }
 .rx-detail-back > span:first-child { color: var(--cyan); font-size: 17px; line-height: 1; }
-.rx-detail-back > span:last-child { color: var(--slate-dim); }
+.rx-detail-back > span:last-child { color: var(--slate-muted-text); }
 .rx-detail-back:hover, .rx-detail-back:focus-visible { color: var(--cyan); background: var(--control-surface-hover); outline: none; }
 .rx-detail-view.warn .rx-detail-back { color: var(--danger); }
 .rx-scroll { min-height: 0; padding: 7px; overflow-y: auto; border-top: 1px solid var(--rule); outline: 0; overscroll-behavior: contain; scrollbar-gutter: stable; }
@@ -1458,13 +1458,13 @@ button { font: inherit; }
 .rx-name { min-width: 0; overflow: hidden; color: var(--slate); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
 .rx-state { padding: 1px 6px; border-radius: 2px; font-size: 9px; letter-spacing: .1em; text-transform: uppercase; }
 .rx-state.on { color: #4ade80; background: rgba(74,222,128,.14); }
-.rx-state.off { color: var(--slate-dim); background: rgba(120,130,145,.14); }
+.rx-state.off { color: var(--slate-muted-text); background: rgba(120,130,145,.14); }
 .rx-state.ready { color: var(--cyan); background: rgba(45,212,191,.14); }
 .rx-state.charging { color: var(--amber); background: rgba(251,191,36,.14); }
 .rx-state.control { border: 1px solid currentColor; cursor: pointer; font-family: var(--mono); }
 .rx-state.control:hover:not(:disabled), .rx-state.control:focus-visible { filter: brightness(1.3); outline: none; }
 .rx-state.control:disabled { cursor: wait; opacity: .6; }
-.rx-charge-row { display: grid; margin-top: 7px; align-items: center; grid-template-columns: auto minmax(48px,1fr) auto; gap: 7px; color: var(--slate-dim); font-size: 9px; }
+.rx-charge-row { display: grid; margin-top: 7px; align-items: center; grid-template-columns: auto minmax(48px,1fr) auto; gap: 7px; color: var(--slate-muted-text); font-size: 9px; }
 .rx-charge-row strong { color: var(--amber); font-weight: 500; font-variant-numeric: tabular-nums; }
 .rx-charge-track { height: 5px; overflow: hidden; border: 1px solid var(--rule-bright); border-radius: 2px; background: var(--instrument-surface); }
 .rx-charge-fill { display: block; height: 100%; background: var(--amber); }
@@ -1472,7 +1472,7 @@ button { font: inherit; }
 .rx-command-result.error { color: var(--danger); }
 .rx-stats { display: grid; margin-top: 6px; grid-template-columns: 1fr 1fr; gap: 2px 12px; }
 .rx-stat { display: flex; min-width: 0; justify-content: space-between; gap: 8px; font-size: 10px; }
-.rx-stat label { color: var(--slate-dim); }
+.rx-stat label { color: var(--slate-muted-text); }
 .rx-stat .rv { min-width: 0; overflow: hidden; color: var(--amber); text-align: right; text-overflow: ellipsis; white-space: nowrap; }
 .flight-workspace-shell[data-arrangement="side-by-side"] #elec:not(.panel-collapsed) {
   display: flex;
@@ -1529,7 +1529,7 @@ button { font: inherit; }
 .sci-banked-value { display: flex; min-width: 0; min-height: 30px; padding: 5px 11px; overflow: hidden; align-items: center; justify-content: flex-end; text-overflow: ellipsis; white-space: nowrap; }
 .sci-experiment-open { display: grid; min-width: 0; min-height: 30px; padding: 5px 8px 5px 11px; align-items: center; grid-template-columns: minmax(0,1fr) auto 10px; gap: 7px; border: 0; border-right: 1px solid var(--rule); color: var(--slate); background: transparent; cursor: pointer; font: 9px var(--mono); letter-spacing: .08em; text-align: left; text-transform: uppercase; }
 .sci-experiment-open > span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.sci-experiment-open > span:nth-child(2) { color: var(--slate-dim); font-size: 10px; font-variant-numeric: tabular-nums; }
+.sci-experiment-open > span:nth-child(2) { color: var(--slate-muted-text); font-size: 10px; font-variant-numeric: tabular-nums; }
 .sci-experiment-open > span:last-child { color: var(--cyan); font-size: 16px; line-height: 1; text-align: center; }
 .sci-experiment-open:hover, .sci-experiment-open:focus-visible { color: var(--cyan); background: var(--control-surface-hover); outline: none; }
 .sci-content-slot { --sci-content-max: min(250px,35vh); min-height: 0; margin-top: 8px; }
@@ -1604,7 +1604,7 @@ button { font: inherit; }
 .sci-experiment-view[hidden] { display: none; }
 .sci-experiment-back { display: grid; width: 100%; min-height: 31px; padding: 5px 9px; align-items: center; grid-template-columns: 16px minmax(0,1fr) auto; gap: 6px; border: 0; color: var(--slate); background: var(--panel); cursor: pointer; font: 10px var(--mono); letter-spacing: .1em; text-align: left; text-transform: uppercase; }
 .sci-experiment-back > span:first-child { color: var(--cyan); font-size: 17px; line-height: 1; }
-.sci-experiment-back > span:last-child { color: var(--slate-dim); font-variant-numeric: tabular-nums; }
+.sci-experiment-back > span:last-child { color: var(--slate-muted-text); font-variant-numeric: tabular-nums; }
 .sci-experiment-back:hover, .sci-experiment-back:focus-visible { color: var(--cyan); background: var(--control-surface-hover); outline: none; }
 .sci-experiment-scroll { min-height: 0; padding: 7px; overflow-y: auto; border-top: 1px solid var(--rule); }
 .sci-list { display: flex; flex-direction: column; gap: 5px; }

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -267,6 +267,11 @@ def dashboard_asset(request_target, web_root=DASHBOARD_WEB_ROOT):
         return HTTPStatus.NOT_FOUND, "text/plain; charset=utf-8", "no-store", b"Not found\n"
 
     media_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    # Python's platform MIME database may report JavaScript as either
+    # text/javascript or application/javascript. Keep the loopback server's
+    # response stable across supported Windows/Python environments.
+    if target.suffix.casefold() == ".js":
+        media_type = "text/javascript"
     if media_type.startswith("text/") or media_type in {
         "application/javascript", "application/json", "image/svg+xml"
     }:

--- a/tests/test_krpc_preflight.py
+++ b/tests/test_krpc_preflight.py
@@ -164,9 +164,17 @@ class KrpcPrerequisiteTests(unittest.TestCase):
             self.assertEqual(inventory["status"], "issues")
             self.assertEqual(len(inventory["embedded_packages"]), 1)
             package = inventory["embedded_packages"][0]
-            self.assertEqual(package["root"], release_root)
-            self.assertEqual(package["release_root"], release_root)
-            self.assertEqual(package["dlls"], [packaged])
+            # Hosted Windows runners may expose the temporary directory through
+            # its 8.3 alias while Path.resolve() returns the long form.
+            self.assertEqual(package["root"].resolve(), release_root.resolve())
+            self.assertEqual(
+                package["release_root"].resolve(),
+                release_root.resolve(),
+            )
+            self.assertEqual(
+                [path.resolve() for path in package["dlls"]],
+                [packaged.resolve()],
+            )
 
             recommendations = app.installation_recommendations(
                 app.ksp_installation_inventory(root),

--- a/tests/test_mock_mission_control.py
+++ b/tests/test_mock_mission_control.py
@@ -43,13 +43,16 @@ class MockMissionControlTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             (root / "index.html").write_text("Mission Control", encoding="utf-8")
+            (root / "app.js").write_text("export {};", encoding="utf-8")
             status, media, cache, body = mock_server.dashboard_asset("/", root)
+            script = mock_server.dashboard_asset("/app.js", root)
             traversal = mock_server.dashboard_asset("/%2e%2e/secret.txt", root)
 
             self.assertEqual(status, HTTPStatus.OK)
             self.assertEqual(media, "text/html; charset=utf-8")
             self.assertEqual(cache, "no-cache")
             self.assertIn(b"Mission Control", body)
+            self.assertEqual(script[1], "text/javascript; charset=utf-8")
             self.assertEqual(traversal[0], HTTPStatus.NOT_FOUND)
 
 

--- a/tools/mock_mission_control_server.py
+++ b/tools/mock_mission_control_server.py
@@ -115,6 +115,10 @@ def dashboard_asset(request_target, web_root):
         return HTTPStatus.NOT_FOUND, "text/plain; charset=utf-8", "no-store", b"Not found\n"
 
     media_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    # Match the production loopback contract even when the host MIME database
+    # registers JavaScript as application/javascript.
+    if target.suffix.casefold() == ".js":
+        media_type = "text/javascript"
     if media_type.startswith("text/") or media_type in {
         "application/javascript", "application/json", "image/svg+xml"
     }:


### PR DESCRIPTION
## Summary

- repair invalid CSS custom-property references and promote repeated exact palette values into shared semantic tokens across both production stylesheets
- raise operational text to an 8 px floor and move readable copy off the low-contrast decorative slate role
- add a dependency-free CSS contract, contributor/design guidance, Unreleased notes, and Windows GitHub CI for Python plus the complete frontend/Chrome/Edge gate

## Why

The dashboard already had a design system, but later CSS accumulated repeated raw colors, undefined properties, and undersized or low-contrast operational text. This reconciles the implementation with the tracked UI authority without flattening legitimate gradients, alpha overlays, instrument geometry, or data-visualization colors.

## Impact

- dashboard-only; no telemetry, kRPC service, DLL, persisted-data, launcher behavior, or product-version changes
- deterministic fixtures remain the visual acceptance surface; live KSP was not required for this scope
- CI is added prospectively; required status checks can be added to the active Protect Main ruleset after the workflow has run

## Validation

- Python: 289/289
- frontend: 43 files / 421 tests
- strict TypeScript and Vite production build
- Chrome and Edge Playwright: 36/36
- rendered Flight, Editor, and Mission Overview fixture review at required viewport matrix
- user Chrome fixture acceptance
- independent read-only audit: COMPLETE, no blocking findings