### PR TITLE
Publish v0.5.1 README status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Woobie's Mission Control
 
-Current public release: **v0.5.0**
-
-Next release candidate: **v0.5.1**
+Current public release: **[v0.5.1](https://github.com/SacredWoobie/woobies-mission-control/releases/tag/v0.5.1)**
 
 Woobie's Mission Control is a local browser dashboard and mission-planning
 workspace for Kerbal Space Program 1. It uses kRPC for live game data and serves
@@ -113,8 +111,8 @@ does not execute nodes, warp, steer, stage, or change throttle.
 
 ## Packaged KSP services
 
-The v0.5.1 release candidate selects four independently versioned kRPC
-extensions. Published release packs, including v0.5.0 with
+The v0.5.1 public release selects four independently versioned kRPC extensions.
+Earlier release packs, including v0.5.0 with
 WoobiesControlStats 0.2.6, remain pinned to their original service bytes:
 
 | Service | Selected version | Purpose |

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -273,6 +273,19 @@ class ReleaseContractTests(unittest.TestCase):
             launcher.SERVICE_TESTED_VERSIONS,
         )
 
+    def test_readme_identifies_the_current_public_release(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn(
+            "Current public release: **[v0.5.1]"
+            "(https://github.com/SacredWoobie/woobies-mission-control/"
+            "releases/tag/v0.5.1)**",
+            readme,
+        )
+        self.assertIn("The v0.5.1 public release selects", readme)
+        self.assertNotIn("Next release candidate", readme)
+        self.assertNotIn("v0.5.1 release candidate", readme)
+
     def test_only_react_loopback_runtime_is_supported(self):
         self.assertFalse((ROOT / "ksp_mission_dashboard.html").exists())
         self.assertFalse((ROOT / "Start React POC.bat").exists())


### PR DESCRIPTION
## Summary

- identify v0.5.1 as the current public release in the tracked README
- replace release-candidate wording while preserving the historical v0.5.0 service-byte note
- add a release-contract regression test for public-version wording and links

## Why

The v0.5.1 draft is fully validated and approved for publication. The repository README must no longer describe it as a candidate once the public release is published.

## User impact

The repository landing page points users to the correct public v0.5.1 release and accurately describes the packaged WoobiesControlStats 0.2.7 service set. Product behavior and release assets are unchanged by this PR.

## Validation

- independent documentation/version audit: COMPLETE
- focused release contracts: 19/19
- diff check: passed
- version and service authorities remain aligned
- no candidate, WIP, unreleased, service, package, or product-code drift