### PR TITLE
Expose live contract deadlines in Mission Overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable public changes will be recorded here.
 
 ## Unreleased
 
+- Added authoritative live KSP due dates and time remaining to Active Contracts
+  when the new read-only MissionOverview service API is available, while older
+  service installations continue to omit unavailable deadlines safely.
 - Reconciled the dashboard CSS foundation across both active production
   stylesheets: repaired undefined custom-property references, promoted repeated
   exact palette values into shared semantic roles, and added a dependency-free

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable public changes will be recorded here.
 
 ## Unreleased
 
-- Added authoritative live KSP due dates and time remaining to Active Contracts
-  when the new read-only MissionOverview service API is available, while older
-  service installations continue to omit unavailable deadlines safely.
+- Added authoritative live KSP deadlines to Active Contracts when the new
+  read-only MissionOverview service API is available. Compact cards prioritize
+  a low-noise time-remaining countdown, expanded briefings show the absolute
+  due date, and older services continue to omit unavailable deadlines safely.
 - Reconciled the dashboard CSS foundation across both active production
   stylesheets: repaired undefined custom-property references, promoted repeated
   exact palette values into shared semantic roles, and added a dependency-free

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ does not execute nodes, warp, steer, stage, or change throttle.
 
 ## Packaged KSP services
 
-The current release includes four independently versioned kRPC extensions.
-Historical release packs remain pinned to their original service bytes:
+The Unreleased development manifest selects four independently versioned kRPC
+extensions. Published release packs, including v0.5.0 with
+WoobiesControlStats 0.2.6, remain pinned to their original service bytes:
 
 | Service | Selected version | Purpose |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Historical release packs remain pinned to their original service bytes:
 
 | Service | Selected version | Purpose |
 | --- | --- | --- |
-| WoobiesControlStats | 0.2.6 | Roster, stored science, research-lab telemetry and controls, stock thermal data, KAC bridge recovery, and guarded vessel termination |
+| WoobiesControlStats | 0.2.7 | Roster, stored science, research-lab telemetry and controls, stock thermal data, authoritative contract deadlines, KAC bridge recovery, and guarded vessel termination |
 | KRPC.StageStats | 0.2.7 | Flight/editor staging, TWR ranges, and VAB/SPH craft totals |
 | KRPC.SystemHeat | 0.2.9 | System Heat loops, components, electrical integration, reactor control, and guarded per-loop radiator control |
 | KRPC.WoobiesMechJeb | 0.8.6 | MechJeb 2.15.3 staging and transfer-planning bridge |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -31,11 +31,11 @@ versions for Mission Control, then stage exactly that set:
 .\Stage-Selected-Releases.bat
 ```
 
-For Mission Control v0.5.0, the selected set remains:
+The current development manifest selects:
 
 | Service | Release |
 | --- | --- |
-| WoobiesControlStats | 0.2.6 |
+| WoobiesControlStats | 0.2.7 |
 | KRPC.StageStats | 0.2.7 |
 | KRPC.SystemHeat | 0.2.9 |
 | KRPC.WoobiesMechJeb | 0.8.6 |

--- a/frontend/src/components/MissionOverview.test.tsx
+++ b/frontend/src/components/MissionOverview.test.tsx
@@ -190,12 +190,34 @@ describe("MissionOverview", () => {
 
     expect(within(contracts).queryByText("Exploration", { exact: true })).toBeNull();
     expect(within(contracts).queryByText("Satellite", { exact: true })).toBeNull();
-    expect(within(contracts).getAllByText(/Due Y2 · D/)).toHaveLength(3);
+    expect(within(contracts).getAllByText(/^T− \d+d \d+h$/)).toHaveLength(3);
     fireEvent.click(within(contracts).getByRole("button", { name: "Expand contract Explore Duna" }));
+    const detail = contracts.querySelector<HTMLElement>(".overview-contract-focus-reader")!;
+    expect(within(detail).getByText("Due date", { exact: true })).toBeTruthy();
+    expect(within(detail).getByText("Y2 · D186", { exact: true })).toBeTruthy();
+    expect(within(detail).queryByText("Time remaining", { exact: true })).toBeNull();
     expect(within(contracts).getAllByRole("generic", { name: "Completion rewards" })).toHaveLength(1);
     expect(within(contracts).getByText("+185,000", { exact: true })).toBeTruthy();
     expect(within(contracts).getByText("+22", { exact: true })).toBeTruthy();
     expect(within(contracts).getByText("+8", { exact: true })).toBeTruthy();
+  });
+
+  it("keeps compact contract countdowns useful without showing seconds", () => {
+    renderOverview({
+      ...inactiveTelemetryFixture,
+      "t.universalTime": 1_000,
+      "overview.contracts": [
+        { title: "Beyond one day", type: "Test", deadline: 1_000 + 21_600 + 7_200 + 599 },
+        { title: "Inside one day", type: "Test", deadline: 1_000 + 7_200 + 20 * 60 + 59 },
+        { title: "Inside one minute", type: "Test", deadline: 1_059 },
+      ],
+    });
+    const contracts = screen.getByRole("heading", { name: "Active contracts" }).closest("section")!;
+
+    expect(within(contracts).getByText("T− 1d 2h", { exact: true })).toBeTruthy();
+    expect(within(contracts).getByText("T− 2h 20m", { exact: true })).toBeTruthy();
+    expect(within(contracts).getByText("T− <1m", { exact: true })).toBeTruthy();
+    expect(contracts.textContent).not.toMatch(/\d{1,2}:\d{2}:\d{2}/);
   });
 
   it("keeps one contract briefing expanded at a time", async () => {

--- a/frontend/src/components/MissionOverview.tsx
+++ b/frontend/src/components/MissionOverview.tsx
@@ -753,6 +753,24 @@ function formatContractType(type: string) {
   return spaced ? `${spaced.charAt(0).toLocaleUpperCase()}${spaced.slice(1)}` : "Contract";
 }
 
+function formatContractCountdown(deadline: number | null | undefined, universalTime: number | undefined, kerbin: boolean) {
+  if (!isFiniteNumber(deadline) || !isFiniteNumber(universalTime)) return null;
+  const remaining = Math.max(0, deadline - universalTime);
+  if (remaining === 0) return "DUE";
+  const secondsPerDay = kerbin ? 21_600 : 86_400;
+  if (remaining >= secondsPerDay) {
+    const days = Math.floor(remaining / secondsPerDay);
+    const hours = Math.floor((remaining % secondsPerDay) / 3_600);
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (remaining < 60) return "<1m";
+  const totalMinutes = Math.floor(remaining / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `${minutes}m`;
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
 function ContractParameterList({ className, depthOffset = 0, parameters }: { className?: string; depthOffset?: number; parameters: ContractParameter[] }) {
   return <ul className={className}>{parameters.map((parameter, parameterIndex) => <li className={parameter.status} key={`${parameter.title}-${parameterIndex}`} style={{ "--contract-depth": Math.max(0, (parameter.depth ?? 0) - depthOffset) } as CSSProperties}>
     <span aria-label={parameter.status} className="overview-contract-parameter-status" />
@@ -760,7 +778,7 @@ function ContractParameterList({ className, depthOffset = 0, parameters }: { cla
   </li>)}</ul>;
 }
 
-function ContractFocusDetail({ contract, detailsId, kerbin, universalTime }: { contract: OverviewContractTelemetry; detailsId: string; kerbin: boolean; universalTime?: number }) {
+function ContractFocusDetail({ contract, detailsId, kerbin }: { contract: OverviewContractTelemetry; detailsId: string; kerbin: boolean }) {
   const due = isFiniteNumber(contract.deadline) ? formatUniversalTime(contract.deadline, kerbin) : null;
   const parameters = contract.parameters ?? [];
   const shallowParameters = parameters.filter((parameter) => (parameter.depth ?? 0) <= 1);
@@ -770,13 +788,12 @@ function ContractFocusDetail({ contract, detailsId, kerbin, universalTime }: { c
   return <article aria-labelledby={`${detailsId}-title`} className="overview-contract-focus-reader" id={detailsId}>
     <header className="overview-contract-focus-head">
       <div><span>Contract briefing</span><h3 id={`${detailsId}-title`}>{contract.title}</h3></div>
-      {due && <time dateTime={`UT ${contract.deadline}`}><strong>Due {due.big}</strong><span>{due.sub}</span></time>}
     </header>
     <div className="overview-contract-focus-scroll">
       {contract.synopsis && <p className="overview-contract-synopsis">{contract.synopsis}</p>}
       <div className="overview-contract-focus-overview">
         <div><span>Category</span><strong>{formatContractType(contract.type)}</strong></div>
-        {due && <div><span>Time remaining</span><strong>T- {formatMissionDuration(Math.max(0, contract.deadline! - (universalTime ?? contract.deadline!)), kerbin)}</strong></div>}
+        {due && <div><span>Due date</span><strong>{due.big}</strong><small>{due.sub}</small></div>}
         <ContractRewards contract={contract} />
       </div>
       {contract.description && contract.description !== contract.synopsis && <details className="overview-contract-more"><summary>More briefing</summary><p>{contract.description}</p></details>}
@@ -832,7 +849,7 @@ function ContractSection({ rows, universalTime, kerbin, onFocusChange }: { rows:
     const key = contractKey(contract, index);
     const expanded = expandedKey === key;
     const detailsId = `overview-contract-${index}-details`;
-    const due = isFiniteNumber(contract.deadline) ? formatUniversalTime(contract.deadline, kerbin) : null;
+    const countdown = formatContractCountdown(contract.deadline, universalTime, kerbin);
     return <article className={`overview-contract-card${expanded ? " expanded" : ""}`} key={key}>
       <button
         aria-controls={expanded ? detailsId : undefined}
@@ -851,14 +868,14 @@ function ContractSection({ rows, universalTime, kerbin, onFocusChange }: { rows:
       >
         <span aria-hidden="true" className="overview-contract-chevron" />
         <span className="overview-contract-title"><strong>{contract.title}</strong></span>
-        {due && <span className="overview-contract-time"><strong>Due {due.big}</strong><span>{due.sub}</span></span>}
+        {countdown && <span className="overview-contract-time"><strong>T− {countdown}</strong></span>}
       </button>
     </article>;
   })}</div>;
   return <section className={`overview-section overview-contracts${focusedContract ? " focused" : ""}`} ref={sectionRef}>
     <SectionHeader count={rows.length} title="Active contracts">{focusedContract && <button aria-label="Return to contract list" className="overview-header-button" onClick={() => closeFocus()} type="button">BACK</button>}</SectionHeader>
     {rows.length > 0 && (focusedContract
-      ? <div className="overview-contract-focus-body">{contractList}<ContractFocusDetail contract={focusedContract} detailsId={`overview-contract-${focusedIndex}-details`} kerbin={kerbin} key={expandedKey} universalTime={universalTime} /></div>
+      ? <div className="overview-contract-focus-body">{contractList}<ContractFocusDetail contract={focusedContract} detailsId={`overview-contract-${focusedIndex}-details`} kerbin={kerbin} key={expandedKey} /></div>
       : contractList)}
   </section>;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -804,13 +804,10 @@ button { font: inherit; }
 .overview-contract-focus-list .overview-contract-title strong { display: -webkit-box; overflow: hidden; line-height: 1.45; text-overflow: clip; white-space: normal; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
 .overview-contract-focus-list .overview-contract-time { align-items: flex-start; grid-column: 2; text-align: left; }
 .overview-contract-focus-reader { display: grid; min-width: 0; min-height: 0; overflow: hidden; grid-template-rows: auto minmax(0,1fr); background: rgba(2,7,11,.3); }
-.overview-contract-focus-head { display: grid; min-width: 0; min-height: 82px; padding: 13px 16px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 16px; border-bottom: 1px solid var(--rule-bright); background: linear-gradient(90deg,rgba(78,201,224,.075),rgba(8,13,20,.72)); }
+.overview-contract-focus-head { display: grid; min-width: 0; min-height: 82px; padding: 13px 16px; align-items: center; grid-template-columns: minmax(0,1fr); gap: 16px; border-bottom: 1px solid var(--rule-bright); background: linear-gradient(90deg,rgba(78,201,224,.075),rgba(8,13,20,.72)); }
 .overview-contract-focus-head > div { display: grid; min-width: 0; gap: 5px; }
 .overview-contract-focus-head span { color: var(--slate); font-size: 9px; letter-spacing: .12em; text-transform: uppercase; }
 .overview-contract-focus-head h3 { margin: 0; overflow: hidden; color: #e3ebf2; font-size: 16px; font-weight: 560; line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
-.overview-contract-focus-head time { display: grid; align-items: end; gap: 4px; text-align: right; }
-.overview-contract-focus-head time strong { color: var(--amber); font-size: 12px; font-weight: 650; font-variant-numeric: tabular-nums; }
-.overview-contract-focus-head time span { color: var(--slate); font-size: 9px; font-variant-numeric: tabular-nums; }
 .overview-contract-focus-scroll { display: grid; min-width: 0; min-height: 0; padding: 16px 18px 22px; align-content: start; overflow: auto; gap: 14px; overscroll-behavior: contain; scrollbar-gutter: stable; }
 .overview-contract-focus-scroll p { margin: 0; color: #aebdca; font-size: 11px; line-height: 1.58; white-space: pre-line; }
 .overview-contract-focus-scroll .overview-contract-synopsis { color: #dde6ee; font-size: 12px; font-weight: 500; line-height: 1.55; }
@@ -818,6 +815,7 @@ button { font: inherit; }
 .overview-contract-focus-overview > div:not(.overview-contract-rewards) { display: grid; min-width: 145px; gap: 4px; }
 .overview-contract-focus-overview > div > span { color: var(--slate); font-size: 8px; letter-spacing: .11em; text-transform: uppercase; }
 .overview-contract-focus-overview > div > strong { color: var(--cyan); font-size: 11px; font-weight: 550; }
+.overview-contract-focus-overview > div > small { color: var(--slate-muted-text); font-size: 9px; font-variant-numeric: tabular-nums; }
 .overview-contract-focus-overview .overview-contract-rewards { display: flex; min-width: 0; margin-left: auto; flex-flow: row wrap; justify-content: flex-end; gap: 5px 16px; }
 .overview-contract-rewards span { color: var(--slate); }
 .overview-contract-rewards strong { color: var(--cyan); }

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -117,7 +117,7 @@ SERVICE_DLLS = (
     ("KRPC.WoobiesMechJeb", "Mission planning / MechJeb bridge"),
 )
 SERVICE_TESTED_VERSIONS = {
-    "WoobiesControlStats": "0.2.6",
+    "WoobiesControlStats": "0.2.7",
     "KRPC.StageStats": "0.2.7",
     "KRPC.SystemHeat": "0.2.9",
     "KRPC.WoobiesMechJeb": "0.8.6",

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -3713,7 +3713,35 @@ def _gather_overview_fleet(sc):
     }
 
 
-def _gather_overview_contracts(sc):
+def _overview_contract_deadline(contract, mission_overview=None):
+    if mission_overview is not None:
+        schema = _overview_value(
+            mission_overview, "contract_deadline_schema"
+        )
+        if (
+            isinstance(schema, int)
+            and not isinstance(schema, bool)
+            and schema >= 1
+        ):
+            try:
+                deadline = _overview_finite_float(
+                    mission_overview.contract_deadline(contract)
+                )
+                if deadline is not None and deadline > 0:
+                    return deadline
+            except Exception:
+                pass
+
+    for attribute in ("date_deadline", "deadline"):
+        deadline = _overview_finite_float(
+            _overview_value(contract, attribute)
+        )
+        if deadline is not None and deadline > 0:
+            return deadline
+    return None
+
+
+def _gather_overview_contracts(sc, mission_overview=None):
     manager = _overview_value(sc, "contract_manager")
     if manager is None:
         return {
@@ -3731,13 +3759,7 @@ def _gather_overview_contracts(sc):
     }
     active_rows = []
     for contract in groups["active"]:
-        deadline = _overview_finite_float(
-            _overview_value(contract, "date_deadline")
-        )
-        if deadline is None:
-            deadline = _overview_finite_float(
-                _overview_value(contract, "deadline")
-            )
+        deadline = _overview_contract_deadline(contract, mission_overview)
         row = {
             "title": (
                 _overview_contract_text(contract, "title", 512) or
@@ -3939,6 +3961,7 @@ def _gather_overview_telemetry(conn, scene, now=None):
     }
     try:
         sc = conn.space_center
+        mission_overview = _overview_value(conn, "mission_overview")
         current_ut = sc.ut
         data["t.universalTime"] = current_ut
         if _overview_last_ut is not None and current_ut < _overview_last_ut:
@@ -3962,7 +3985,7 @@ def _gather_overview_telemetry(conn, scene, now=None):
         ("fleet", fleet_interval,
          lambda: _gather_overview_fleet(sc)),
         ("contracts", OVERVIEW_CONTRACTS_POLL_SECONDS,
-         lambda: _gather_overview_contracts(sc)),
+         lambda: _gather_overview_contracts(sc, mission_overview)),
         ("roster", OVERVIEW_ROSTER_POLL_SECONDS,
          lambda: _gather_overview_roster(conn)),
     )

--- a/tests/test_mission_overview_telemetry.py
+++ b/tests/test_mission_overview_telemetry.py
@@ -32,6 +32,22 @@ class MissionOverviewService:
     def roster_flight_counts(self): return [5, 11]
 
 
+class ContractDeadlineService:
+    available = True
+    contract_deadline_schema = 1
+
+    def __init__(self, deadline=None, error=None):
+        self.deadline = deadline
+        self.error = error
+        self.contracts = []
+
+    def contract_deadline(self, contract):
+        self.contracts.append(contract)
+        if self.error is not None:
+            raise self.error
+        return self.deadline
+
+
 class VesselManagementService:
     available = True
 
@@ -587,6 +603,66 @@ class MissionOverviewTelemetryTests(unittest.TestCase):
             },
         ])
 
+    def test_contract_deadline_prefers_exact_custom_service_contract(self):
+        contract = SimpleNamespace(
+            title="Explore Duna",
+            type="ContractType.exploration",
+            parameters=[],
+        )
+        service = ContractDeadlineService(deadline=13_200_000.0)
+        manager = SimpleNamespace(
+            active_contracts=[contract], offered_contracts=[],
+            completed_contracts=[], failed_contracts=[],
+        )
+
+        row = telemetry_server._gather_overview_contracts(
+            SimpleNamespace(contract_manager=manager), service
+        )["overview.contracts"][0]
+
+        self.assertEqual(row["deadline"], 13_200_000.0)
+        self.assertEqual(service.contracts, [contract])
+
+    def test_contract_deadline_retains_old_service_property_fallback(self):
+        contract = SimpleNamespace(
+            title="Legacy relay contract",
+            type="ContractType.satellite",
+            date_deadline=10_800_000.0,
+            parameters=[],
+        )
+        manager = SimpleNamespace(
+            active_contracts=[contract], offered_contracts=[],
+            completed_contracts=[], failed_contracts=[],
+        )
+
+        row = telemetry_server._gather_overview_contracts(
+            SimpleNamespace(contract_manager=manager), MissionOverviewService()
+        )["overview.contracts"][0]
+
+        self.assertEqual(row["deadline"], 10_800_000.0)
+
+    def test_contract_deadline_omits_invalid_or_failed_service_values(self):
+        contract = SimpleNamespace(
+            title="Evergreen contract",
+            type="ContractType.configured",
+            parameters=[],
+        )
+        manager = SimpleNamespace(
+            active_contracts=[contract], offered_contracts=[],
+            completed_contracts=[], failed_contracts=[],
+        )
+        services = (
+            ContractDeadlineService(deadline=float("nan")),
+            ContractDeadlineService(deadline=0),
+            ContractDeadlineService(error=RuntimeError("stale contract")),
+        )
+
+        for service in services:
+            with self.subTest(service=service):
+                row = telemetry_server._gather_overview_contracts(
+                    SimpleNamespace(contract_manager=manager), service
+                )["overview.contracts"][0]
+                self.assertIsNone(row["deadline"])
+
     def test_contract_text_strips_markup_without_removing_numeric_comparisons(self):
         contract = SimpleNamespace(
             title="<b>Low flight</b>",
@@ -642,6 +718,41 @@ class MissionOverviewTelemetryTests(unittest.TestCase):
 
         refreshed = telemetry_server._gather_overview_telemetry(conn, "GameScene.space_center", now=102.1)
         self.assertEqual(refreshed["overview.funds"], 300000)
+
+    def test_contract_poll_uses_and_caches_custom_service_deadline(self):
+        conn = fake_connection()
+        contract = SimpleNamespace(
+            title="Explore Duna",
+            type="ContractType.exploration",
+            parameters=[],
+        )
+        conn.space_center.contract_manager.active_contracts = [contract]
+        conn.mission_overview = ContractDeadlineService(deadline=13_200_000.0)
+
+        first = telemetry_server._gather_overview_telemetry(
+            conn, "GameScene.space_center", now=100
+        )
+        self.assertEqual(
+            first["overview.contracts"][0]["deadline"], 13_200_000.0
+        )
+        self.assertEqual(conn.mission_overview.contracts, [contract])
+
+        conn.mission_overview.deadline = 14_400_000.0
+        cached = telemetry_server._gather_overview_telemetry(
+            conn, "GameScene.space_center", now=101
+        )
+        self.assertEqual(
+            cached["overview.contracts"][0]["deadline"], 13_200_000.0
+        )
+        self.assertEqual(conn.mission_overview.contracts, [contract])
+
+        refreshed = telemetry_server._gather_overview_telemetry(
+            conn, "GameScene.space_center", now=110.1
+        )
+        self.assertEqual(
+            refreshed["overview.contracts"][0]["deadline"], 14_400_000.0
+        )
+        self.assertEqual(conn.mission_overview.contracts, [contract, contract])
 
 
 if __name__ == "__main__":

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -212,15 +212,23 @@ class ReleaseContractTests(unittest.TestCase):
         v050_product, v050_services = read_manifest(
             ROOT / "tools" / "Release-Pack-v0.5.0.psd1"
         )
-        manifest_product, manifest_services = read_manifest(
-            ROOT / "tools" / "Release-Manifest.psd1"
-        )
 
         self.assertEqual(v044_product, "0.4.4")
         self.assertEqual(v050_product, "0.5.0")
-        self.assertEqual(manifest_product, "0.5.0")
         self.assertEqual(v050_services, v044_services)
-        self.assertEqual(manifest_services, v050_services)
+
+    def test_development_manifest_records_contract_deadline_service_source(self):
+        manifest = (
+            ROOT / "tools" / "Release-Manifest.psd1"
+        ).read_text(encoding="utf-8")
+
+        self.assertRegex(
+            manifest,
+            r'(?s)Folder = "WoobiesControlStats".*?'
+            r'Version = "0\.2\.7\.0".*?'
+            r'Sha256 = "712A058862C78691B2CB4351E6DD0E554E391C517C2531090DBB57009C605A14".*?'
+            r'SourceCommit = "56723004f10c422686a96775f98978302900a9b4"',
+        )
 
     def test_product_versions_and_service_selection_are_aligned(self):
         spec = importlib.util.spec_from_file_location(

--- a/tools/Release-Manifest.psd1
+++ b/tools/Release-Manifest.psd1
@@ -4,9 +4,10 @@
         @{
             Folder = "WoobiesControlStats"
             File = "WoobiesControlStats.dll"
-            Version = "0.2.6.0"
-            Sha256 = "B6041F1D8C403C82342B8288B86BEA6139E7949E808E6DD27CC471F73A32A088"
+            Version = "0.2.7.0"
+            Sha256 = "712A058862C78691B2CB4351E6DD0E554E391C517C2531090DBB57009C605A14"
             License = "MIT"
+            SourceCommit = "56723004f10c422686a96775f98978302900a9b4"
         }
         @{
             Folder = "KRPC.StageStats"


### PR DESCRIPTION
## Summary

- consume an additive MissionOverview API that resolves deadlines from the exact stock kRPC contract proxy
- preserve older, missing, malformed, and stale-service fallback behavior
- show a low-noise remaining-time countdown in compact contract rows and the absolute KSP due date in expanded briefings
- select the independently versioned WoobiesControlStats 0.2.7 artifact

## Why

Stock kRPC 0.5.4 does not expose KSP's contract deadline on its public Contract API, even though the wrapped KSP contract object contains the authoritative value. Mission Control's existing optional-property probes therefore omitted live due dates. The new read-only service procedure accepts the exact stock proxy and rejects stale, inactive, mismatched, null, and invalid inputs instead of attempting title- or order-based matching.

## Service integration

- WoobiesControlStats: 0.2.7.0
- implementation source commit: `56723004f10c422686a96775f98978302900a9b4`
- builder review/test head: `d1a24cfeafbea5c9b6e94b5a5213b5a9c886215c`
- DLL SHA-256: `712A058862C78691B2CB4351E6DD0E554E391C517C2531090DBB57009C605A14`
- StageStats 0.2.7, SystemHeat 0.2.9, and WoobiesMechJeb 0.8.6 remain unchanged

## Validation

- MissionOverview service contract harness: 11 checks passed against real local KSP and stock kRPC types
- standalone MissionOverview service build: passed with zero warnings
- four-service builder verification: passed with exact selected hashes
- Python: 294 tests passed
- CSS contract: passed
- frontend: 422 tests passed
- strict TypeScript/Vite production build: passed
- launcher `--check`: Dashboard and ESP32 Controlpad ready

The local Playwright run executed all 36 Chrome/Edge cases without an assertion failure but hung during runner shutdown, so the hosted workflow remains the authoritative browser result for this branch.

## Manual acceptance

In a live Career save after installing WoobiesControlStats 0.2.7 and restarting KSP, the one active finite-deadline contract resolved to UT `9,228,507`. Its compact row showed the Kerbin countdown without seconds, its expanded briefing showed `Y2 · D2` / `01:28:27 · UT 9,228,507`, and two contracts without deadlines remained silent. The live Chrome console had no warnings or errors, and the compact and expanded states received user visual acceptance.

The product version remains intentionally unselected until this feature is merged and the release scope is frozen.

Closes #35