### PR TITLE
Add managed runtime updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable public changes will be recorded here.
 
 ## Unreleased
 
+- Added an explicitly confirmed in-app updater for updater-capable release
+  packages. It accepts only stable immutable GitHub releases, verifies the
+  runtime archive against GitHub's SHA-256 digest and its checksum sidecar,
+  preserves user-owned package state, and uses an external transactional
+  helper with automatic rollback and next-launch recovery. The first release
+  containing the updater still requires one normal full-package install, and
+  the updater never writes the user's selected live KSP `GameData` folder.
+
 ## v0.6.0 - kRPC 0.6 and faster Flight telemetry
 
 - Reduced recurring RemoteTech telemetry work by reusing each confirmed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable public changes will be recorded here.
   packages. It accepts only stable immutable GitHub releases, verifies the
   runtime archive against GitHub's SHA-256 digest and its checksum sidecar,
   preserves user-owned package state, and uses an external transactional
-  helper with automatic rollback and next-launch recovery. The first release
+  helper with identity-bound process handoff, complete component-tree shutdown,
+  automatic rollback, and next-launch recovery. The first release
   containing the updater still requires one normal full-package install, and
   the updater never writes the user's selected live KSP `GameData` folder.
 

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -43,6 +43,18 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    launcher provides the official download address and can be run again after
    Python is installed.
 
+   UPDATES: The first release that includes managed updates must still be
+   downloaded and extracted once as a complete ZIP. After that, a newer
+   verified release shows Review & install in this window. Mission Control
+   downloads the smaller runtime-update asset, lets you review its notes and
+   local managed-file changes, and changes nothing until you choose Install
+   and restart. It preserves this package's .venv, logs, settings, README,
+   gallery, and unknown files. It may refresh only the service repair copies
+   inside this package; it never updates the selected live KSP GameData folder.
+   If verification, the health check, or restart fails, the updater restores
+   the previous managed files and retries recovery before the next normal
+   launch. View release remains available for a manual full-ZIP update.
+
 3. SELECT KSP AND INSTALL THE SERVICES
 
    Before starting KSP, choose the main Kerbal Space Program installation

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ service copies that would otherwise register the same kRPC API twice. Load a
 save before testing the connection; kRPC normally stops its servers at KSP's
 main menu.
 
+Updater-capable packages add a **Review & install** action when a newer stable,
+immutable release passes GitHub digest, checksum, archive, and compatibility
+verification. The first such release is still a normal full-ZIP install. Later
+updates replace only manifest-owned package runtime and repair-copy files, with
+an external helper, complete touched-file backup, health check, restart
+acknowledgement, and automatic rollback/recovery. Package `.venv`, local app
+data, logs, README/gallery files, and unknown files are preserved, and this
+flow never writes the selected live KSP `GameData` folder.
+
 The accepted local endpoints are:
 
 | Purpose | Address or port |

--- a/Start KSP Dashboard.bat
+++ b/Start KSP Dashboard.bat
@@ -14,6 +14,10 @@ set "DASHBOARD_REQUIREMENTS=%~dp0requirements-dashboard.txt"
 set "PANEL_REQUIREMENTS=%~dp0requirements-panel.txt"
 set "SETUP_MENU=%~dp0Select Mission Control Setup.ps1"
 set "SETUP_LOG=%~dp0mission_control_setup.log"
+set "PACKAGE_ROOT=%~dp0.."
+set "UPDATE_HELPER=%~dp0runtime_update_helper.py"
+set "INSTALL_MANIFEST=%~dp0..\WMC-INSTALL-MANIFEST.json"
+set "ACTIVE_UPDATE=%~dp0..\.wmc-update\active.json"
 set "SETUP_ONLY="
 set "SETUP_SELECTION="
 set "SETUP_REQUIREMENTS="
@@ -42,7 +46,7 @@ if not "%~1"=="" (
 )
 
 call :launcher_ready
-if not errorlevel 1 goto launch
+if not errorlevel 1 goto prepare_launch
 
 echo.
 echo Woobie's Mission Control needs a one-time setup.
@@ -141,6 +145,15 @@ echo Setup complete. Your system Python installation was not changed.
 
 if defined SETUP_ONLY exit /b 0
 
+:prepare_launch
+if exist "%INSTALL_MANIFEST%" goto prepare_managed_launch
+if not exist "%ACTIVE_UPDATE%" goto launch
+
+:prepare_managed_launch
+if not exist "%UPDATE_HELPER%" goto update_recovery_failed
+"%VENV_PYTHON%" "%UPDATE_HELPER%" prepare-launch "%PACKAGE_ROOT%"
+if errorlevel 1 goto update_recovery_failed
+
 :launch
 if exist "%VENV_PYTHONW%" (
     start "" "%VENV_PYTHONW%" "%APP%"
@@ -160,16 +173,25 @@ exit /b 1
 echo Checking Woobie's Mission Control without changing any files...
 echo.
 call :launcher_ready
-if not errorlevel 1 (
-    echo READY: The local Mission Control environment is available.
-    "%VENV_PYTHON%" --version
-    call :dashboard_ready
-    if errorlevel 1 (echo Dashboard: NOT SET UP) else (echo Dashboard: READY)
-    call :panel_ready
-    if errorlevel 1 (echo ESP32 Controlpad: NOT SET UP) else (echo ESP32 Controlpad: READY)
-    exit /b 0
-)
+if errorlevel 1 goto check_not_ready
+if exist "%INSTALL_MANIFEST%" goto check_managed_runtime
+if exist "%ACTIVE_UPDATE%" goto check_managed_runtime
+goto check_components
 
+:check_managed_runtime
+call :runtime_update_ready
+if errorlevel 1 exit /b 3
+
+:check_components
+echo READY: The local Mission Control environment is available.
+"%VENV_PYTHON%" --version
+call :dashboard_ready
+if errorlevel 1 (echo Dashboard: NOT SET UP) else (echo Dashboard: READY)
+call :panel_ready
+if errorlevel 1 (echo ESP32 Controlpad: NOT SET UP) else (echo ESP32 Controlpad: READY)
+exit /b 0
+
+:check_not_ready
 if exist "%VENV_PYTHON%" (
     echo INCOMPLETE: A local environment exists, but required packages are missing.
 ) else (
@@ -199,6 +221,23 @@ exit /b %errorlevel%
 if not exist "%VENV_PYTHON%" exit /b 1
 "%VENV_PYTHON%" -c "import importlib.metadata as m, krpc, google.protobuf, serial; expected={'krpc':'0.6.0','protobuf':'7.35.1','pyserial':'3.5'}; raise SystemExit(0 if all(m.version(name) == version for name, version in expected.items()) else 1)" >nul 2>&1
 exit /b %errorlevel%
+
+:runtime_update_ready
+if not exist "%UPDATE_HELPER%" (
+    echo Runtime updater: MISSING
+    exit /b 1
+)
+if defined WMC_UPDATE_TRANSACTION (
+    "%VENV_PYTHON%" "%UPDATE_HELPER%" status "%PACKAGE_ROOT%" --transaction-token "%WMC_UPDATE_TRANSACTION%"
+) else (
+    "%VENV_PYTHON%" "%UPDATE_HELPER%" status "%PACKAGE_ROOT%"
+)
+if errorlevel 1 (
+    echo Runtime updater: RECOVERY REQUIRED
+    exit /b 1
+)
+echo Runtime updater: READY
+exit /b 0
 
 :find_python
 py -3.14 -c "import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 14) else 1)" >nul 2>&1
@@ -242,6 +281,15 @@ if exist "%ProgramFiles%\Python314\python.exe" (
 )
 
 exit /b 1
+
+:update_recovery_failed
+echo.
+echo ERROR: Mission Control could not safely finish or recover a pending update.
+echo No normal components were started.
+echo Review the update log under:
+echo "%PACKAGE_ROOT%\.wmc-update"
+pause
+exit /b 3
 
 :python_missing
 echo.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -107,8 +107,9 @@ The packager:
 - stages five curated standalone screenshot assets using names that sort after
   the ZIP and checksum in GitHub's release asset list;
 - audits both ZIPs for exact manifest membership, hashes, missing files, and
-  forbidden source/build artifacts, and requires the update ZIP to be smaller
-  than the full package.
+  forbidden source/build artifacts; applies the shared
+  `runtime-update-contract.json` path and archive-size limits; and requires the
+  update ZIP to be smaller than the full package.
 
 The end-user package contains the compiled `Dashboard\web` directory, never
 the frontend source, Node.js, Vite, pnpm, tests, or developer fixtures.
@@ -137,8 +138,9 @@ Before creating a GitHub draft:
   successful update and restart acknowledgement, cancellation without package
   mutation, rejection of mutable/tampered/wrong-host assets, rollback after a
   locked file or injected mid-apply failure, recovery after helper termination,
-  preservation of `.venv`/settings/logs/unknown files, and an unchanged
-  disposable live-KSP sentinel tree;
+  PID-reuse-safe launcher/helper identity, complete owned component-tree
+  shutdown, preservation of `.venv`/settings/logs/unknown files, and an
+  unchanged disposable live-KSP sentinel tree;
 - follow `docs/images/v0.6.0/README.md` for the screenshot set and
   its source briefs.
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -99,13 +99,24 @@ The packager:
   a separate release asset;
 - packages the consolidated third-party software notices;
 - creates an unpacked allowlisted package under `release-output`;
-- creates the ZIP, checksum, generated build information, and release notes;
+- creates the full ZIP, checksum, generated build information, and release
+  notes;
+- writes `WMC-INSTALL-MANIFEST.json` into the full package and creates one
+  universal `.zz-90-runtime-update.zip` plus `.sha256` sidecar containing only
+  the product-managed runtime, legal notices, and packaged DLL repair copies;
 - stages five curated standalone screenshot assets using names that sort after
   the ZIP and checksum in GitHub's release asset list;
-- audits the ZIP for missing files and forbidden source/build artifacts.
+- audits both ZIPs for exact manifest membership, hashes, missing files, and
+  forbidden source/build artifacts, and requires the update ZIP to be smaller
+  than the full package.
 
 The end-user package contains the compiled `Dashboard\web` directory, never
 the frontend source, Node.js, Vite, pnpm, tests, or developer fixtures.
+The updater-managed manifest deliberately excludes `.venv`, launcher/setup
+logs, README and gallery files, local application data, and unknown files.
+Those remain user-owned. The package's four `GameData` service folders are
+managed repair copies; the updater never follows the launcher's selected KSP
+path or writes live KSP `GameData`.
 
 ## 4. Acceptance test the unpacked package
 
@@ -122,8 +133,22 @@ Before creating a GitHub draft:
 - verify Notes, KAC/stock alarms, stock/System Heat selection, reconnects,
   collapsed panels, planner persistence, transfer preview/confirmation, and
   launcher update/preflight behavior as applicable;
+- run the deterministic two-version updater acceptance fixture: verify a
+  successful update and restart acknowledgement, cancellation without package
+  mutation, rejection of mutable/tampered/wrong-host assets, rollback after a
+  locked file or injected mid-apply failure, recovery after helper termination,
+  preservation of `.venv`/settings/logs/unknown files, and an unchanged
+  disposable live-KSP sentinel tree;
 - follow `docs/images/v0.6.0/README.md` for the screenshot set and
   its source briefs.
+
+The first updater-capable public release cannot update from an older package,
+because those packages do not contain the trusted helper or install manifest.
+Install that release once through the normal full ZIP. Before it is published,
+the synthetic predecessor/current-candidate fixture is the required proof that
+its shipped updater can perform the future transaction. After the next release
+exists, add one public first-release-to-successor smoke test; do not create a
+fake public release or point production code at a test channel.
 
 Version 0.6.0 retains the current Mission Control, contract, Editor, and Flight
 Plan captures and refreshes the Flight Monitor slot with a managed-mock Chrome
@@ -140,7 +165,17 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\Publish-Release.
 ```
 
 This creates a draft GitHub Release and uploads the ZIP, checksum, GPL source
-archive, and five curated screenshots. The screenshot filenames use a `.zz-01`
-through `.zz-05` suffix so `Woobies-Mission-Control-v0.6.0.zip` remains the
-first release asset. Review the draft, its generated notes, asset ordering,
-source archive, and final screenshots before publishing it.
+archive, runtime-update ZIP and checksum, and five curated screenshots. The
+screenshot filenames use a `.zz-01` through `.zz-05` suffix and the updater uses
+`.zz-90`, so `Woobies-Mission-Control-v0.6.0.zip` remains the first release
+asset. Review the draft, its generated notes, asset ordering, source archive,
+update manifests/checksums, and final screenshots before publishing it.
+
+GitHub immutable releases must be enabled for the repository before this
+command will create a draft. This is a deliberate manual repository-setting
+decision; the script verifies the setting but never enables it. Attach every
+asset while the release is a draft, then publish it. After publication, verify
+through the GitHub API that the stable release reports `immutable: true`, both
+runtime-update assets report `state: uploaded` and `sha256:` digests, and the
+launcher sees the same canonical tag and asset names. If any check fails, the
+launcher must retain its manual **View release** fallback and must not install.

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -3812,6 +3812,16 @@ class App:
             except tk.TclError:
                 self.update_install_dialog = None
 
+        # The update decision owns the launcher while it is visible.  In
+        # particular, do not leave a changelog grab/focus chain behind if a
+        # staged update becomes ready while that secondary window is open.
+        if self.changelog_dialog is not None:
+            try:
+                if self.changelog_dialog.winfo_exists():
+                    self._close_changelog()
+            except tk.TclError:
+                self.changelog_dialog = None
+
         dialog = tk.Toplevel(self.root)
         self.update_install_dialog = dialog
         dialog.title(f"Install {staged['release']['tag_name']} - {APP_NAME}")
@@ -3896,14 +3906,21 @@ class App:
             footer, text="Cancel", width=10, command=self._cancel_staged_update
         )
         self.update_cancel_button.pack(side="right")
+        self.update_cancel_button.bind(
+            "<Return>", lambda _event: self._cancel_staged_update()
+        )
         self.update_confirm_button = ttk.Button(
             footer,
             text="Install and restart",
             command=self._install_staged_update,
         )
         self.update_confirm_button.pack(side="right", padx=(0, 8))
+        self.update_confirm_button.bind(
+            "<Return>", lambda _event: self._install_staged_update()
+        )
 
         dialog.protocol("WM_DELETE_WINDOW", self._cancel_staged_update)
+        dialog.bind("<Escape>", lambda _event: self._cancel_staged_update())
         dialog.update_idletasks()
         x = self.root.winfo_rootx() + max(
             0, (self.root.winfo_width() - dialog.winfo_width()) // 2
@@ -3913,6 +3930,7 @@ class App:
         )
         dialog.geometry(f"{dialog.winfo_width()}x{dialog.winfo_height()}+{x}+{y}")
         dialog.grab_set()
+        dialog.lift()
         self.update_confirm_button.focus_set()
 
     def _cancel_staged_update(self):
@@ -4072,6 +4090,12 @@ class App:
             self._enqueue("updates", f"couldn't save update preferences: {exc}")
 
     def _maybe_show_changelog(self):
+        # Never allow the delayed startup changelog to steal the modal grab or
+        # keyboard focus from a verified update decision.  If the user cancels,
+        # the changelog can still be opened from its launcher button; if the
+        # update proceeds, the successor's changelog is the relevant one.
+        if self.staged_update is not None or self.update_install_dialog is not None:
+            return
         changelog = load_changelog(self.changelog_path)
         current_notes = extract_version_changelog(changelog, APP_VERSION)
         if should_show_changelog(

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -152,6 +152,109 @@ COMPONENTS = (
 
 # Prevent child processes from opening extra console windows on Windows.
 CREATE_NO_WINDOW = 0x08000000 if os.name == "nt" else 0
+CREATE_SUSPENDED = 0x00000004 if os.name == "nt" else 0
+
+
+def _create_component_job():
+    """Create a Windows job whose close terminates the complete child tree."""
+    if os.name != "nt":
+        return None
+    from ctypes import wintypes
+
+    class IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class BASIC_LIMITS(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class EXTENDED_LIMITS(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", BASIC_LIMITS),
+            ("IoInfo", IO_COUNTERS),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.argtypes = (wintypes.LPVOID, wintypes.LPCWSTR)
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    kernel32.SetInformationJobObject.argtypes = (
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    )
+    kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    handle = kernel32.CreateJobObjectW(None, None)
+    if not handle:
+        raise OSError(ctypes.get_last_error(), "could not create component process job")
+    limits = EXTENDED_LIMITS()
+    limits.BasicLimitInformation.LimitFlags = 0x00002000  # KILL_ON_JOB_CLOSE
+    if not kernel32.SetInformationJobObject(
+        handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)
+    ):
+        error = ctypes.get_last_error()
+        kernel32.CloseHandle(handle)
+        raise OSError(error, "could not secure component process job")
+    return handle
+
+
+def _assign_component_job(job_handle, process_handle):
+    if os.name != "nt" or job_handle is None:
+        return
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.AssignProcessToJobObject.argtypes = (wintypes.HANDLE, wintypes.HANDLE)
+    kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    if not kernel32.AssignProcessToJobObject(job_handle, process_handle):
+        raise OSError(
+            ctypes.get_last_error(), "could not own the component process tree"
+        )
+
+
+def _resume_component_process(process_handle):
+    if os.name != "nt":
+        return
+    from ctypes import wintypes
+
+    ntdll = ctypes.WinDLL("ntdll")
+    ntdll.NtResumeProcess.argtypes = (wintypes.HANDLE,)
+    ntdll.NtResumeProcess.restype = ctypes.c_long
+    status = ntdll.NtResumeProcess(process_handle)
+    if status < 0:
+        raise OSError(status, "could not resume the secured component process")
+
+
+def _close_component_job(job_handle):
+    if os.name == "nt" and job_handle is not None:
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.CloseHandle(job_handle)
 
 PACKAGED_GAMEDATA = HERE.parent / "GameData"
 CHANGELOG_CANDIDATES = (HERE / "CHANGELOG.md", HERE.parent / "CHANGELOG.md")
@@ -2199,7 +2302,15 @@ class Backend:
         self.log = log
         self.environment_provider = environment_provider
         self.proc = None
+        self.job_handle = None
+        self.job_lock = threading.Lock()
         self.startup_ready = False
+
+    def _close_job(self):
+        with self.job_lock:
+            handle = self.job_handle
+            self.job_handle = None
+        _close_component_job(handle)
 
     def running(self):
         return self.proc is not None and self.proc.poll() is None
@@ -2213,10 +2324,12 @@ class Backend:
             return False
 
         self.log(self.name, "starting...")
+        job_handle = None
         try:
             child_environment = os.environ.copy()
             if self.environment_provider is not None:
                 child_environment.update(self.environment_provider())
+            job_handle = _create_component_job()
             self.proc = subprocess.Popen(
                 self.argv,
                 cwd=str(HERE),
@@ -2224,11 +2337,28 @@ class Backend:
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
-                creationflags=CREATE_NO_WINDOW,
+                creationflags=CREATE_NO_WINDOW | CREATE_SUSPENDED,
                 env=child_environment,
             )
+            if job_handle is not None:
+                _assign_component_job(job_handle, self.proc._handle)
+                with self.job_lock:
+                    self.job_handle = job_handle
+                job_handle = None
+            _resume_component_process(self.proc._handle)
         except Exception as exc:
             self.log(self.name, f"FAILED to start: {exc}")
+            if self.proc is not None and self.proc.poll() is None:
+                try:
+                    self.proc.terminate()
+                    self.proc.wait(timeout=2)
+                except (OSError, subprocess.TimeoutExpired):
+                    try:
+                        self.proc.kill()
+                    except OSError:
+                        pass
+            _close_component_job(job_handle)
+            self._close_job()
             self.proc = None
             return False
 
@@ -2248,15 +2378,26 @@ class Backend:
         except Exception as exc:
             self.log(self.name, f"log reader stopped: {exc}")
             return_code = process.poll()
+        finally:
+            if process.stdout is not None:
+                process.stdout.close()
+        self._close_job()
         self.log(self.name, f"exited (code {return_code}).")
 
     def stop(self):
         if not self.running():
+            self._close_job()
             self.startup_ready = False
             return
         self.log(self.name, "stopping...")
         try:
-            self.proc.terminate()
+            if os.name == "nt" and self.job_handle is not None:
+                # Closing the job atomically terminates the direct child and
+                # every descendant it created. This prevents a grandchild from
+                # retaining a managed package file during self-update.
+                self._close_job()
+            else:
+                self.proc.terminate()
             try:
                 self.proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
@@ -2266,6 +2407,7 @@ class Backend:
         except Exception as exc:
             self.log(self.name, f"error while stopping: {exc}")
         finally:
+            self._close_job()
             self.startup_ready = False
 
 

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -2542,43 +2542,45 @@ class App:
             style="Shell.TLabel",
         )
         self.update_status.pack(side="left", fill="x", expand=True)
-        self.view_release_button = ttk.Button(
-            update_bar,
-            text="View release",
-            state="disabled",
-            command=self._open_latest_release,
-        )
-        self.view_release_button.pack(side="right", padx=(4, 0))
-        self.install_update_button = ttk.Button(
-            update_bar,
-            text="Review & install",
-            state="disabled",
-            command=self._stage_available_update,
-        )
-        self.install_update_button.pack(side="right", padx=(4, 0))
-        self.changelog_button = ttk.Button(
-            update_bar,
-            text="Changelog",
-            state="normal" if self.changelog_path is not None else "disabled",
-            command=lambda: self._show_changelog(current_version_only=False),
-        )
-        self.changelog_button.pack(side="right", padx=(4, 0))
-        self.check_updates_button = ttk.Button(
-            update_bar,
-            text="Check now",
-            command=lambda: self._start_update_check(use_cache=False),
-        )
-        self.check_updates_button.pack(side="right", padx=(4, 0))
+        update_actions = ttk.Frame(update_bar, style="Shell.TFrame")
+        update_actions.pack(side="right")
         self.check_updates_var = tk.BooleanVar(
             value=self.update_state.get("check_enabled", True) is not False
         )
         self.check_updates_control = CheckXControl(
-            update_bar,
+            update_actions,
             self.check_updates_var,
             "AUTOMATIC UPDATE CHECKS",
             self._toggle_automatic_updates,
         )
-        self.check_updates_control.pack(side="right", padx=(6, 0))
+        self.check_updates_control.pack(side="left", padx=(6, 0))
+        self.check_updates_button = ttk.Button(
+            update_actions,
+            text="Check now",
+            command=lambda: self._start_update_check(use_cache=False),
+        )
+        self.check_updates_button.pack(side="left", padx=(4, 0))
+        self.install_update_button = ttk.Button(
+            update_actions,
+            text="Review & install",
+            state="disabled",
+            command=self._stage_available_update,
+        )
+        self.install_update_button.pack(side="left", padx=(4, 0))
+        self.changelog_button = ttk.Button(
+            update_actions,
+            text="Changelog",
+            state="normal" if self.changelog_path is not None else "disabled",
+            command=lambda: self._show_changelog(current_version_only=False),
+        )
+        self.changelog_button.pack(side="left", padx=(4, 0))
+        self.view_release_button = ttk.Button(
+            update_actions,
+            text="View release",
+            state="disabled",
+            command=self._open_latest_release,
+        )
+        self.view_release_button.pack(side="left", padx=(4, 0))
 
         self.main_panes = tk.PanedWindow(
             root,

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -30,7 +30,6 @@ import subprocess
 import sys
 import threading
 import time
-import urllib.parse
 import urllib.error
 import urllib.request
 import webbrowser
@@ -38,6 +37,8 @@ from pathlib import Path
 
 import tkinter as tk
 from tkinter import filedialog, font as tkfont, messagebox, scrolledtext, ttk
+
+import runtime_update
 
 
 HERE = Path(__file__).resolve().parent
@@ -54,7 +55,7 @@ LATEST_RELEASE_API = (
 )
 UPDATE_CACHE_SECONDS = 24 * 60 * 60
 UPDATE_TIMEOUT_SECONDS = 4
-_VERSION_TAG = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+MAX_RELEASE_RESPONSE_BYTES = 2 * 1024 * 1024
 
 
 def _default_update_state_path():
@@ -65,6 +66,48 @@ def _default_update_state_path():
 
 
 UPDATE_STATE_PATH = _default_update_state_path()
+UPDATE_DOWNLOAD_ROOT = UPDATE_STATE_PATH.parent / "updates"
+
+
+class LauncherInstanceGuard:
+    """Hold one Windows launcher instance per resolved package directory."""
+
+    def __init__(self, directory=HERE):
+        self.handle = None
+        if os.name != "nt":
+            return
+        from ctypes import wintypes
+
+        identity = hashlib.sha256(
+            str(Path(directory).resolve()).casefold().encode("utf-8")
+        ).hexdigest()[:32]
+        name = f"Local\\WoobiesMissionControlLauncher-{identity}"
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateMutexW.argtypes = (
+            wintypes.LPVOID,
+            wintypes.BOOL,
+            wintypes.LPCWSTR,
+        )
+        kernel32.CreateMutexW.restype = wintypes.HANDLE
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        ctypes.set_last_error(0)
+        handle = kernel32.CreateMutexW(None, False, name)
+        if not handle:
+            raise OSError(ctypes.get_last_error(), "could not create launcher guard")
+        if ctypes.get_last_error() == 183:  # ERROR_ALREADY_EXISTS
+            kernel32.CloseHandle(handle)
+            raise RuntimeError(
+                "Mission Control is already running from this package. Close its "
+                "launcher window before starting another copy."
+            )
+        self.handle = handle
+        self._close_handle = kernel32.CloseHandle
+
+    def close(self):
+        if self.handle is not None:
+            self._close_handle(self.handle)
+            self.handle = None
 
 
 def _default_settings_path():
@@ -1775,12 +1818,7 @@ def install_service_dlls(
 
 def parse_version_tag(tag):
     """Return a comparable three-part version tuple, or ``None``."""
-    if not isinstance(tag, str):
-        return None
-    match = _VERSION_TAG.fullmatch(tag.strip())
-    if not match:
-        return None
-    return tuple(int(part) for part in match.groups())
+    return runtime_update.parse_version(tag)
 
 
 def classify_release(current_version, latest_tag):
@@ -1798,26 +1836,7 @@ def classify_release(current_version, latest_tag):
 
 def validate_release_payload(payload):
     """Validate and return the update fields used from a GitHub response."""
-    if not isinstance(payload, dict):
-        raise ValueError("GitHub returned an invalid release response")
-
-    tag_name = payload.get("tag_name")
-    html_url = payload.get("html_url")
-    if parse_version_tag(tag_name) is None:
-        raise ValueError("the latest release tag is not vMAJOR.MINOR.PATCH")
-    if not isinstance(html_url, str):
-        raise ValueError("the latest release does not have a web address")
-
-    parsed = urllib.parse.urlparse(html_url)
-    expected_path = "/sacredwoobie/woobies-mission-control/releases/"
-    if (
-        parsed.scheme != "https"
-        or parsed.netloc.lower() != "github.com"
-        or not parsed.path.lower().startswith(expected_path)
-    ):
-        raise ValueError("the latest release has an unexpected web address")
-
-    return {"tag_name": tag_name.strip(), "html_url": html_url}
+    return runtime_update.validate_release_payload(payload)
 
 
 def fetch_latest_release(opener=urllib.request.urlopen, timeout=UPDATE_TIMEOUT_SECONDS):
@@ -1827,11 +1846,14 @@ def fetch_latest_release(opener=urllib.request.urlopen, timeout=UPDATE_TIMEOUT_S
         headers={
             "Accept": "application/vnd.github+json",
             "User-Agent": f"Woobies-Mission-Control/{APP_VERSION}",
-            "X-GitHub-Api-Version": "2022-11-28",
+            "X-GitHub-Api-Version": runtime_update.GITHUB_API_VERSION,
         },
     )
     with opener(request, timeout=timeout) as response:
-        payload = json.loads(response.read().decode("utf-8"))
+        encoded = response.read(MAX_RELEASE_RESPONSE_BYTES + 1)
+        if len(encoded) > MAX_RELEASE_RESPONSE_BYTES:
+            raise ValueError("GitHub returned an unexpectedly large release response")
+        payload = json.loads(encoded.decode("utf-8"))
     return validate_release_payload(payload)
 
 
@@ -2307,8 +2329,15 @@ class ScrollableLauncherPane(ttk.Frame):
 
 
 class App:
-    def __init__(self, root, update_state_path=UPDATE_STATE_PATH,
-                 settings_path=SETTINGS_PATH):
+    def __init__(
+        self,
+        root,
+        update_state_path=UPDATE_STATE_PATH,
+        settings_path=SETTINGS_PATH,
+        update_download_root=UPDATE_DOWNLOAD_ROOT,
+        restart_transaction=None,
+        package_root=None,
+    ):
         self.root = root
         self.log_queue = queue.Queue()
         self.update_queue = queue.Queue()
@@ -2319,11 +2348,21 @@ class App:
         self.component_setups = set()
         self.update_state_path = Path(update_state_path)
         self.update_state = load_update_state(self.update_state_path)
+        self.update_download_root = Path(update_download_root)
         self.settings_path = Path(settings_path)
         self.settings = load_settings(self.settings_path)
         self.update_generation = 0
         self.update_checking = False
+        self.update_staging = False
+        self.update_handoff_active = False
         self.latest_release_url = None
+        self.latest_release = None
+        self.installable_update = None
+        self.staged_update = None
+        self.update_install_dialog = None
+        self.restart_transaction = restart_transaction
+        self.package_root = Path(package_root) if package_root is not None else None
+        self.restart_visibility_deadline = None
         self.changelog_path = find_changelog_path()
         self.changelog_dialog = None
         self.prerequisite_fix_dialog = None
@@ -2368,6 +2407,13 @@ class App:
             command=self._open_latest_release,
         )
         self.view_release_button.pack(side="right", padx=(4, 0))
+        self.install_update_button = ttk.Button(
+            update_bar,
+            text="Review & install",
+            state="disabled",
+            command=self._stage_available_update,
+        )
+        self.install_update_button.pack(side="right", padx=(4, 0))
         self.changelog_button = ttk.Button(
             update_bar,
             text="Changelog",
@@ -2712,6 +2758,16 @@ class App:
         self._drain_krpc_test_queue()
         self._drain_component_setup_queue()
         self._refresh()
+        if self.restart_transaction is not None:
+            self.update_status.config(
+                text="Finishing verified update restart...",
+                foreground=THEME["amber"],
+            )
+            self.root.after_idle(self._acknowledge_update_restart)
+        else:
+            self._schedule_post_start_tasks()
+
+    def _schedule_post_start_tasks(self):
         if self.check_updates_var.get():
             self.root.after(300, lambda: self._start_update_check(use_cache=True))
         else:
@@ -3560,13 +3616,15 @@ class App:
         self.root.after(100, self._drain_log)
 
     def _start_update_check(self, use_cache):
-        if self.update_checking:
+        if self.update_checking or self.update_staging or self.staged_update is not None:
             return
 
         if use_cache:
             cached = get_fresh_cached_release(self.update_state)
             if cached is not None:
-                self._apply_release_status(cached)
+                # Cached metadata is display-only. Installation always starts
+                # from a fresh, authenticated GitHub response.
+                self._apply_release_status(cached, allow_install=False)
                 return
             cached_app_version = self.update_state.get("app_version")
             if (
@@ -3582,16 +3640,18 @@ class App:
         self.update_generation += 1
         generation = self.update_generation
         self.update_checking = True
+        self.installable_update = None
         self.update_status.config(
             text="Checking GitHub for updates...", foreground=THEME["slate"]
         )
         self.check_updates_button.config(state="disabled")
+        self.install_update_button.config(state="disabled")
 
         def worker():
             try:
                 release = fetch_latest_release()
             except Exception as exc:
-                self.update_queue.put((generation, "error", str(exc)))
+                self.update_queue.put((generation, "check_error", str(exc)))
             else:
                 self.update_queue.put((generation, "release", release))
 
@@ -3602,42 +3662,95 @@ class App:
             while True:
                 generation, result_type, result = self.update_queue.get_nowait()
                 if generation != self.update_generation:
+                    if result_type == "staged":
+                        try:
+                            runtime_update.discard_staged_transaction(
+                                result["root"], result["transaction_id"]
+                            )
+                        except Exception:
+                            pass
                     continue
 
-                self.update_checking = False
-                self.check_updates_button.config(state="normal")
                 if result_type == "release":
+                    self.update_checking = False
+                    self.check_updates_button.config(state="normal")
                     self.update_state.update(result)
                     self.update_state["app_version"] = APP_VERSION
                     self.update_state["last_checked"] = time.time()
                     self.update_state["check_enabled"] = self.check_updates_var.get()
                     self._save_update_state()
-                    self._apply_release_status(result)
-                else:
+                    self._apply_release_status(result, allow_install=True)
+                elif result_type == "check_error":
+                    self.update_checking = False
+                    self.check_updates_button.config(state="normal")
                     self.update_status.config(
                         text="Couldn’t check for updates (offline is OK)",
                         foreground=THEME["slate_dim"],
                     )
                     self._enqueue("updates", f"update check unavailable: {result}")
+                elif result_type == "staged":
+                    self.update_staging = False
+                    self.staged_update = result
+                    self.update_status.config(
+                        text=f"Verified {result['release']['tag_name']} - ready to review",
+                        foreground=THEME["green"],
+                    )
+                    self._show_update_install_dialog(result)
+                elif result_type == "stage_error":
+                    self.update_staging = False
+                    self.check_updates_button.config(state="normal")
+                    if self.installable_update is not None:
+                        self.install_update_button.config(state="normal")
+                    self.update_status.config(
+                        text="Update could not be verified; no package files changed",
+                        foreground=THEME["amber"],
+                    )
+                    self._enqueue("updates", f"update verification failed: {result}")
+                    messagebox.showerror(
+                        "Update not installed",
+                        "Mission Control could not safely verify and stage the update. "
+                        "No installed package files were changed.\n\n" + str(result),
+                        parent=self.root,
+                    )
         except queue.Empty:
             pass
         self.root.after(100, self._drain_update_queue)
 
-    def _apply_release_status(self, release):
+    def _apply_release_status(self, release, allow_install=False):
         tag_name = release["tag_name"]
+        self.latest_release = release
         self.latest_release_url = release["html_url"]
         self.view_release_button.config(state="normal")
+        self.installable_update = None
+        self.install_update_button.config(state="disabled")
 
         status = classify_release(APP_VERSION, tag_name)
         if status == "available":
-            self.update_status.config(
-                text=f"Update available: {tag_name}",
-                foreground=THEME["cyan"],
-            )
-            self._enqueue(
-                "updates",
-                f"{tag_name} is available; use View release to review it.",
-            )
+            offer = None
+            if allow_install:
+                offer = runtime_update.assess_release_offer(release, APP_VERSION, HERE)
+            if offer is not None and offer["installable"]:
+                self.installable_update = {"release": release, **offer}
+                self.install_update_button.config(state="normal")
+                self.update_status.config(
+                    text=f"Verified update available: {tag_name}",
+                    foreground=THEME["cyan"],
+                )
+                self._enqueue(
+                    "updates",
+                    f"{tag_name} can update this installed package; review it before installing.",
+                )
+            else:
+                if offer is None:
+                    reason = (
+                        "Select Check now to verify whether in-app installation is available."
+                    )
+                    status_text = f"Update available: {tag_name} - select Check now"
+                else:
+                    reason = offer["reason"]
+                    status_text = f"Update available: {tag_name} (manual download)"
+                self.update_status.config(text=status_text, foreground=THEME["cyan"])
+                self._enqueue("updates", f"{tag_name}: {reason}")
         elif status == "development":
             self.update_status.config(
                 text=f"Development build—newer than published {tag_name}",
@@ -3649,10 +3762,296 @@ class App:
                 foreground=THEME["green"],
             )
 
+    def _stage_available_update(self):
+        offer = self.installable_update
+        if offer is None or self.update_staging or self.staged_update is not None:
+            return
+        self.update_generation += 1
+        generation = self.update_generation
+        self.update_staging = True
+        self.check_updates_button.config(state="disabled")
+        self.install_update_button.config(state="disabled")
+        release = offer["release"]
+        self.update_status.config(
+            text=f"Downloading and verifying {release['tag_name']}...",
+            foreground=THEME["slate"],
+        )
+
+        def worker():
+            try:
+                version = runtime_update.canonical_version(release["tag_name"])
+                archive = runtime_update.download_verified_update(
+                    release,
+                    self.update_download_root / f"v{version}",
+                )
+                staged = runtime_update.stage_transaction(offer["root"], archive)
+                if generation != self.update_generation:
+                    runtime_update.discard_staged_transaction(
+                        offer["root"], staged["transaction_id"]
+                    )
+                    return
+                result = {
+                    **staged,
+                    "root": offer["root"],
+                    "release": release,
+                    "archive_size": archive.stat().st_size,
+                }
+            except Exception as exc:
+                self.update_queue.put((generation, "stage_error", str(exc)))
+            else:
+                self.update_queue.put((generation, "staged", result))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _show_update_install_dialog(self, staged):
+        if self.update_install_dialog is not None:
+            try:
+                if self.update_install_dialog.winfo_exists():
+                    self.update_install_dialog.lift()
+                    return
+            except tk.TclError:
+                self.update_install_dialog = None
+
+        dialog = tk.Toplevel(self.root)
+        self.update_install_dialog = dialog
+        dialog.title(f"Install {staged['release']['tag_name']} - {APP_NAME}")
+        dialog.transient(self.root)
+        dialog.geometry("720x610")
+        dialog.minsize(600, 470)
+        dialog.configure(background=THEME["bg"])
+
+        body = ttk.Frame(dialog, padding=(18, 16))
+        body.pack(fill="both", expand=True)
+        ttk.Label(
+            body,
+            text=f"READY TO UPDATE TO v{staged['target_version']}",
+            style="DialogTitle.TLabel",
+            anchor="w",
+        ).pack(fill="x")
+        size_mb = staged["archive_size"] / (1024 * 1024)
+        ttk.Label(
+            body,
+            text=(
+                f"Verified download: {size_mb:.2f} MB. Mission Control will stop only "
+                "the components launched from this window, update its packaged runtime, "
+                "run a health check, and restart."
+            ),
+            style="DialogBody.TLabel",
+            wraplength=670,
+            justify="left",
+        ).pack(fill="x", pady=(8, 4))
+        ttk.Label(
+            body,
+            text=(
+                "Preserved: the package .venv, settings, logs, README, gallery images, "
+                "and unknown files. Your selected live KSP/GameData installation is never "
+                "changed by this updater; only the repair copies inside this package may change."
+            ),
+            style="DialogBody.TLabel",
+            wraplength=670,
+            justify="left",
+        ).pack(fill="x", pady=(0, 8))
+
+        differences = staged.get("local_differences") or []
+        if differences:
+            names = ", ".join(item["path"] for item in differences[:5])
+            if len(differences) > 5:
+                names += f", and {len(differences) - 5} more"
+            ttk.Label(
+                body,
+                text=(
+                    "Locally changed managed files will be replaced (and backed up): "
+                    + names
+                ),
+                foreground=THEME["amber"],
+                style="Shell.TLabel",
+                wraplength=670,
+                justify="left",
+            ).pack(fill="x", pady=(0, 8))
+
+        ttk.Label(body, text="RELEASE NOTES", style="Section.TLabel").pack(
+            fill="x", pady=(4, 4)
+        )
+        notes = scrolledtext.ScrolledText(
+            body,
+            wrap="word",
+            state="normal",
+            height=13,
+            font=UI_FONT,
+            background=THEME["input"],
+            foreground=THEME["amber"],
+            insertbackground=THEME["cyan"],
+            borderwidth=1,
+            relief="solid",
+            padx=9,
+            pady=7,
+        )
+        notes.pack(fill="both", expand=True)
+        notes.insert("1.0", staged["release"].get("body") or "No release notes provided.")
+        notes.config(state="disabled")
+
+        footer = ttk.Frame(body)
+        footer.pack(fill="x", pady=(12, 0))
+        self.update_cancel_button = ttk.Button(
+            footer, text="Cancel", width=10, command=self._cancel_staged_update
+        )
+        self.update_cancel_button.pack(side="right")
+        self.update_confirm_button = ttk.Button(
+            footer,
+            text="Install and restart",
+            command=self._install_staged_update,
+        )
+        self.update_confirm_button.pack(side="right", padx=(0, 8))
+
+        dialog.protocol("WM_DELETE_WINDOW", self._cancel_staged_update)
+        dialog.update_idletasks()
+        x = self.root.winfo_rootx() + max(
+            0, (self.root.winfo_width() - dialog.winfo_width()) // 2
+        )
+        y = self.root.winfo_rooty() + max(
+            0, (self.root.winfo_height() - dialog.winfo_height()) // 2
+        )
+        dialog.geometry(f"{dialog.winfo_width()}x{dialog.winfo_height()}+{x}+{y}")
+        dialog.grab_set()
+        self.update_confirm_button.focus_set()
+
+    def _cancel_staged_update(self):
+        staged = self.staged_update
+        if staged is None:
+            return
+        try:
+            runtime_update.discard_staged_transaction(
+                staged["root"], staged["transaction_id"]
+            )
+        except Exception as exc:
+            messagebox.showerror(
+                "Could not clear staged update",
+                str(exc),
+                parent=self.update_install_dialog or self.root,
+            )
+            return
+        self.staged_update = None
+        dialog = self.update_install_dialog
+        self.update_install_dialog = None
+        if dialog is not None:
+            dialog.destroy()
+        if self.installable_update is not None:
+            self.install_update_button.config(state="normal")
+            self.check_updates_button.config(state="normal")
+            self.update_status.config(
+                text=f"Verified update available: {self.installable_update['release']['tag_name']}",
+                foreground=THEME["cyan"],
+            )
+        self._enqueue("updates", "staged update canceled; no package files changed.")
+
+    def _install_staged_update(self):
+        staged = self.staged_update
+        if staged is None or self.update_handoff_active:
+            return
+        if self.component_setups:
+            messagebox.showerror(
+                "Component setup still running",
+                "Wait for the package-local Python component setup to finish before "
+                "installing the Mission Control update.",
+                parent=self.update_install_dialog,
+            )
+            return
+        self.update_confirm_button.config(state="disabled")
+        self.update_cancel_button.config(state="disabled")
+        self.update_status.config(
+            text="Stopping Mission Control components and starting the updater...",
+            foreground=THEME["amber"],
+        )
+        for backend in self.backends:
+            backend.stop()
+        still_running = [backend.name for backend in self.backends if backend.running()]
+        if still_running:
+            self.update_confirm_button.config(state="normal")
+            self.update_cancel_button.config(state="normal")
+            messagebox.showerror(
+                "Update could not start",
+                "These Mission Control components did not stop: "
+                + ", ".join(still_running)
+                + ". No package files were changed.",
+                parent=self.update_install_dialog,
+            )
+            return
+        try:
+            runtime_update.activate_transaction(
+                staged["root"],
+                staged["transaction_id"],
+                launcher_pid=os.getpid(),
+                python_executable=PYTHON,
+            )
+        except Exception as exc:
+            self.update_confirm_button.config(state="normal")
+            self.update_cancel_button.config(state="normal")
+            self.update_status.config(
+                text="Update handoff failed; no package files changed",
+                foreground=THEME["amber"],
+            )
+            messagebox.showerror(
+                "Update could not start",
+                "The external updater could not be started. No package files were "
+                "changed.\n\n" + str(exc),
+                parent=self.update_install_dialog,
+            )
+            return
+        self.update_handoff_active = True
+        self.staged_update = None
+        self.root.destroy()
+
+    def _acknowledge_update_restart(self):
+        try:
+            if self.package_root is None:
+                raise runtime_update.TransactionError(
+                    "updated launcher does not know its package root"
+                )
+            runtime_update.acknowledge_restart(
+                self.package_root, self.restart_transaction
+            )
+        except Exception as exc:
+            messagebox.showerror(
+                "Update startup check failed",
+                "The updated launcher could not confirm a healthy restart. The updater "
+                "will restore the previous version.\n\n" + str(exc),
+                parent=self.root,
+            )
+            self.root.destroy()
+            return
+        os.environ.pop("WMC_UPDATE_TRANSACTION", None)
+        self._enqueue("updates", "updated launcher startup acknowledged.")
+        self.restart_visibility_deadline = time.monotonic() + 15
+        self.root.after(200, self._finish_update_restart)
+
+    def _finish_update_restart(self):
+        status = runtime_update.pending_update_status(self.package_root)
+        if not status["pending"]:
+            self.restart_transaction = None
+            self.restart_visibility_deadline = None
+            self.root.deiconify()
+            self.root.lift()
+            self._schedule_post_start_tasks()
+            return
+        if time.monotonic() < self.restart_visibility_deadline:
+            self.root.after(200, self._finish_update_restart)
+            return
+        messagebox.showerror(
+            "Update did not finish",
+            "The external updater did not complete its final commit. Mission Control "
+            "will close so the normal launcher can recover the previous version.\n\n"
+            + status["message"],
+            parent=self.root,
+        )
+        self.root.destroy()
+
     def _toggle_automatic_updates(self):
         enabled = self.check_updates_var.get()
         self.update_state["check_enabled"] = enabled
         self._save_update_state()
+
+        if self.update_staging or self.staged_update is not None:
+            return
 
         if enabled:
             self._start_update_check(use_cache=True)
@@ -3995,6 +4394,30 @@ class App:
         self.root.after(500, self._refresh)
 
     def _on_close(self):
+        if self.update_staging:
+            close_anyway = messagebox.askyesno(
+                "Update verification in progress",
+                "Mission Control is still downloading or verifying an update. Close "
+                "anyway? No installed package files have been changed.",
+                parent=self.root,
+            )
+            if not close_anyway:
+                return
+            self.update_generation += 1
+        if self.staged_update is not None and not self.update_handoff_active:
+            try:
+                runtime_update.discard_staged_transaction(
+                    self.staged_update["root"],
+                    self.staged_update["transaction_id"],
+                )
+            except Exception as exc:
+                messagebox.showerror(
+                    "Could not clear staged update",
+                    str(exc),
+                    parent=self.root,
+                )
+                return
+            self.staged_update = None
         for backend in self.backends:
             backend.stop()
         self.root.destroy()
@@ -4020,10 +4443,47 @@ def _fatal(_exc):
         print(traceback_text)
 
 
+def runtime_start_context(directory=HERE, environment=None):
+    """Fail closed when a packaged launch has unresolved update state."""
+    dashboard = Path(directory).resolve()
+    environment = os.environ if environment is None else environment
+    if dashboard.name.casefold() != "dashboard":
+        return None, None
+    root = dashboard.parent
+    active_marker = (
+        root
+        / runtime_update.UPDATE_DIRECTORY_NAME
+        / runtime_update.ACTIVE_TRANSACTION_NAME
+    )
+    if not (root / runtime_update.INSTALL_MANIFEST_NAME).is_file() and not active_marker.exists():
+        return None, None
+    token = environment.get("WMC_UPDATE_TRANSACTION")
+    status = runtime_update.pending_update_status(root, token)
+    if status["pending"]:
+        raise runtime_update.TransactionError(status["message"])
+    restart_transaction = (
+        status.get("transaction_id")
+        if status.get("state") in {"checking", "awaiting_restart"}
+        else None
+    )
+    return root, restart_transaction
+
+
 def main():
-    root = tk.Tk()
-    App(root)
-    root.mainloop()
+    package_root, restart_transaction = runtime_start_context()
+    instance_guard = LauncherInstanceGuard()
+    try:
+        root = tk.Tk()
+        if restart_transaction is not None:
+            root.withdraw()
+        App(
+            root,
+            restart_transaction=restart_transaction,
+            package_root=package_root,
+        )
+        root.mainloop()
+    finally:
+        instance_guard.close()
 
 
 if __name__ == "__main__":

--- a/runtime-update-contract.json
+++ b/runtime-update-contract.json
@@ -1,0 +1,40 @@
+{
+  "schema": 1,
+  "limits": {
+    "download_bytes": 33554432,
+    "checksum_bytes": 1024,
+    "archive_entries": 256,
+    "archive_file_bytes": 33554432,
+    "archive_expanded_bytes": 67108864,
+    "relative_path_length": 220
+  },
+  "root_managed_files": [
+    "BUILD-INFO.txt",
+    "CHANGELOG.md",
+    "LICENSE",
+    "QUICKSTART.txt",
+    "THIRD-PARTY/NOTICES.md",
+    "docs/CONTROL_PAD_PROTOCOL.md",
+    "firmware/KSP_control.ino"
+  ],
+  "dashboard_contract_path": "Dashboard/runtime-update-contract.json",
+  "dashboard_top_level_extensions": [
+    ".bat",
+    ".ps1",
+    ".py",
+    ".txt"
+  ],
+  "dashboard_web_index": "Dashboard/web/index.html",
+  "dashboard_asset_extensions": [
+    ".css",
+    ".js",
+    ".map"
+  ],
+  "service_folders": [
+    "KRPC.StageStats",
+    "KRPC.SystemHeat",
+    "KRPC.WoobiesMechJeb",
+    "WoobiesControlStats"
+  ],
+  "source_archive_suffix": "-source.zip"
+}

--- a/runtime_update.py
+++ b/runtime_update.py
@@ -19,8 +19,73 @@ import urllib.parse
 import urllib.request
 import uuid
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
+
+def _load_runtime_contract():
+    path = Path(__file__).resolve().with_name("runtime-update-contract.json")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise RuntimeError(f"could not load the runtime-update contract: {exc}") from exc
+    expected = {
+        "schema",
+        "limits",
+        "root_managed_files",
+        "dashboard_contract_path",
+        "dashboard_top_level_extensions",
+        "dashboard_web_index",
+        "dashboard_asset_extensions",
+        "service_folders",
+        "source_archive_suffix",
+    }
+    if not isinstance(value, dict) or set(value) != expected or value["schema"] != 1:
+        raise RuntimeError("the runtime-update contract schema is invalid")
+    limit_keys = {
+        "download_bytes",
+        "checksum_bytes",
+        "archive_entries",
+        "archive_file_bytes",
+        "archive_expanded_bytes",
+        "relative_path_length",
+    }
+    limits = value["limits"]
+    if (
+        not isinstance(limits, dict)
+        or set(limits) != limit_keys
+        or any(
+            not isinstance(item, int) or isinstance(item, bool) or item <= 0
+            for item in limits.values()
+        )
+    ):
+        raise RuntimeError("the runtime-update contract limits are invalid")
+    for key in (
+        "root_managed_files",
+        "dashboard_top_level_extensions",
+        "dashboard_asset_extensions",
+        "service_folders",
+    ):
+        items = value[key]
+        if (
+            not isinstance(items, list)
+            or not items
+            or any(not isinstance(item, str) or not item for item in items)
+            or len({item.casefold() for item in items}) != len(items)
+        ):
+            raise RuntimeError(f"the runtime-update contract field {key} is invalid")
+    for key in (
+        "dashboard_contract_path",
+        "dashboard_web_index",
+        "source_archive_suffix",
+    ):
+        if not isinstance(value[key], str) or not value[key]:
+            raise RuntimeError(f"the runtime-update contract field {key} is invalid")
+    return value
+
+
+_RUNTIME_CONTRACT = _load_runtime_contract()
+_LIMITS = _RUNTIME_CONTRACT["limits"]
 
 INSTALL_MANIFEST_NAME = "WMC-INSTALL-MANIFEST.json"
 UPDATE_MANIFEST_NAME = "update-manifest.json"
@@ -32,14 +97,14 @@ RESTART_ACK_NAME = "restart-ack.json"
 UPDATER_PROTOCOL = 1
 RESTART_STABILITY_SECONDS = 1.0
 
-MAX_UPDATE_DOWNLOAD_BYTES = 32 * 1024 * 1024
-MAX_CHECKSUM_BYTES = 1024
+MAX_UPDATE_DOWNLOAD_BYTES = _LIMITS["download_bytes"]
+MAX_CHECKSUM_BYTES = _LIMITS["checksum_bytes"]
 MAX_RELEASE_NOTES_CHARS = 256 * 1024
 MAX_RELEASE_ASSETS = 128
-MAX_ARCHIVE_ENTRIES = 256
-MAX_ARCHIVE_FILE_BYTES = 32 * 1024 * 1024
-MAX_ARCHIVE_EXPANDED_BYTES = 64 * 1024 * 1024
-MAX_RELATIVE_PATH_LENGTH = 220
+MAX_ARCHIVE_ENTRIES = _LIMITS["archive_entries"]
+MAX_ARCHIVE_FILE_BYTES = _LIMITS["archive_file_bytes"]
+MAX_ARCHIVE_EXPANDED_BYTES = _LIMITS["archive_expanded_bytes"]
+MAX_RELATIVE_PATH_LENGTH = _LIMITS["relative_path_length"]
 
 REPOSITORY_OWNER = "SacredWoobie"
 REPOSITORY_NAME = "woobies-mission-control"
@@ -62,31 +127,15 @@ _WINDOWS_RESERVED = frozenset(
         *(f"LPT{index}" for index in range(1, 10)),
     }
 )
-_ROOT_MANAGED_FILES = frozenset(
-    {
-        "BUILD-INFO.txt",
-        "CHANGELOG.md",
-        "LICENSE",
-        "QUICKSTART.txt",
-        "THIRD-PARTY/NOTICES.md",
-        "docs/CONTROL_PAD_PROTOCOL.md",
-        "firmware/KSP_control.ino",
-    }
-)
-_SERVICE_FOLDERS = frozenset(
-    {
-        "KRPC.StageStats",
-        "KRPC.SystemHeat",
-        "KRPC.WoobiesMechJeb",
-        "WoobiesControlStats",
-    }
-)
+_ROOT_MANAGED_FILES = frozenset(_RUNTIME_CONTRACT["root_managed_files"])
+_SERVICE_FOLDERS = frozenset(_RUNTIME_CONTRACT["service_folders"])
 _UPDATER_CRITICAL_FILES = frozenset(
     {
         "Dashboard/Start KSP Dashboard.bat",
         "Dashboard/ksp_dashboard_app.py",
         "Dashboard/runtime_update.py",
         "Dashboard/runtime_update_helper.py",
+        _RUNTIME_CONTRACT["dashboard_contract_path"],
     }
 )
 
@@ -113,6 +162,23 @@ class InstallationError(UpdateError):
 
 class TransactionError(UpdateError):
     """A transactional apply, health check, recovery, or rollback failed."""
+
+
+@dataclass(frozen=True)
+class WindowsProcessIdentity:
+    """Identity strong enough to distinguish a PID from a later reuse."""
+
+    pid: int
+    creation_time: int
+    executable: str
+
+
+@dataclass
+class RestartedProcess:
+    """Keep the owned subprocess handle alive until commit or rollback."""
+
+    process: subprocess.Popen
+    identity: WindowsProcessIdentity | None
 
 
 def parse_version(value):
@@ -199,15 +265,23 @@ def _is_allowed_dashboard_path(path):
         return False
     if any(part.casefold().endswith((".log", ".pyc", ".pyo")) for part in parts):
         return False
+    if path == _RUNTIME_CONTRACT["dashboard_contract_path"]:
+        return True
     if len(parts) == 2:
         suffix = PurePosixPath(parts[-1]).suffix.casefold()
-        return suffix in {".py", ".txt", ".ps1", ".bat"}
+        return suffix in {
+            item.casefold()
+            for item in _RUNTIME_CONTRACT["dashboard_top_level_extensions"]
+        }
     if parts[1] != "web":
         return False
-    if len(parts) == 3 and parts[2] == "index.html":
+    if path == _RUNTIME_CONTRACT["dashboard_web_index"]:
         return True
     if len(parts) == 4 and parts[2] == "assets":
-        return PurePosixPath(parts[3]).suffix.casefold() in {".js", ".css", ".map"}
+        return PurePosixPath(parts[3]).suffix.casefold() in {
+            item.casefold()
+            for item in _RUNTIME_CONTRACT["dashboard_asset_extensions"]
+        }
     return False
 
 
@@ -225,7 +299,9 @@ def is_allowed_managed_path(path):
     if len(parts) >= 3 and parts[0] == "GameData" and parts[1] in _SERVICE_FOLDERS:
         return True
     if len(parts) == 2 and parts[0] == "SOURCE":
-        return parts[1].casefold().endswith("-source.zip")
+        return parts[1].casefold().endswith(
+            _RUNTIME_CONTRACT["source_archive_suffix"].casefold()
+        )
     return False
 
 
@@ -1138,6 +1214,9 @@ def activate_transaction(root, transaction_id, *, launcher_pid, python_executabl
         raise TransactionError("only a staged update transaction can be activated")
     if not isinstance(launcher_pid, int) or launcher_pid <= 0:
         raise TransactionError("launcher PID is invalid")
+    launcher_identity = (
+        _windows_process_identity(launcher_pid) if os.name == "nt" else None
+    )
     if python_executable is None:
         python_executable = Path(
             paths["root"] / "Dashboard" / ".venv" / "Scripts" / "python.exe"
@@ -1167,6 +1246,7 @@ def activate_transaction(root, transaction_id, *, launcher_pid, python_executabl
     helper_sources = (
         "Dashboard/runtime_update.py",
         "Dashboard/runtime_update_helper.py",
+        _RUNTIME_CONTRACT["dashboard_contract_path"],
     )
     command = [
         str(python_executable),
@@ -1200,7 +1280,14 @@ def activate_transaction(root, transaction_id, *, launcher_pid, python_executabl
                 record["size"],
                 record["sha256"],
             )
-        _journal(paths, "activated", launcher_pid=launcher_pid, helper_pid=None)
+        _journal(
+            paths,
+            "activated",
+            launcher_pid=launcher_pid,
+            launcher_identity=_identity_record(launcher_identity),
+            helper_pid=None,
+            helper_identity=None,
+        )
         _atomic_write_json(
             paths["active"], {"schema": 1, "transaction_id": transaction_id}
         )
@@ -1232,41 +1319,154 @@ def activate_transaction(root, transaction_id, *, launcher_pid, python_executabl
     return helper_pid
 
 
-def _pid_is_running(pid):
+def _windows_process_api():
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (
+        wintypes.DWORD,
+        wintypes.BOOL,
+        wintypes.DWORD,
+    )
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.GetProcessTimes.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    )
+    kernel32.GetProcessTimes.restype = wintypes.BOOL
+    kernel32.QueryFullProcessImageNameW.argtypes = (
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD),
+    )
+    kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    return ctypes, wintypes, kernel32
+
+
+def _filetime_value(value):
+    return (int(value.dwHighDateTime) << 32) | int(value.dwLowDateTime)
+
+
+def _windows_process_identity_from_handle(handle, pid):
+    ctypes, wintypes, kernel32 = _windows_process_api()
+    created = wintypes.FILETIME()
+    exited = wintypes.FILETIME()
+    kernel = wintypes.FILETIME()
+    user = wintypes.FILETIME()
+    if not kernel32.GetProcessTimes(
+        handle,
+        ctypes.byref(created),
+        ctypes.byref(exited),
+        ctypes.byref(kernel),
+        ctypes.byref(user),
+    ):
+        raise OSError(ctypes.get_last_error(), "could not identify updater process time")
+    capacity = wintypes.DWORD(32768)
+    buffer = ctypes.create_unicode_buffer(capacity.value)
+    if not kernel32.QueryFullProcessImageNameW(
+        handle, 0, buffer, ctypes.byref(capacity)
+    ):
+        raise OSError(ctypes.get_last_error(), "could not identify updater executable")
+    return WindowsProcessIdentity(
+        pid=pid,
+        creation_time=_filetime_value(created),
+        executable=str(Path(buffer.value).resolve()).casefold(),
+    )
+
+
+def _open_windows_process(pid):
+    ctypes, _wintypes, kernel32 = _windows_process_api()
+    handle = kernel32.OpenProcess(0x00100000 | 0x1000, False, pid)
+    if not handle:
+        error = ctypes.get_last_error()
+        if error == 87:  # ERROR_INVALID_PARAMETER: no process owns this PID.
+            return None
+        raise OSError(error, "could not open updater-owned process")
+    return handle
+
+
+def _windows_process_identity(pid):
+    if not isinstance(pid, int) or pid <= 0:
+        raise TransactionError("process PID is invalid")
+    handle = _open_windows_process(pid)
+    if handle is None:
+        raise TransactionError("could not securely identify the updater-owned process")
+    _ctypes, _wintypes, kernel32 = _windows_process_api()
+    try:
+        return _windows_process_identity_from_handle(handle, pid)
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _identity_record(identity):
+    if identity is None:
+        return None
+    return {
+        "pid": identity.pid,
+        "creation_time": identity.creation_time,
+        "executable": identity.executable,
+    }
+
+
+def _parse_identity_record(value, *, description):
+    if value is None:
+        return None
+    if not isinstance(value, dict) or set(value) != {
+        "pid",
+        "creation_time",
+        "executable",
+    }:
+        raise TransactionError(f"{description} identity is invalid")
+    pid = value["pid"]
+    creation_time = value["creation_time"]
+    executable = value["executable"]
+    if (
+        not isinstance(pid, int)
+        or isinstance(pid, bool)
+        or pid <= 0
+        or not isinstance(creation_time, int)
+        or isinstance(creation_time, bool)
+        or creation_time <= 0
+        or not isinstance(executable, str)
+        or not executable
+    ):
+        raise TransactionError(f"{description} identity is invalid")
+    return WindowsProcessIdentity(pid, creation_time, executable.casefold())
+
+
+def _pid_is_running(pid, identity=None):
     if not isinstance(pid, int) or pid <= 0:
         return False
     if os.name == "nt":
-        import ctypes
-        from ctypes import wintypes
-
-        process_query_limited_information = 0x1000
-        still_active = 259
-        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-        kernel32.OpenProcess.argtypes = (
-            wintypes.DWORD,
-            wintypes.BOOL,
-            wintypes.DWORD,
-        )
-        kernel32.OpenProcess.restype = wintypes.HANDLE
-        kernel32.GetExitCodeProcess.argtypes = (
-            wintypes.HANDLE,
-            ctypes.POINTER(wintypes.DWORD),
-        )
-        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
-        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
-        kernel32.CloseHandle.restype = wintypes.BOOL
-        handle = kernel32.OpenProcess(
-            process_query_limited_information, False, pid
-        )
-        if not handle:
-            # Access denied still means that a process owns this PID. Other
-            # failures (most commonly an invalid PID) mean it has exited.
-            return ctypes.get_last_error() == 5
+        handle = _open_windows_process(pid)
+        if handle is None:
+            return False
+        ctypes, wintypes, kernel32 = _windows_process_api()
         try:
             exit_code = wintypes.DWORD()
             if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
-                return True
-            return exit_code.value == still_active
+                raise OSError(ctypes.get_last_error(), "could not inspect process exit")
+            if exit_code.value != 259:
+                return False
+            if identity is not None:
+                observed = _windows_process_identity_from_handle(handle, pid)
+                if observed != identity:
+                    return False
+            return True
         finally:
             kernel32.CloseHandle(handle)
     try:
@@ -1276,9 +1476,37 @@ def _pid_is_running(pid):
     return True
 
 
-def _wait_for_pid_exit(pid, timeout):
+def _wait_for_pid_exit(pid, timeout, identity=None):
+    if os.name == "nt" and identity is not None:
+        handle = _open_windows_process(pid)
+        if handle is None:
+            return
+        _ctypes, _wintypes, kernel32 = _windows_process_api()
+        try:
+            exit_code = _wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(
+                handle, _ctypes.byref(exit_code)
+            ):
+                raise OSError(
+                    _ctypes.get_last_error(), "could not inspect launcher exit"
+                )
+            if exit_code.value != 259:
+                return
+            observed = _windows_process_identity_from_handle(handle, pid)
+            if observed != identity:
+                return
+            wait_result = kernel32.WaitForSingleObject(handle, int(timeout * 1000))
+            if wait_result == 0:
+                return
+            if wait_result == 0x102:
+                raise TransactionError(
+                    "the launcher did not exit before the update timeout"
+                )
+            raise OSError(wait_result, "could not wait for the launcher to exit")
+        finally:
+            kernel32.CloseHandle(handle)
     deadline = time.monotonic() + timeout
-    while _pid_is_running(pid):
+    while _pid_is_running(pid, identity):
         if time.monotonic() >= deadline:
             raise TransactionError("the launcher did not exit before the update timeout")
         time.sleep(0.1)
@@ -1494,6 +1722,9 @@ def _default_restart(paths, timeout=30):
         creationflags=0x08000000 if os.name == "nt" else 0,
     )
     try:
+        identity = (
+            _windows_process_identity(process.pid) if os.name == "nt" else None
+        )
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if paths["ack"].is_file():
@@ -1515,16 +1746,10 @@ def _default_restart(paths, timeout=30):
                             f"acknowledgement ({code})"
                         )
                     time.sleep(0.1)
-                # The restarted launcher is intentionally independent of the
-                # short-lived helper. Close only our Windows process handle
-                # after acknowledgement; this does not terminate the child.
-                process.poll()
-                if process.returncode is None and os.name == "nt":
-                    handle = getattr(process, "_handle", None)
-                    if handle is not None:
-                        handle.Close()
-                    process.returncode = 0
-                return process.pid
+                # Keep the owned process handle until the transaction has
+                # committed. If commit fails, rollback can terminate exactly
+                # this process without trusting a potentially reused PID.
+                return RestartedProcess(process, identity)
             code = process.poll()
             if code is not None:
                 raise TransactionError(
@@ -1576,6 +1801,8 @@ def _commit_transaction(paths, plan):
 
 
 def _terminate_restarted_process(value):
+    if isinstance(value, RestartedProcess):
+        value = value.process
     if isinstance(value, subprocess.Popen):
         if value.poll() is None:
             try:
@@ -1587,15 +1814,22 @@ def _terminate_restarted_process(value):
                 except OSError:
                     pass
         return
-    if not isinstance(value, int) or value <= 0 or not _pid_is_running(value):
+    # Never signal an integer PID supplied by a custom restart hook. Without a
+    # retained handle and creation identity, the PID could belong to a later,
+    # unrelated process.
+
+
+def _release_restarted_process(value):
+    if isinstance(value, RestartedProcess):
+        value = value.process
+    if not isinstance(value, subprocess.Popen):
         return
-    try:
-        os.kill(value, 15)
-    except OSError:
-        return
-    deadline = time.monotonic() + 5
-    while _pid_is_running(value) and time.monotonic() < deadline:
-        time.sleep(0.05)
+    value.poll()
+    if value.returncode is None and os.name == "nt":
+        handle = getattr(value, "_handle", None)
+        if handle is not None:
+            handle.Close()
+        value.returncode = 0
 
 
 def discard_staged_transaction(root, transaction_id):
@@ -1628,11 +1862,26 @@ def apply_transaction(
     journal = _load_json(paths["journal"], "update journal")
     if launcher_pid is None:
         launcher_pid = journal.get("launcher_pid")
-    _journal(paths, "waiting_for_launcher_exit", helper_pid=os.getpid(), launcher_pid=launcher_pid)
+    launcher_identity = _parse_identity_record(
+        journal.get("launcher_identity"), description="launcher"
+    )
+    if os.name == "nt" and launcher_pid is not None and launcher_identity is None:
+        raise TransactionError("the activated update has no trusted launcher identity")
+    helper_identity = (
+        _windows_process_identity(os.getpid()) if os.name == "nt" else None
+    )
+    _journal(
+        paths,
+        "waiting_for_launcher_exit",
+        helper_pid=os.getpid(),
+        helper_identity=_identity_record(helper_identity),
+        launcher_pid=launcher_pid,
+        launcher_identity=_identity_record(launcher_identity),
+    )
     restarted_process = None
     try:
         if launcher_pid is not None:
-            _wait_for_pid_exit(launcher_pid, 30)
+            _wait_for_pid_exit(launcher_pid, 30, launcher_identity)
         _journal(paths, "backing_up")
         _prepare_backup(paths, plan)
         _apply_target(paths, plan)
@@ -1641,7 +1890,9 @@ def apply_transaction(
             return _commit_transaction(paths, plan)
         _journal(paths, "awaiting_restart")
         restarted_process = (restart or _default_restart)(paths)
-        return _commit_transaction(paths, plan)
+        result = _commit_transaction(paths, plan)
+        _release_restarted_process(restarted_process)
+        return result
     except Exception as exc:
         if restarted_process is not None:
             _terminate_restarted_process(restarted_process)
@@ -1674,13 +1925,22 @@ def recover_pending_update(root):
     paths = _transaction_paths(root, marker["transaction_id"])
     journal = _load_json(paths["journal"], "update journal")
     helper_pid = journal.get("helper_pid")
+    helper_identity = _parse_identity_record(
+        journal.get("helper_identity"), description="helper"
+    )
     updated_at = journal.get("updated_at")
     helper_is_recent = (
         isinstance(updated_at, (int, float))
         and not isinstance(updated_at, bool)
         and 0 <= time.time() - updated_at < 10 * 60
     )
-    if helper_is_recent and _pid_is_running(helper_pid):
+    helper_is_owned = (
+        _pid_is_running(helper_pid)
+        if os.name != "nt"
+        else helper_identity is not None
+        and _pid_is_running(helper_pid, helper_identity)
+    )
+    if helper_is_recent and helper_is_owned:
         return {"status": "busy", "message": "A Mission Control update is still running."}
     state = journal.get("state")
     if state in {

--- a/runtime_update.py
+++ b/runtime_update.py
@@ -1,0 +1,1725 @@
+"""Verified, crash-recoverable runtime updates for packaged Mission Control.
+
+The module deliberately uses only the Python standard library.  Source
+checkouts are not update targets: an eligible installation has a ``Dashboard``
+directory beside a generated ``WMC-INSTALL-MANIFEST.json`` at its package root.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import time
+import urllib.parse
+import urllib.request
+import uuid
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+INSTALL_MANIFEST_NAME = "WMC-INSTALL-MANIFEST.json"
+UPDATE_MANIFEST_NAME = "update-manifest.json"
+UPDATE_DIRECTORY_NAME = ".wmc-update"
+ACTIVE_TRANSACTION_NAME = "active.json"
+TRANSACTION_PLAN_NAME = "plan.json"
+TRANSACTION_JOURNAL_NAME = "journal.json"
+RESTART_ACK_NAME = "restart-ack.json"
+UPDATER_PROTOCOL = 1
+RESTART_STABILITY_SECONDS = 1.0
+
+MAX_UPDATE_DOWNLOAD_BYTES = 32 * 1024 * 1024
+MAX_CHECKSUM_BYTES = 1024
+MAX_RELEASE_NOTES_CHARS = 256 * 1024
+MAX_RELEASE_ASSETS = 128
+MAX_ARCHIVE_ENTRIES = 256
+MAX_ARCHIVE_FILE_BYTES = 32 * 1024 * 1024
+MAX_ARCHIVE_EXPANDED_BYTES = 64 * 1024 * 1024
+MAX_RELATIVE_PATH_LENGTH = 220
+
+REPOSITORY_OWNER = "SacredWoobie"
+REPOSITORY_NAME = "woobies-mission-control"
+GITHUB_API_VERSION = "2026-03-10"
+ALLOWED_DOWNLOAD_HOSTS = frozenset(
+    {"github.com", "release-assets.githubusercontent.com"}
+)
+
+_VERSION_TAG = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+_SERVICE_VERSION = re.compile(r"^\d+\.\d+\.\d+(?:\.\d+)?$")
+_SHA256 = re.compile(r"^[0-9a-fA-F]{64}$")
+_COMMIT = re.compile(r"^[0-9a-fA-F]{40}$")
+_WINDOWS_RESERVED = frozenset(
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{index}" for index in range(1, 10)),
+        *(f"LPT{index}" for index in range(1, 10)),
+    }
+)
+_ROOT_MANAGED_FILES = frozenset(
+    {
+        "BUILD-INFO.txt",
+        "CHANGELOG.md",
+        "LICENSE",
+        "QUICKSTART.txt",
+        "THIRD-PARTY/NOTICES.md",
+        "docs/CONTROL_PAD_PROTOCOL.md",
+        "firmware/KSP_control.ino",
+    }
+)
+_SERVICE_FOLDERS = frozenset(
+    {
+        "KRPC.StageStats",
+        "KRPC.SystemHeat",
+        "KRPC.WoobiesMechJeb",
+        "WoobiesControlStats",
+    }
+)
+_UPDATER_CRITICAL_FILES = frozenset(
+    {
+        "Dashboard/Start KSP Dashboard.bat",
+        "Dashboard/ksp_dashboard_app.py",
+        "Dashboard/runtime_update.py",
+        "Dashboard/runtime_update_helper.py",
+    }
+)
+
+
+class UpdateError(ValueError):
+    """Base class for a safe, user-displayable update failure."""
+
+
+class ReleaseValidationError(UpdateError):
+    """The GitHub response or selected assets violated the update contract."""
+
+
+class ManifestValidationError(UpdateError):
+    """An installation or update manifest violated its schema."""
+
+
+class ArchiveValidationError(UpdateError):
+    """An update archive was unsafe, incomplete, or internally inconsistent."""
+
+
+class InstallationError(UpdateError):
+    """The selected package is not eligible for managed updates."""
+
+
+class TransactionError(UpdateError):
+    """A transactional apply, health check, recovery, or rollback failed."""
+
+
+def parse_version(value):
+    """Return a comparable semantic-release tuple, or ``None``."""
+    if not isinstance(value, str):
+        return None
+    match = _VERSION_TAG.fullmatch(value.strip())
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def canonical_version(value):
+    parsed = parse_version(value)
+    if parsed is None:
+        raise ManifestValidationError("versions must use MAJOR.MINOR.PATCH")
+    return ".".join(str(part) for part in parsed)
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _atomic_write_json(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    with temporary.open("w", encoding="utf-8", newline="\n") as stream:
+        json.dump(value, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+
+
+def _load_json(path, description):
+    if _is_reparse_or_symlink(path):
+        raise ManifestValidationError(f"refusing linked {description}")
+    try:
+        with Path(path).open("r", encoding="utf-8") as stream:
+            return json.load(stream)
+    except (OSError, UnicodeError, ValueError) as exc:
+        raise ManifestValidationError(f"could not read {description}: {exc}") from exc
+
+
+def canonical_relative_path(value):
+    """Validate one portable, Windows-safe relative file path."""
+    if not isinstance(value, str) or not value:
+        raise ManifestValidationError("managed paths must be non-empty strings")
+    if len(value) > MAX_RELATIVE_PATH_LENGTH:
+        raise ManifestValidationError(f"managed path is too long: {value!r}")
+    if "\\" in value or "\x00" in value or ":" in value:
+        raise ManifestValidationError(f"managed path uses unsafe characters: {value!r}")
+    if any(ord(character) < 32 for character in value):
+        raise ManifestValidationError(f"managed path uses control characters: {value!r}")
+
+    path = PurePosixPath(value)
+    if path.is_absolute() or value.startswith("/"):
+        raise ManifestValidationError(f"managed path must be relative: {value!r}")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ManifestValidationError(f"managed path contains an unsafe segment: {value!r}")
+    for part in path.parts:
+        if part.endswith((" ", ".")):
+            raise ManifestValidationError(
+                f"managed path is ambiguous on Windows: {value!r}"
+            )
+        stem = part.split(".", 1)[0].upper()
+        if stem in _WINDOWS_RESERVED:
+            raise ManifestValidationError(
+                f"managed path uses a reserved Windows name: {value!r}"
+            )
+    return path.as_posix()
+
+
+def _is_allowed_dashboard_path(path):
+    parts = PurePosixPath(path).parts
+    if len(parts) < 2 or parts[0] != "Dashboard":
+        return False
+    if any(part.casefold() in {".venv", "__pycache__"} for part in parts):
+        return False
+    if any(part.casefold().endswith((".log", ".pyc", ".pyo")) for part in parts):
+        return False
+    if len(parts) == 2:
+        suffix = PurePosixPath(parts[-1]).suffix.casefold()
+        return suffix in {".py", ".txt", ".ps1", ".bat"}
+    if parts[1] != "web":
+        return False
+    if len(parts) == 3 and parts[2] == "index.html":
+        return True
+    if len(parts) == 4 and parts[2] == "assets":
+        return PurePosixPath(parts[3]).suffix.casefold() in {".js", ".css", ".map"}
+    return False
+
+
+def is_allowed_managed_path(path):
+    """Return whether *path* belongs to the product-managed update surface."""
+    try:
+        path = canonical_relative_path(path)
+    except ManifestValidationError:
+        return False
+    if path in _ROOT_MANAGED_FILES:
+        return True
+    if _is_allowed_dashboard_path(path):
+        return True
+    parts = PurePosixPath(path).parts
+    if len(parts) >= 3 and parts[0] == "GameData" and parts[1] in _SERVICE_FOLDERS:
+        return True
+    if len(parts) == 2 and parts[0] == "SOURCE":
+        return parts[1].casefold().endswith("-source.zip")
+    return False
+
+
+def _validate_hash(value, description):
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise ManifestValidationError(f"{description} must be a SHA-256 digest")
+    return value.lower()
+
+
+def _validate_file_records(records, *, allow_install_manifest=False):
+    if not isinstance(records, list) or not records:
+        raise ManifestValidationError("manifest files must be a non-empty list")
+    normalized = []
+    identities = set()
+    for record in records:
+        if not isinstance(record, dict) or set(record) != {"path", "size", "sha256"}:
+            raise ManifestValidationError(
+                "each manifest file must contain only path, size, and sha256"
+            )
+        path = canonical_relative_path(record["path"])
+        managed_path = path
+        if allow_install_manifest:
+            if not path.startswith("payload/"):
+                raise ManifestValidationError(
+                    f"update payload path must begin with payload/: {path}"
+                )
+            managed_path = path[len("payload/") :]
+        allowed = is_allowed_managed_path(managed_path)
+        if allow_install_manifest and managed_path == INSTALL_MANIFEST_NAME:
+            allowed = True
+        if not allowed:
+            raise ManifestValidationError(f"path is outside the managed surface: {path}")
+        identity = path.casefold()
+        if identity in identities:
+            raise ManifestValidationError(
+                f"manifest contains a case-insensitive path collision: {path}"
+            )
+        identities.add(identity)
+        size = record["size"]
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise ManifestValidationError(f"invalid file size for {path}")
+        if size > MAX_ARCHIVE_FILE_BYTES:
+            raise ManifestValidationError(f"managed file is too large: {path}")
+        normalized.append(
+            {"path": path, "size": size, "sha256": _validate_hash(record["sha256"], path)}
+        )
+    if normalized != sorted(normalized, key=lambda item: item["path"].casefold()):
+        raise ManifestValidationError("manifest file records must be sorted by path")
+    return normalized
+
+
+def _validate_services(records):
+    if not isinstance(records, list):
+        raise ManifestValidationError("manifest services must be a list")
+    normalized = []
+    names = set()
+    for record in records:
+        if not isinstance(record, dict) or set(record) != {"name", "version", "sha256"}:
+            raise ManifestValidationError(
+                "each service must contain only name, version, and sha256"
+            )
+        name = record["name"]
+        if name not in _SERVICE_FOLDERS or name in names:
+            raise ManifestValidationError(f"invalid or duplicate service name: {name!r}")
+        names.add(name)
+        version = record["version"]
+        if not isinstance(version, str) or _SERVICE_VERSION.fullmatch(version) is None:
+            raise ManifestValidationError(f"invalid service version for {name}")
+        normalized.append(
+            {
+                "name": name,
+                "version": version,
+                "sha256": _validate_hash(record["sha256"], name),
+            }
+        )
+    if normalized != sorted(normalized, key=lambda item: item["name"].casefold()):
+        raise ManifestValidationError("service records must be sorted by name")
+    return normalized
+
+
+def validate_install_manifest(value):
+    """Validate and normalize a generated installation manifest."""
+    expected = {
+        "schema",
+        "product_version",
+        "updater_protocol",
+        "source_commit",
+        "services",
+        "files",
+    }
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ManifestValidationError(
+            "install manifest must contain the exact schema, version, source, service, and file fields"
+        )
+    if value["schema"] != 1:
+        raise ManifestValidationError("unsupported install-manifest schema")
+    protocol = value["updater_protocol"]
+    if not isinstance(protocol, int) or isinstance(protocol, bool) or protocol < 1:
+        raise ManifestValidationError("invalid updater protocol")
+    source_commit = value["source_commit"]
+    if not isinstance(source_commit, str) or _COMMIT.fullmatch(source_commit) is None:
+        raise ManifestValidationError("install manifest source commit must be a Git commit")
+    return {
+        "schema": 1,
+        "product_version": canonical_version(value["product_version"]),
+        "updater_protocol": protocol,
+        "source_commit": source_commit.lower(),
+        "services": _validate_services(value["services"]),
+        "files": _validate_file_records(value["files"]),
+    }
+
+
+def validate_update_manifest(value):
+    """Validate and normalize the manifest stored inside an update archive."""
+    expected = {
+        "schema",
+        "product_version",
+        "source_commit",
+        "compatible_updater_protocols",
+        "services",
+        "files",
+    }
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ManifestValidationError(
+            "update manifest must contain the exact schema, version, source, protocol, service, and file fields"
+        )
+    if value["schema"] != 1:
+        raise ManifestValidationError("unsupported update-manifest schema")
+    protocols = value["compatible_updater_protocols"]
+    if (
+        not isinstance(protocols, list)
+        or not protocols
+        or any(not isinstance(item, int) or isinstance(item, bool) or item < 1 for item in protocols)
+        or protocols != sorted(set(protocols))
+    ):
+        raise ManifestValidationError("compatible updater protocols must be unique sorted integers")
+    source_commit = value["source_commit"]
+    if not isinstance(source_commit, str) or _COMMIT.fullmatch(source_commit) is None:
+        raise ManifestValidationError("update manifest source commit must be a Git commit")
+    return {
+        "schema": 1,
+        "product_version": canonical_version(value["product_version"]),
+        "source_commit": source_commit.lower(),
+        "compatible_updater_protocols": protocols,
+        "services": _validate_services(value["services"]),
+        "files": _validate_file_records(value["files"], allow_install_manifest=True),
+    }
+
+
+def verify_installation_files(root, manifest):
+    """Return missing or changed managed files without writing anything."""
+    root = Path(root)
+    differences = []
+    for record in manifest["files"]:
+        path = safe_destination(root, record["path"])
+        if not path.is_file():
+            differences.append({"path": record["path"], "status": "missing"})
+            continue
+        try:
+            size = path.stat().st_size
+            digest = sha256_file(path)
+        except OSError as exc:
+            differences.append(
+                {"path": record["path"], "status": "unreadable", "error": str(exc)}
+            )
+            continue
+        if size != record["size"] or digest != record["sha256"]:
+            differences.append({"path": record["path"], "status": "modified"})
+    return differences
+
+
+def load_install_manifest(root, *, verify_files=False):
+    root = Path(root)
+    manifest = validate_install_manifest(
+        _load_json(root / INSTALL_MANIFEST_NAME, "installation manifest")
+    )
+    if verify_files:
+        differences = verify_installation_files(root, manifest)
+        if differences:
+            summary = ", ".join(item["path"] for item in differences[:5])
+            raise InstallationError(f"managed installation files do not match: {summary}")
+    return manifest
+
+
+def update_asset_names(version):
+    version = canonical_version(version)
+    archive = f"Woobies-Mission-Control-v{version}.zz-90-runtime-update.zip"
+    return archive, archive + ".sha256"
+
+
+def _canonical_release_html(tag):
+    return (
+        f"https://github.com/{REPOSITORY_OWNER}/{REPOSITORY_NAME}/"
+        f"releases/tag/{tag}"
+    )
+
+
+def _canonical_asset_url(tag, name):
+    return (
+        f"https://github.com/{REPOSITORY_OWNER}/{REPOSITORY_NAME}/"
+        f"releases/download/{tag}/{urllib.parse.quote(name)}"
+    )
+
+
+def validate_release_payload(payload):
+    """Validate the stable GitHub release fields used by the launcher."""
+    if not isinstance(payload, dict):
+        raise ReleaseValidationError("GitHub returned an invalid release response")
+    tag = payload.get("tag_name")
+    if parse_version(tag) is None or not isinstance(tag, str):
+        raise ReleaseValidationError("the latest release tag is not vMAJOR.MINOR.PATCH")
+    tag = tag.strip()
+    if tag != f"v{canonical_version(tag)}":
+        raise ReleaseValidationError("the latest release tag is not canonical vMAJOR.MINOR.PATCH")
+    html_url = payload.get("html_url")
+    if html_url != _canonical_release_html(tag):
+        raise ReleaseValidationError("the latest release has an unexpected web address")
+    if payload.get("draft") is not False or payload.get("prerelease") is not False:
+        raise ReleaseValidationError("the latest endpoint returned a non-stable release")
+    immutable = payload.get("immutable")
+    if not isinstance(immutable, bool):
+        raise ReleaseValidationError("GitHub did not report release immutability")
+    body = payload.get("body", "")
+    if body is None:
+        body = ""
+    if not isinstance(body, str):
+        raise ReleaseValidationError("the latest release notes are invalid")
+    if len(body) > MAX_RELEASE_NOTES_CHARS:
+        raise ReleaseValidationError("the latest release notes are unexpectedly large")
+    assets = payload.get("assets")
+    if not isinstance(assets, list) or len(assets) > MAX_RELEASE_ASSETS:
+        raise ReleaseValidationError("the latest release assets are invalid")
+    normalized_assets = []
+    names = set()
+    for asset in assets:
+        if not isinstance(asset, dict):
+            raise ReleaseValidationError("the latest release contains an invalid asset")
+        name = asset.get("name")
+        size = asset.get("size")
+        url = asset.get("browser_download_url")
+        digest = asset.get("digest")
+        if (
+            not isinstance(name, str)
+            or not name
+            or len(name) > 200
+            or "/" in name
+            or "\\" in name
+            or any(ord(character) < 32 for character in name)
+        ):
+            raise ReleaseValidationError("a release asset has an invalid name")
+        identity = name.casefold()
+        if identity in names:
+            raise ReleaseValidationError(f"duplicate release asset name: {name}")
+        names.add(identity)
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise ReleaseValidationError(f"release asset has an invalid size: {name}")
+        if asset.get("state") != "uploaded":
+            raise ReleaseValidationError(f"release asset is not fully uploaded: {name}")
+        if url != _canonical_asset_url(tag, name):
+            raise ReleaseValidationError(f"release asset has an unexpected URL: {name}")
+        normalized_digest = None
+        if digest is not None:
+            if not isinstance(digest, str) or not digest.startswith("sha256:"):
+                raise ReleaseValidationError(f"release asset has an invalid digest: {name}")
+            normalized_digest = _validate_hash(digest[7:], name)
+        normalized_assets.append(
+            {
+                "name": name,
+                "size": size,
+                "browser_download_url": url,
+                "state": "uploaded",
+                "digest": (
+                    f"sha256:{normalized_digest}"
+                    if normalized_digest is not None
+                    else None
+                ),
+                "sha256": normalized_digest,
+            }
+        )
+    return {
+        "tag_name": tag,
+        "html_url": html_url,
+        "draft": False,
+        "prerelease": False,
+        "immutable": immutable,
+        "body": body,
+        "assets": normalized_assets,
+    }
+
+
+def select_update_assets(release):
+    """Return the unique, immutable runtime update and checksum assets."""
+    if release.get("immutable") is not True:
+        raise ReleaseValidationError("the release is mutable and cannot be installed")
+    archive_name, checksum_name = update_asset_names(release["tag_name"])
+    by_name = {asset["name"]: asset for asset in release["assets"]}
+    archive = by_name.get(archive_name)
+    checksum = by_name.get(checksum_name)
+    if archive is None or checksum is None:
+        raise ReleaseValidationError("the release does not include the runtime update and checksum")
+    if archive["size"] <= 0 or archive["size"] > MAX_UPDATE_DOWNLOAD_BYTES:
+        raise ReleaseValidationError("the runtime update asset has an unsafe size")
+    if checksum["size"] <= 0 or checksum["size"] > MAX_CHECKSUM_BYTES:
+        raise ReleaseValidationError("the runtime update checksum has an unsafe size")
+    if archive["sha256"] is None or checksum["sha256"] is None:
+        raise ReleaseValidationError("GitHub did not provide SHA-256 digests for the update assets")
+    return archive, checksum
+
+
+def _validate_final_download_url(value):
+    parsed = urllib.parse.urlparse(value)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ReleaseValidationError("the update download used an invalid port") from exc
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname not in ALLOWED_DOWNLOAD_HOSTS
+        or port not in {None, 443}
+    ):
+        raise ReleaseValidationError("the update download redirected to an unexpected host")
+    if parsed.username is not None or parsed.password is not None:
+        raise ReleaseValidationError("the update download URL contains credentials")
+
+
+def download_asset(asset, destination, *, opener=urllib.request.urlopen, timeout=30, max_bytes):
+    """Stream one canonical release asset with strict length and digest checks."""
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    request = urllib.request.Request(
+        asset["browser_download_url"],
+        headers={
+            "Accept": "application/octet-stream",
+            "User-Agent": "Woobies-Mission-Control-Updater/1",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+    )
+    temporary = destination.with_name(destination.name + ".part")
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with opener(request, timeout=timeout) as response:
+            final_url = (
+                response.geturl()
+                if callable(getattr(response, "geturl", None))
+                else asset["browser_download_url"]
+            )
+            _validate_final_download_url(final_url)
+            headers = getattr(response, "headers", None)
+            if headers is not None:
+                declared = headers.get("Content-Length")
+                if declared is not None:
+                    try:
+                        declared_size = int(declared)
+                    except ValueError as exc:
+                        raise ReleaseValidationError("download returned an invalid length") from exc
+                    if declared_size != asset["size"] or declared_size > max_bytes:
+                        raise ReleaseValidationError("download length does not match release metadata")
+            with temporary.open("wb") as stream:
+                while True:
+                    block = response.read(1024 * 1024)
+                    if not block:
+                        break
+                    total += len(block)
+                    if total > max_bytes or total > asset["size"]:
+                        raise ReleaseValidationError("download exceeded its declared safe size")
+                    digest.update(block)
+                    stream.write(block)
+                stream.flush()
+                os.fsync(stream.fileno())
+        if total != asset["size"]:
+            raise ReleaseValidationError("download size does not match release metadata")
+        if digest.hexdigest() != asset["sha256"]:
+            raise ReleaseValidationError("download SHA-256 does not match GitHub metadata")
+        os.replace(temporary, destination)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+    return destination
+
+
+def parse_checksum(text, expected_name):
+    if not isinstance(text, str):
+        raise ReleaseValidationError("update checksum is not text")
+    match = re.fullmatch(r"([0-9a-fA-F]{64})[ \t]+\*?([^\r\n]+)\r?\n?", text)
+    if match is None or match.group(2) != expected_name:
+        raise ReleaseValidationError("update checksum has an unexpected format or filename")
+    return match.group(1).lower()
+
+
+def download_verified_update(release, cache_directory, *, opener=urllib.request.urlopen):
+    """Download both immutable assets and enforce GitHub plus sidecar hashes."""
+    archive_asset, checksum_asset = select_update_assets(release)
+    cache_directory = Path(cache_directory)
+    archive = download_asset(
+        archive_asset,
+        cache_directory / archive_asset["name"],
+        opener=opener,
+        max_bytes=MAX_UPDATE_DOWNLOAD_BYTES,
+    )
+    checksum = download_asset(
+        checksum_asset,
+        cache_directory / checksum_asset["name"],
+        opener=opener,
+        max_bytes=MAX_CHECKSUM_BYTES,
+    )
+    try:
+        checksum_text = checksum.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ReleaseValidationError(f"could not read update checksum: {exc}") from exc
+    sidecar_digest = parse_checksum(checksum_text, archive_asset["name"])
+    if sidecar_digest != archive_asset["sha256"] or sha256_file(archive) != sidecar_digest:
+        raise ReleaseValidationError("update archive does not match its published checksum")
+    return archive
+
+
+def _zip_entry_is_link_or_reparse(info):
+    unix_mode = (info.external_attr >> 16) & 0xFFFF
+    if unix_mode and stat.S_ISLNK(unix_mode):
+        return True
+    dos_attributes = info.external_attr & 0xFFFF
+    return bool(dos_attributes & 0x0400)
+
+
+def inspect_update_archive(path):
+    """Validate an update ZIP without extracting it and return both manifests."""
+    path = Path(path)
+    try:
+        archive = zipfile.ZipFile(path, "r")
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ArchiveValidationError(f"could not open update archive: {exc}") from exc
+    with archive:
+        infos = archive.infolist()
+        if not infos or len(infos) > MAX_ARCHIVE_ENTRIES:
+            raise ArchiveValidationError("update archive has an unsafe entry count")
+        files = {}
+        identities = set()
+        expanded = 0
+        for info in infos:
+            try:
+                name = canonical_relative_path(info.filename)
+            except ManifestValidationError as exc:
+                raise ArchiveValidationError(str(exc)) from exc
+            if _zip_entry_is_link_or_reparse(info):
+                raise ArchiveValidationError(f"update archive contains a link: {name}")
+            if info.flag_bits & 0x1:
+                raise ArchiveValidationError(f"update archive contains an encrypted entry: {name}")
+            if info.compress_type not in {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}:
+                raise ArchiveValidationError(
+                    f"update archive uses an unsupported compression method: {name}"
+                )
+            identity = name.casefold().rstrip("/")
+            if identity in identities:
+                raise ArchiveValidationError(f"update archive contains a path collision: {name}")
+            identities.add(identity)
+            if info.is_dir():
+                continue
+            if info.file_size < 0 or info.file_size > MAX_ARCHIVE_FILE_BYTES:
+                raise ArchiveValidationError(f"update archive entry is too large: {name}")
+            expanded += info.file_size
+            if expanded > MAX_ARCHIVE_EXPANDED_BYTES:
+                raise ArchiveValidationError("update archive expands beyond its safe limit")
+            files[name] = info
+        manifest_info = files.get(UPDATE_MANIFEST_NAME)
+        if manifest_info is None:
+            raise ArchiveValidationError("update archive is missing update-manifest.json")
+        try:
+            raw_manifest = archive.read(manifest_info)
+            if len(raw_manifest) > 1024 * 1024:
+                raise ArchiveValidationError("update manifest is too large")
+            update_manifest = validate_update_manifest(json.loads(raw_manifest.decode("utf-8")))
+        except (UnicodeError, ValueError, ManifestValidationError) as exc:
+            raise ArchiveValidationError(f"invalid update manifest: {exc}") from exc
+
+        expected = {UPDATE_MANIFEST_NAME, *(record["path"] for record in update_manifest["files"])}
+        if set(files) != expected:
+            missing = sorted(expected - set(files))
+            extra = sorted(set(files) - expected)
+            raise ArchiveValidationError(
+                f"update archive contents do not match its manifest; missing={missing}, extra={extra}"
+            )
+        for record in update_manifest["files"]:
+            info = files[record["path"]]
+            if info.file_size != record["size"]:
+                raise ArchiveValidationError(f"payload size mismatch: {record['path']}")
+            digest = hashlib.sha256()
+            with archive.open(info, "r") as stream:
+                for block in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(block)
+            if digest.hexdigest() != record["sha256"]:
+                raise ArchiveValidationError(f"payload hash mismatch: {record['path']}")
+
+        install_record_path = f"payload/{INSTALL_MANIFEST_NAME}"
+        install_info = files.get(install_record_path)
+        if install_info is None:
+            raise ArchiveValidationError("update payload is missing its install manifest")
+        try:
+            install_manifest = validate_install_manifest(
+                json.loads(archive.read(install_info).decode("utf-8"))
+            )
+        except (UnicodeError, ValueError, ManifestValidationError) as exc:
+            raise ArchiveValidationError(f"invalid target install manifest: {exc}") from exc
+        if (
+            install_manifest["product_version"] != update_manifest["product_version"]
+            or install_manifest["source_commit"] != update_manifest["source_commit"]
+            or install_manifest["services"] != update_manifest["services"]
+        ):
+            raise ArchiveValidationError("update and target install manifests disagree")
+        payload_records = {
+            record["path"][len("payload/") :]: {
+                "path": record["path"][len("payload/") :],
+                "size": record["size"],
+                "sha256": record["sha256"],
+            }
+            for record in update_manifest["files"]
+            if record["path"] != install_record_path
+        }
+        target_records = {record["path"]: record for record in install_manifest["files"]}
+        if payload_records != target_records:
+            raise ArchiveValidationError("update payload does not exactly match target managed files")
+        return update_manifest, install_manifest
+
+
+def _is_reparse_or_symlink(path):
+    try:
+        metadata = Path(path).lstat()
+    except FileNotFoundError:
+        return False
+    if stat.S_ISLNK(metadata.st_mode):
+        return True
+    return bool(getattr(metadata, "st_file_attributes", 0) & 0x0400)
+
+
+def safe_destination(root, relative_path):
+    """Resolve one validated path while rejecting existing link ancestors."""
+    relative_path = canonical_relative_path(relative_path)
+    root = Path(root).resolve()
+    current = root
+    for part in PurePosixPath(relative_path).parts:
+        current = current / part
+        if current.exists() and _is_reparse_or_symlink(current):
+            raise InstallationError(f"managed path crosses a link or reparse point: {relative_path}")
+    try:
+        current.resolve(strict=False).relative_to(root)
+    except ValueError as exc:
+        raise InstallationError(f"managed path escapes the package: {relative_path}") from exc
+    return current
+
+
+def package_root_from_dashboard(dashboard_directory):
+    dashboard = Path(dashboard_directory).resolve()
+    if dashboard.name.casefold() != "dashboard":
+        return None
+    root = dashboard.parent
+    if (root / INSTALL_MANIFEST_NAME).is_file():
+        return root
+    return None
+
+
+def _validate_package_root_boundary(root):
+    root = Path(root).resolve()
+    if not root.is_dir():
+        raise InstallationError("the Mission Control package folder is unavailable")
+    if any(part.casefold() == "gamedata" for part in root.parts):
+        raise InstallationError("Mission Control must be moved outside KSP GameData before updating")
+    return root
+
+
+def validate_package_location(root):
+    root = _validate_package_root_boundary(root)
+    if not (root / "Dashboard" / "ksp_dashboard_app.py").is_file():
+        raise InstallationError("the selected folder is not a packaged Mission Control installation")
+    return root
+
+
+def assess_installation(dashboard_directory, current_version):
+    """Return read-only updater eligibility for one running launcher."""
+    root = package_root_from_dashboard(dashboard_directory)
+    if root is None:
+        return {
+            "eligible": False,
+            "reason": "Managed updates are available only in an installed release package.",
+            "root": None,
+            "manifest": None,
+        }
+    try:
+        validate_package_location(root)
+        manifest = load_install_manifest(root)
+        if manifest["product_version"] != canonical_version(current_version):
+            raise InstallationError("the package manifest version does not match the launcher")
+        if manifest["updater_protocol"] != UPDATER_PROTOCOL:
+            raise InstallationError("this package uses an unsupported updater protocol")
+        managed_paths = {item["path"].casefold() for item in manifest["files"]}
+        missing_critical = sorted(
+            path for path in _UPDATER_CRITICAL_FILES if path.casefold() not in managed_paths
+        )
+        if missing_critical:
+            raise InstallationError(
+                "the package manifest does not own every updater-critical file"
+            )
+        differences = verify_installation_files(root, manifest)
+        critical = [
+            item
+            for item in differences
+            if item["path"].casefold()
+            in {path.casefold() for path in _UPDATER_CRITICAL_FILES}
+        ]
+        if critical:
+            raise InstallationError(
+                "updater-critical package files were modified or missing"
+            )
+    except UpdateError as exc:
+        return {"eligible": False, "reason": str(exc), "root": root, "manifest": None}
+    return {"eligible": True, "reason": "", "root": root, "manifest": manifest}
+
+
+def assess_release_offer(release, current_version, dashboard_directory):
+    """Classify whether a normalized newer release can be installed in-app."""
+    current = parse_version(current_version)
+    latest = parse_version(release.get("tag_name"))
+    if current is None or latest is None:
+        return {"installable": False, "reason": "Release versions are invalid."}
+    if latest <= current:
+        return {
+            "installable": False,
+            "reason": "The published release is not newer than this launcher.",
+        }
+    installation = assess_installation(dashboard_directory, current_version)
+    if not installation["eligible"]:
+        return {"installable": False, "reason": installation["reason"]}
+    try:
+        archive, checksum = select_update_assets(release)
+    except UpdateError as exc:
+        return {"installable": False, "reason": str(exc)}
+    return {
+        "installable": True,
+        "reason": "",
+        "root": installation["root"],
+        "manifest": installation["manifest"],
+        "archive_asset": archive,
+        "checksum_asset": checksum,
+    }
+
+
+def verify_update_compatibility(current_manifest, update_manifest, target_manifest):
+    current = parse_version(current_manifest["product_version"])
+    target = parse_version(update_manifest["product_version"])
+    if current is None or target is None or target <= current:
+        raise InstallationError("the update target must be newer than this installation")
+    if current_manifest["updater_protocol"] not in update_manifest["compatible_updater_protocols"]:
+        raise InstallationError("this launcher needs a manual full-package update")
+    if target_manifest["updater_protocol"] not in update_manifest["compatible_updater_protocols"]:
+        raise InstallationError("the target install manifest uses an incompatible updater protocol")
+    for description, manifest in (
+        ("current", current_manifest),
+        ("target", target_manifest),
+    ):
+        managed_paths = {item["path"].casefold() for item in manifest["files"]}
+        missing = sorted(
+            path for path in _UPDATER_CRITICAL_FILES if path.casefold() not in managed_paths
+        )
+        if missing:
+            raise InstallationError(
+                f"the {description} package is missing updater-critical manifest entries: "
+                + ", ".join(missing)
+            )
+
+
+def extract_update_payload(archive_path, stage_root):
+    """Validate then extract only declared payload files into a clean stage."""
+    update_manifest, install_manifest = inspect_update_archive(archive_path)
+    stage_root = Path(stage_root)
+    if stage_root.exists():
+        raise TransactionError(f"update stage already exists: {stage_root}")
+    stage_root.mkdir(parents=True)
+    try:
+        with zipfile.ZipFile(archive_path, "r") as archive:
+            for record in update_manifest["files"]:
+                relative = record["path"][len("payload/") :]
+                destination = safe_destination(stage_root, relative)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                temporary = destination.with_name(destination.name + ".tmp")
+                with archive.open(record["path"], "r") as source, temporary.open("wb") as target:
+                    shutil.copyfileobj(source, target, 1024 * 1024)
+                    target.flush()
+                    os.fsync(target.fileno())
+                os.replace(temporary, destination)
+        for record in install_manifest["files"]:
+            destination = safe_destination(stage_root, record["path"])
+            if destination.stat().st_size != record["size"] or sha256_file(destination) != record["sha256"]:
+                raise TransactionError(f"staged payload verification failed: {record['path']}")
+        manifest_path = stage_root / INSTALL_MANIFEST_NAME
+        if not manifest_path.is_file():
+            raise TransactionError("staged payload is missing its install manifest")
+    except Exception:
+        shutil.rmtree(stage_root, ignore_errors=True)
+        raise
+    return update_manifest, install_manifest
+
+
+def _validate_update_workspace(root, transaction_root=None):
+    root = Path(root).resolve()
+    candidates = [root / UPDATE_DIRECTORY_NAME, root / UPDATE_DIRECTORY_NAME / "transactions"]
+    if transaction_root is not None:
+        candidates.append(Path(transaction_root))
+    for candidate in candidates:
+        if _is_reparse_or_symlink(candidate):
+            raise TransactionError("the update workspace contains a link or reparse point")
+        if candidate.exists() and not candidate.is_dir():
+            raise TransactionError("the update workspace contains a non-directory path")
+
+
+def _transaction_paths(root, transaction_id=None):
+    root = Path(root).resolve()
+    update_root = root / UPDATE_DIRECTORY_NAME
+    transaction_id = transaction_id or uuid.uuid4().hex
+    if not re.fullmatch(r"[0-9a-f]{32}", transaction_id):
+        raise TransactionError("invalid update transaction identifier")
+    transaction_root = update_root / "transactions" / transaction_id
+    _validate_update_workspace(root, transaction_root)
+    return {
+        "root": root,
+        "update_root": update_root,
+        "active": update_root / ACTIVE_TRANSACTION_NAME,
+        "transaction_id": transaction_id,
+        "transaction_root": transaction_root,
+        "stage": transaction_root / "stage",
+        "backup": transaction_root / "backup",
+        "helper": transaction_root / "helper",
+        "plan": transaction_root / TRANSACTION_PLAN_NAME,
+        "journal": transaction_root / TRANSACTION_JOURNAL_NAME,
+        "ack": transaction_root / RESTART_ACK_NAME,
+        "log": transaction_root / "update.log",
+    }
+
+
+def _read_active_marker(root):
+    root = Path(root).resolve()
+    _validate_update_workspace(root)
+    path = root / UPDATE_DIRECTORY_NAME / ACTIVE_TRANSACTION_NAME
+    if not path.exists():
+        return None
+    if not path.is_file():
+        raise TransactionError("active update marker is not a regular file")
+    value = _load_json(path, "active update marker")
+    if not isinstance(value, dict) or set(value) != {"schema", "transaction_id"}:
+        raise TransactionError("active update marker is invalid")
+    if value["schema"] != 1 or not isinstance(value["transaction_id"], str):
+        raise TransactionError("active update marker is invalid")
+    _transaction_paths(root, value["transaction_id"])
+    return value
+
+
+def pending_update_status(root, transaction_token=None):
+    """Return a read-only description of any active update transaction."""
+    root = Path(root).resolve()
+    try:
+        marker = _read_active_marker(root)
+    except UpdateError as exc:
+        return {"pending": True, "state": "invalid", "message": str(exc)}
+    if marker is None:
+        return {"pending": False, "state": "none", "message": "No update is pending."}
+    paths = _transaction_paths(root, marker["transaction_id"])
+    try:
+        journal = _load_json(paths["journal"], "update journal")
+        state = journal.get("state") if isinstance(journal, dict) else "invalid"
+    except UpdateError:
+        state = "invalid"
+    authorized = transaction_token == marker["transaction_id"] and state in {
+        "checking",
+        "awaiting_restart",
+    }
+    return {
+        "pending": not authorized,
+        "state": state,
+        "transaction_id": marker["transaction_id"],
+        "message": (
+            "The active update may launch its verified target."
+            if authorized
+            else f"An update transaction needs attention ({state})."
+        ),
+    }
+
+
+def _journal(paths, state, **values):
+    current = {}
+    if paths["journal"].is_file():
+        loaded = _load_json(paths["journal"], "update journal")
+        if isinstance(loaded, dict):
+            current.update(loaded)
+    current.update(values)
+    current.update(
+        {
+            "schema": 1,
+            "transaction_id": paths["transaction_id"],
+            "state": state,
+            "updated_at": time.time(),
+        }
+    )
+    _atomic_write_json(paths["journal"], current)
+    return current
+
+
+def stage_transaction(root, archive_path, *, transaction_id=None):
+    """Stage and inspect a verified archive without activating an update."""
+    root = validate_package_location(root)
+    if _read_active_marker(root) is not None:
+        raise TransactionError("another update transaction is already active")
+    current_manifest = load_install_manifest(root)
+    paths = _transaction_paths(root, transaction_id)
+    if paths["transaction_root"].exists():
+        raise TransactionError("update transaction directory already exists")
+    paths["transaction_root"].mkdir(parents=True)
+    try:
+        update_manifest, target_manifest = extract_update_payload(archive_path, paths["stage"])
+        verify_update_compatibility(current_manifest, update_manifest, target_manifest)
+        differences = verify_installation_files(root, current_manifest)
+        critical = [
+            item
+            for item in differences
+            if item["path"].casefold()
+            in {path.casefold() for path in _UPDATER_CRITICAL_FILES}
+        ]
+        if critical:
+            names = ", ".join(item["path"] for item in critical)
+            raise InstallationError(
+                "updater-critical files were modified or missing; use the full package: "
+                + names
+            )
+        current_identities = {
+            item["path"].casefold() for item in current_manifest["files"]
+        }
+        unmanaged_collisions = []
+        for record in target_manifest["files"]:
+            if record["path"].casefold() in current_identities:
+                continue
+            destination = safe_destination(root, record["path"])
+            if destination.exists():
+                unmanaged_collisions.append(record["path"])
+        if unmanaged_collisions:
+            raise InstallationError(
+                "new managed files conflict with user-owned package paths; "
+                "preserve them and use the full package: "
+                + ", ".join(unmanaged_collisions[:5])
+            )
+        plan = {
+            "schema": 1,
+            "transaction_id": paths["transaction_id"],
+            "install_root": str(root),
+            "current_manifest": current_manifest,
+            "update_manifest": update_manifest,
+            "target_manifest": target_manifest,
+            "local_differences": differences,
+            "created_at": time.time(),
+        }
+        _atomic_write_json(paths["plan"], plan)
+        _journal(paths, "staged", helper_pid=None, launcher_pid=None)
+        return {
+            "transaction_id": paths["transaction_id"],
+            "current_version": current_manifest["product_version"],
+            "target_version": target_manifest["product_version"],
+            "services": target_manifest["services"],
+            "local_differences": differences,
+            "transaction_root": paths["transaction_root"],
+        }
+    except Exception:
+        shutil.rmtree(paths["transaction_root"], ignore_errors=True)
+        raise
+
+
+def _validate_plan(paths):
+    value = _load_json(paths["plan"], "update transaction plan")
+    expected = {
+        "schema",
+        "transaction_id",
+        "install_root",
+        "current_manifest",
+        "update_manifest",
+        "target_manifest",
+        "local_differences",
+        "created_at",
+    }
+    if not isinstance(value, dict) or set(value) != expected or value["schema"] != 1:
+        raise TransactionError("update transaction plan is invalid")
+    if value["transaction_id"] != paths["transaction_id"]:
+        raise TransactionError("update transaction identifier does not match its folder")
+    if Path(value["install_root"]).resolve() != paths["root"]:
+        raise TransactionError("update transaction targets a different installation")
+    value["current_manifest"] = validate_install_manifest(value["current_manifest"])
+    value["update_manifest"] = validate_update_manifest(value["update_manifest"])
+    value["target_manifest"] = validate_install_manifest(value["target_manifest"])
+    verify_update_compatibility(
+        value["current_manifest"], value["update_manifest"], value["target_manifest"]
+    )
+    if not isinstance(value["local_differences"], list):
+        raise TransactionError("update transaction local-difference list is invalid")
+    return value
+
+
+def activate_transaction(root, transaction_id, *, launcher_pid, python_executable=None):
+    """Activate a staged transaction and spawn its trusted external helper."""
+    paths = _transaction_paths(root, transaction_id)
+    plan = _validate_plan(paths)
+    if _read_active_marker(paths["root"]) is not None:
+        raise TransactionError("another update transaction is already active")
+    journal = _load_json(paths["journal"], "update journal")
+    if journal.get("state") not in {"staged", "activation_failed"}:
+        raise TransactionError("only a staged update transaction can be activated")
+    if not isinstance(launcher_pid, int) or launcher_pid <= 0:
+        raise TransactionError("launcher PID is invalid")
+    if python_executable is None:
+        python_executable = Path(
+            paths["root"] / "Dashboard" / ".venv" / "Scripts" / "python.exe"
+        )
+    python_executable = Path(python_executable).resolve()
+    if not python_executable.is_file():
+        raise InstallationError("the package-local Python environment is not available")
+
+    live_manifest = load_install_manifest(paths["root"])
+    if live_manifest != plan["current_manifest"]:
+        raise InstallationError("the installed package changed after update review")
+    reviewed_differences = {
+        (item.get("path"), item.get("status"))
+        for item in plan["local_differences"]
+        if isinstance(item, dict)
+    }
+    live_differences = {
+        (item.get("path"), item.get("status"))
+        for item in verify_installation_files(paths["root"], live_manifest)
+    }
+    if live_differences != reviewed_differences:
+        raise InstallationError(
+            "managed package files changed after update review; verify the update again"
+        )
+
+    current_records = {item["path"]: item for item in plan["current_manifest"]["files"]}
+    helper_sources = (
+        "Dashboard/runtime_update.py",
+        "Dashboard/runtime_update_helper.py",
+    )
+    command = [
+        str(python_executable),
+        str(paths["helper"] / "runtime_update_helper.py"),
+        "apply",
+        str(paths["root"]),
+        transaction_id,
+        "--launcher-pid",
+        str(launcher_pid),
+    ]
+    creation_flags = 0
+    if os.name == "nt":
+        creation_flags = 0x00000008 | 0x08000000  # DETACHED_PROCESS | CREATE_NO_WINDOW
+    try:
+        if paths["helper"].exists():
+            shutil.rmtree(paths["helper"])
+        paths["helper"].mkdir(parents=True, exist_ok=False)
+        for relative in helper_sources:
+            record = current_records.get(relative)
+            source = safe_destination(paths["root"], relative)
+            if record is None or not source.is_file():
+                raise InstallationError(f"trusted updater helper is missing: {relative}")
+            if (
+                source.stat().st_size != record["size"]
+                or sha256_file(source) != record["sha256"]
+            ):
+                raise InstallationError(f"trusted updater helper was modified: {relative}")
+            _copy_verified(
+                source,
+                paths["helper"] / Path(relative).name,
+                record["size"],
+                record["sha256"],
+            )
+        _journal(paths, "activated", launcher_pid=launcher_pid, helper_pid=None)
+        _atomic_write_json(
+            paths["active"], {"schema": 1, "transaction_id": transaction_id}
+        )
+        process = subprocess.Popen(
+            command,
+            cwd=str(paths["helper"]),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            creationflags=creation_flags,
+        )
+    except Exception:
+        try:
+            paths["active"].unlink()
+        except FileNotFoundError:
+            pass
+        shutil.rmtree(paths["helper"], ignore_errors=True)
+        _journal(paths, "activation_failed")
+        raise
+    helper_pid = process.pid
+    # The child records its own PID and waiting state. Avoid a second parent
+    # write to the same atomic journal immediately after process creation.
+    if process.returncode is None and os.name == "nt":
+        handle = getattr(process, "_handle", None)
+        if handle is not None:
+            handle.Close()
+        process.returncode = 0
+    return helper_pid
+
+
+def _pid_is_running(pid):
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    if os.name == "nt":
+        import ctypes
+        from ctypes import wintypes
+
+        process_query_limited_information = 0x1000
+        still_active = 259
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = (
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        )
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.GetExitCodeProcess.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.DWORD),
+        )
+        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        handle = kernel32.OpenProcess(
+            process_query_limited_information, False, pid
+        )
+        if not handle:
+            # Access denied still means that a process owns this PID. Other
+            # failures (most commonly an invalid PID) mean it has exited.
+            return ctypes.get_last_error() == 5
+        try:
+            exit_code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return True
+            return exit_code.value == still_active
+        finally:
+            kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _wait_for_pid_exit(pid, timeout):
+    deadline = time.monotonic() + timeout
+    while _pid_is_running(pid):
+        if time.monotonic() >= deadline:
+            raise TransactionError("the launcher did not exit before the update timeout")
+        time.sleep(0.1)
+
+
+def _copy_verified(source, destination, expected_size=None, expected_hash=None):
+    source = Path(source)
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(destination.name + f".wmc-{uuid.uuid4().hex}.tmp")
+    try:
+        with source.open("rb") as input_stream, temporary.open("wb") as output_stream:
+            shutil.copyfileobj(input_stream, output_stream, 1024 * 1024)
+            output_stream.flush()
+            os.fsync(output_stream.fileno())
+        if expected_size is not None and temporary.stat().st_size != expected_size:
+            raise TransactionError(f"copied file size mismatch: {destination}")
+        if expected_hash is not None and sha256_file(temporary) != expected_hash:
+            raise TransactionError(f"copied file hash mismatch: {destination}")
+        os.replace(temporary, destination)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _prepare_backup(paths, plan):
+    current_identities = {
+        item["path"].casefold() for item in plan["current_manifest"]["files"]
+    }
+    for record in plan["target_manifest"]["files"]:
+        if record["path"].casefold() not in current_identities:
+            destination = safe_destination(paths["root"], record["path"])
+            if destination.exists():
+                raise TransactionError(
+                    "a user-owned path appeared after staging: " + record["path"]
+                )
+    touched = {
+        INSTALL_MANIFEST_NAME,
+        *(item["path"] for item in plan["current_manifest"]["files"]),
+        *(item["path"] for item in plan["target_manifest"]["files"]),
+    }
+    inventory = []
+    paths["backup"].mkdir(parents=True, exist_ok=False)
+    for relative in sorted(touched, key=str.casefold):
+        source = safe_destination(paths["root"], relative)
+        entry = {"path": relative, "existed": source.is_file(), "size": None, "sha256": None}
+        if source.exists() and not source.is_file():
+            raise TransactionError(f"managed update target is not a file: {relative}")
+        if source.is_file():
+            entry["size"] = source.stat().st_size
+            entry["sha256"] = sha256_file(source)
+            backup = safe_destination(paths["backup"], relative)
+            _copy_verified(source, backup, entry["size"], entry["sha256"])
+        inventory.append(entry)
+    _atomic_write_json(paths["transaction_root"] / "backup-inventory.json", inventory)
+    _journal(paths, "backed_up", backup_inventory=inventory)
+    return inventory
+
+
+def _load_backup_inventory(paths):
+    value = _load_json(paths["transaction_root"] / "backup-inventory.json", "backup inventory")
+    if not isinstance(value, list) or not value:
+        raise TransactionError("backup inventory is invalid")
+    normalized = []
+    identities = set()
+    for entry in value:
+        if not isinstance(entry, dict) or set(entry) != {"path", "existed", "size", "sha256"}:
+            raise TransactionError("backup inventory entry is invalid")
+        path = canonical_relative_path(entry["path"])
+        if path.casefold() in identities:
+            raise TransactionError("backup inventory contains a path collision")
+        identities.add(path.casefold())
+        if not isinstance(entry["existed"], bool):
+            raise TransactionError("backup inventory existence flag is invalid")
+        if entry["existed"]:
+            if not isinstance(entry["size"], int) or entry["size"] < 0:
+                raise TransactionError("backup inventory size is invalid")
+            digest = _validate_hash(entry["sha256"], path)
+        else:
+            if entry["size"] is not None or entry["sha256"] is not None:
+                raise TransactionError("nonexistent backup entry contains file metadata")
+            digest = None
+        normalized.append(
+            {"path": path, "existed": entry["existed"], "size": entry["size"], "sha256": digest}
+        )
+    return normalized
+
+
+def _remove_file_if_present(path):
+    path = Path(path)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except IsADirectoryError as exc:
+        raise TransactionError(f"refusing to remove a directory as a managed file: {path}") from exc
+
+
+def _apply_target(paths, plan):
+    target_records = {item["path"]: item for item in plan["target_manifest"]["files"]}
+    old_paths = {item["path"] for item in plan["current_manifest"]["files"]}
+    _journal(paths, "applying")
+    for relative in sorted(target_records, key=str.casefold):
+        record = target_records[relative]
+        source = safe_destination(paths["stage"], relative)
+        destination = safe_destination(paths["root"], relative)
+        _copy_verified(source, destination, record["size"], record["sha256"])
+    for relative in sorted(old_paths - set(target_records), key=str.casefold):
+        _remove_file_if_present(safe_destination(paths["root"], relative))
+    differences = verify_installation_files(paths["root"], plan["target_manifest"])
+    if differences:
+        raise TransactionError(
+            "target verification failed: " + ", ".join(item["path"] for item in differences[:5])
+        )
+    target_manifest_path = safe_destination(paths["stage"], INSTALL_MANIFEST_NAME)
+    encoded = target_manifest_path.read_bytes()
+    target_manifest_hash = hashlib.sha256(encoded).hexdigest()
+    _copy_verified(
+        target_manifest_path,
+        paths["root"] / INSTALL_MANIFEST_NAME,
+        len(encoded),
+        target_manifest_hash,
+    )
+    loaded = load_install_manifest(paths["root"], verify_files=True)
+    if loaded != plan["target_manifest"]:
+        raise TransactionError("installed manifest does not match the update target")
+    _journal(paths, "checking")
+
+
+def rollback_transaction(root, transaction_id, *, reason="update did not complete"):
+    """Restore every touched path to its exact pre-update file state."""
+    paths = _transaction_paths(root, transaction_id)
+    inventory = _load_backup_inventory(paths)
+    errors = []
+    _journal(paths, "rolling_back", rollback_reason=reason)
+    for entry in inventory:
+        try:
+            destination = safe_destination(paths["root"], entry["path"])
+            if entry["existed"]:
+                backup = safe_destination(paths["backup"], entry["path"])
+                if (
+                    not backup.is_file()
+                    or backup.stat().st_size != entry["size"]
+                    or sha256_file(backup) != entry["sha256"]
+                ):
+                    raise TransactionError(f"backup verification failed: {entry['path']}")
+                # A locked destination that was never replaced is already a
+                # valid rollback result. Avoid rewriting it so recovery can
+                # succeed even when another process permits reads but denies
+                # replacement/deletion.
+                destination_matches = False
+                try:
+                    destination_matches = (
+                        destination.is_file()
+                        and destination.stat().st_size == entry["size"]
+                        and sha256_file(destination) == entry["sha256"]
+                    )
+                except OSError:
+                    pass
+                if not destination_matches:
+                    _copy_verified(backup, destination, entry["size"], entry["sha256"])
+            else:
+                _remove_file_if_present(destination)
+        except Exception as exc:
+            errors.append(f"{entry['path']}: {exc}")
+    if errors:
+        _journal(paths, "rollback_failed", rollback_errors=errors)
+        raise TransactionError("automatic rollback was incomplete: " + "; ".join(errors))
+    _journal(paths, "rolled_back")
+    try:
+        paths["active"].unlink()
+    except FileNotFoundError:
+        pass
+    return True
+
+
+def _default_health_check(paths):
+    batch = paths["root"] / "Dashboard" / "Start KSP Dashboard.bat"
+    environment = os.environ.copy()
+    environment["WMC_UPDATE_TRANSACTION"] = paths["transaction_id"]
+    command_processor = os.environ.get("COMSPEC", "cmd.exe")
+    result = subprocess.run(
+        [command_processor, "/d", "/s", "/c", "call", str(batch), "--check"],
+        cwd=str(batch.parent),
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
+        shell=False,
+    )
+    if result.returncode != 0:
+        raise TransactionError(
+            "updated launcher check failed: " + (result.stdout or "").strip()
+        )
+
+
+def _default_restart(paths, timeout=30):
+    dashboard = paths["root"] / "Dashboard"
+    pythonw = dashboard / ".venv" / "Scripts" / "pythonw.exe"
+    python = dashboard / ".venv" / "Scripts" / "python.exe"
+    executable = pythonw if pythonw.is_file() else python
+    if not executable.is_file():
+        raise TransactionError("package-local Python disappeared before restart")
+    environment = os.environ.copy()
+    environment["WMC_UPDATE_TRANSACTION"] = paths["transaction_id"]
+    process = subprocess.Popen(
+        [str(executable), str(dashboard / "ksp_dashboard_app.py")],
+        cwd=str(dashboard),
+        env=environment,
+        creationflags=0x08000000 if os.name == "nt" else 0,
+    )
+    try:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if paths["ack"].is_file():
+                value = _load_json(paths["ack"], "restart acknowledgement")
+                if not (
+                    isinstance(value, dict)
+                    and value.get("schema") == 1
+                    and value.get("transaction_id") == paths["transaction_id"]
+                ):
+                    raise TransactionError(
+                        "updated launcher wrote an invalid restart acknowledgement"
+                    )
+                stability_deadline = time.monotonic() + RESTART_STABILITY_SECONDS
+                while time.monotonic() < stability_deadline:
+                    code = process.poll()
+                    if code is not None:
+                        raise TransactionError(
+                            "updated launcher exited immediately after startup "
+                            f"acknowledgement ({code})"
+                        )
+                    time.sleep(0.1)
+                # The restarted launcher is intentionally independent of the
+                # short-lived helper. Close only our Windows process handle
+                # after acknowledgement; this does not terminate the child.
+                process.poll()
+                if process.returncode is None and os.name == "nt":
+                    handle = getattr(process, "_handle", None)
+                    if handle is not None:
+                        handle.Close()
+                    process.returncode = 0
+                return process.pid
+            code = process.poll()
+            if code is not None:
+                raise TransactionError(
+                    f"updated launcher exited before startup acknowledgement ({code})"
+                )
+            time.sleep(0.1)
+        raise TransactionError("updated launcher did not acknowledge startup in time")
+    except Exception:
+        if process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                try:
+                    process.kill()
+                except OSError:
+                    pass
+        raise
+
+
+def _commit_transaction(paths, plan):
+    _journal(
+        paths,
+        "complete",
+        completed_at=time.time(),
+        previous_version=plan["current_manifest"]["product_version"],
+    )
+    try:
+        paths["active"].unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        print(f"Warning: completed update marker could not be removed: {exc}")
+    transactions_root = paths["transaction_root"].parent
+    for obsolete in transactions_root.iterdir():
+        if not obsolete.is_dir() or obsolete == paths["transaction_root"]:
+            continue
+        journal = obsolete / TRANSACTION_JOURNAL_NAME
+        try:
+            value = _load_json(journal, "completed update journal")
+        except UpdateError:
+            continue
+        if value.get("state") == "complete":
+            try:
+                shutil.rmtree(obsolete)
+            except OSError as exc:
+                print(f"Warning: old update backup could not be pruned: {exc}")
+    return paths["backup"]
+
+
+def _terminate_restarted_process(value):
+    if isinstance(value, subprocess.Popen):
+        if value.poll() is None:
+            try:
+                value.terminate()
+                value.wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                try:
+                    value.kill()
+                except OSError:
+                    pass
+        return
+    if not isinstance(value, int) or value <= 0 or not _pid_is_running(value):
+        return
+    try:
+        os.kill(value, 15)
+    except OSError:
+        return
+    deadline = time.monotonic() + 5
+    while _pid_is_running(value) and time.monotonic() < deadline:
+        time.sleep(0.05)
+
+
+def discard_staged_transaction(root, transaction_id):
+    """Remove a never-activated staged transaction after user cancellation."""
+    paths = _transaction_paths(root, transaction_id)
+    marker = _read_active_marker(paths["root"])
+    if marker is not None:
+        raise TransactionError("an active update transaction cannot be discarded")
+    journal = _load_json(paths["journal"], "update journal")
+    if journal.get("state") not in {"staged", "activation_failed"}:
+        raise TransactionError("only an unapplied staged transaction can be discarded")
+    shutil.rmtree(paths["transaction_root"])
+
+
+def apply_transaction(
+    root,
+    transaction_id,
+    *,
+    launcher_pid=None,
+    health_check=None,
+    restart=None,
+    restart_required=True,
+):
+    """Apply one activated transaction; rollback deterministically on failure."""
+    paths = _transaction_paths(root, transaction_id)
+    marker = _read_active_marker(paths["root"])
+    if marker is None or marker["transaction_id"] != transaction_id:
+        raise TransactionError("update transaction is not active")
+    plan = _validate_plan(paths)
+    journal = _load_json(paths["journal"], "update journal")
+    if launcher_pid is None:
+        launcher_pid = journal.get("launcher_pid")
+    _journal(paths, "waiting_for_launcher_exit", helper_pid=os.getpid(), launcher_pid=launcher_pid)
+    restarted_process = None
+    try:
+        if launcher_pid is not None:
+            _wait_for_pid_exit(launcher_pid, 30)
+        _journal(paths, "backing_up")
+        _prepare_backup(paths, plan)
+        _apply_target(paths, plan)
+        (health_check or _default_health_check)(paths)
+        if not restart_required:
+            return _commit_transaction(paths, plan)
+        _journal(paths, "awaiting_restart")
+        restarted_process = (restart or _default_restart)(paths)
+        return _commit_transaction(paths, plan)
+    except Exception as exc:
+        if restarted_process is not None:
+            _terminate_restarted_process(restarted_process)
+        journal = _load_json(paths["journal"], "update journal")
+        if journal.get("state") in {
+            "backed_up",
+            "applying",
+            "checking",
+            "awaiting_restart",
+            "rolling_back",
+        }:
+            rollback_transaction(paths["root"], transaction_id, reason=str(exc))
+        else:
+            try:
+                paths["active"].unlink()
+            except FileNotFoundError:
+                pass
+            _journal(paths, "abandoned", failure=str(exc))
+        raise
+
+
+def recover_pending_update(root):
+    """Recover a stale transaction before normal launcher startup."""
+    # Recovery cannot depend on the target launcher file being present: an
+    # interrupted replacement is exactly the condition this path must repair.
+    root = _validate_package_root_boundary(root)
+    marker = _read_active_marker(root)
+    if marker is None:
+        return {"status": "none", "message": "No update recovery is required."}
+    paths = _transaction_paths(root, marker["transaction_id"])
+    journal = _load_json(paths["journal"], "update journal")
+    helper_pid = journal.get("helper_pid")
+    updated_at = journal.get("updated_at")
+    helper_is_recent = (
+        isinstance(updated_at, (int, float))
+        and not isinstance(updated_at, bool)
+        and 0 <= time.time() - updated_at < 10 * 60
+    )
+    if helper_is_recent and _pid_is_running(helper_pid):
+        return {"status": "busy", "message": "A Mission Control update is still running."}
+    state = journal.get("state")
+    if state in {
+        "backed_up",
+        "applying",
+        "checking",
+        "awaiting_restart",
+        "rolling_back",
+        "rollback_failed",
+    }:
+        rollback_transaction(root, marker["transaction_id"], reason="recovered after interruption")
+        return {"status": "recovered", "message": "The interrupted update was rolled back."}
+    if state in {"activated", "waiting_for_launcher_exit", "backing_up", "staged", "activation_failed"}:
+        try:
+            paths["active"].unlink()
+        except FileNotFoundError:
+            pass
+        _journal(paths, "abandoned", failure="interrupted before package modification")
+        return {"status": "recovered", "message": "The interrupted update was safely abandoned."}
+    if state in {"rolled_back", "complete", "abandoned"}:
+        try:
+            paths["active"].unlink()
+        except FileNotFoundError:
+            pass
+        return {"status": "recovered", "message": f"Cleared completed update state ({state})."}
+    raise TransactionError(f"cannot automatically recover update state: {state!r}")
+
+
+def acknowledge_restart(root, transaction_id):
+    """Acknowledge that the updated Tk launcher completed initialization."""
+    paths = _transaction_paths(root, transaction_id)
+    marker = _read_active_marker(paths["root"])
+    if marker is None or marker["transaction_id"] != transaction_id:
+        raise TransactionError("restart acknowledgement does not match an active update")
+    journal = _load_json(paths["journal"], "update journal")
+    if journal.get("state") != "awaiting_restart":
+        raise TransactionError("update is not waiting for a restart acknowledgement")
+    _atomic_write_json(
+        paths["ack"],
+        {"schema": 1, "transaction_id": transaction_id, "acknowledged_at": time.time()},
+    )
+    return True

--- a/runtime_update_helper.py
+++ b/runtime_update_helper.py
@@ -1,0 +1,67 @@
+"""External command-line helper for Mission Control runtime updates."""
+
+import argparse
+import contextlib
+import sys
+from pathlib import Path
+
+from runtime_update import (
+    _transaction_paths,
+    apply_transaction,
+    pending_update_status,
+    recover_pending_update,
+)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Mission Control runtime updater")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status = subparsers.add_parser("status")
+    status.add_argument("root", type=Path)
+    status.add_argument("--transaction-token")
+
+    prepare = subparsers.add_parser("prepare-launch")
+    prepare.add_argument("root", type=Path)
+
+    apply = subparsers.add_parser("apply")
+    apply.add_argument("root", type=Path)
+    apply.add_argument("transaction_id")
+    apply.add_argument("--launcher-pid", type=int, required=True)
+    return parser
+
+
+def main(argv=None):
+    arguments = build_parser().parse_args(argv)
+    try:
+        if arguments.command == "status":
+            result = pending_update_status(arguments.root, arguments.transaction_token)
+            print(result["message"])
+            return 4 if result["pending"] else 0
+        if arguments.command == "prepare-launch":
+            result = recover_pending_update(arguments.root)
+            print(result["message"])
+            return 3 if result["status"] == "busy" else 0
+        paths = _transaction_paths(arguments.root, arguments.transaction_id)
+        paths["log"].parent.mkdir(parents=True, exist_ok=True)
+        with paths["log"].open("a", encoding="utf-8", buffering=1) as log:
+            with contextlib.redirect_stdout(log), contextlib.redirect_stderr(log):
+                print("Starting Mission Control runtime update helper.")
+                try:
+                    apply_transaction(
+                        arguments.root,
+                        arguments.transaction_id,
+                        launcher_pid=arguments.launcher_pid,
+                    )
+                except Exception as exc:
+                    print(f"Mission Control update error: {exc}", file=sys.stderr)
+                    return 1
+                print("Mission Control runtime update completed.")
+        return 0
+    except Exception as exc:
+        print(f"Mission Control update error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -504,6 +504,10 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn("WMC-INSTALL-MANIFEST.json", publish_script)
         self.assertIn("$packageName.zz-90-runtime-update.zip", publish_script)
         self.assertIn("compatible_updater_protocols = @(1)", publish_script)
+        self.assertGreaterEqual(
+            publish_script.count("[System.StringComparer]::OrdinalIgnoreCase"),
+            2,
+        )
         self.assertIn("ZipFileExtensions]::CreateEntryFromFile", publish_script)
         self.assertIn("$entryName = $relativePath.Replace('\\', '/')", publish_script)
         self.assertIn("Runtime-update ZIP entries do not exactly match", publish_script)

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -453,6 +453,10 @@ class ReleaseContractTests(unittest.TestCase):
             "Woobies-Mission-Control-v0.6.0.zz-00-"
             "KRPC.WoobiesMechJeb-0.8.10-source.zip"
         )
+        update_name = (
+            "Woobies-Mission-Control-v0.6.0.zz-90-runtime-update.zip"
+        )
+        update_checksum_name = f"{update_name}.sha256"
         self.assertEqual(
             sorted(
                 [
@@ -460,6 +464,8 @@ class ReleaseContractTests(unittest.TestCase):
                     checksum_name,
                     source_archive_name,
                     *release_image_names,
+                    update_name,
+                    update_checksum_name,
                 ],
                 key=str.casefold,
             ),
@@ -468,6 +474,8 @@ class ReleaseContractTests(unittest.TestCase):
                 checksum_name,
                 source_archive_name,
                 *release_image_names,
+                update_name,
+                update_checksum_name,
             ],
         )
         self.assertIn(
@@ -475,9 +483,38 @@ class ReleaseContractTests(unittest.TestCase):
         )
         self.assertIn("$zipPath, $checksumPath", publish_script)
         self.assertIn(
-            ") + $sourceArchiveOutputPaths + $releaseImagePaths + @(",
+            ") + $sourceArchiveOutputPaths + $releaseImagePaths + $releaseUpdatePaths + @(",
             publish_script,
         )
+
+    def test_release_packager_emits_verified_managed_update_contract(self):
+        publish_script = (ROOT / "tools" / "Publish-Release.ps1").read_text(
+            encoding="utf-8"
+        )
+
+        for packaged_source in (
+            "runtime_update.py",
+            "runtime_update_helper.py",
+        ):
+            self.assertIn(
+                f"@{{ Source = '{packaged_source}'; Destination = "
+                f"'Dashboard/{packaged_source}' }}",
+                publish_script,
+            )
+        self.assertIn("WMC-INSTALL-MANIFEST.json", publish_script)
+        self.assertIn("$packageName.zz-90-runtime-update.zip", publish_script)
+        self.assertIn("compatible_updater_protocols = @(1)", publish_script)
+        self.assertIn("Runtime-update ZIP entries do not exactly match", publish_script)
+        self.assertIn("Runtime-update ZIP hash mismatch", publish_script)
+        self.assertIn("must be smaller than the normal release ZIP", publish_script)
+        self.assertIn("status --porcelain", publish_script)
+        self.assertIn("must be assembled from a clean Git checkout", publish_script)
+
+        self.assertIn("repos/$Repository/immutable-releases", publish_script)
+        self.assertIn("X-GitHub-Api-Version: 2026-03-10", publish_script)
+        self.assertIn("$immutableSetting.enabled -ne $true", publish_script)
+        self.assertNotIn("-X PUT", publish_script)
+        self.assertNotIn("--method PUT", publish_script)
 
     def test_v050_release_notes_preserve_utf8_and_exclude_mock_only_history(self):
         publish_script = (ROOT / "tools" / "Publish-Release.ps1").read_text(

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -495,6 +495,7 @@ class ReleaseContractTests(unittest.TestCase):
         for packaged_source in (
             "runtime_update.py",
             "runtime_update_helper.py",
+            "runtime-update-contract.json",
         ):
             self.assertIn(
                 f"@{{ Source = '{packaged_source}'; Destination = "
@@ -515,6 +516,16 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn("must be smaller than the normal release ZIP", publish_script)
         self.assertIn("status --porcelain", publish_script)
         self.assertIn("must be assembled from a clean Git checkout", publish_script)
+        self.assertIn("runtime-update-contract.json", publish_script)
+        self.assertIn("$contractLimits.archive_entries", publish_script)
+        self.assertIn("$contractLimits.archive_file_bytes", publish_script)
+        self.assertIn("$contractLimits.archive_expanded_bytes", publish_script)
+        self.assertIn("$contractLimits.download_bytes", publish_script)
+        self.assertIn("$contractLimits.checksum_bytes", publish_script)
+        self.assertIn(
+            "Packaged runtime paths are absent from runtime-update-contract.json",
+            publish_script,
+        )
 
         self.assertIn("repos/$Repository/immutable-releases", publish_script)
         self.assertIn("X-GitHub-Api-Version: 2026-03-10", publish_script)

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -504,6 +504,8 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn("WMC-INSTALL-MANIFEST.json", publish_script)
         self.assertIn("$packageName.zz-90-runtime-update.zip", publish_script)
         self.assertIn("compatible_updater_protocols = @(1)", publish_script)
+        self.assertIn("ZipFileExtensions]::CreateEntryFromFile", publish_script)
+        self.assertIn("$entryName = $relativePath.Replace('\\', '/')", publish_script)
         self.assertIn("Runtime-update ZIP entries do not exactly match", publish_script)
         self.assertIn("Runtime-update ZIP hash mismatch", publish_script)
         self.assertIn("must be smaller than the normal release ZIP", publish_script)

--- a/tests/test_runtime_update.py
+++ b/tests/test_runtime_update.py
@@ -13,6 +13,9 @@ from unittest import mock
 import runtime_update as update
 
 
+CONTRACT_BYTES = Path(update.__file__).with_name("runtime-update-contract.json").read_bytes()
+
+
 def digest_bytes(value):
     return hashlib.sha256(value).hexdigest()
 
@@ -39,6 +42,7 @@ def write_installation(root, version="1.0.0", commit="a" * 40, files=None):
         "Dashboard/ksp_dashboard_app.py": b"old launcher\n",
         "Dashboard/runtime_update.py": b"old update module\n",
         "Dashboard/runtime_update_helper.py": b"old helper\n",
+        "Dashboard/runtime-update-contract.json": CONTRACT_BYTES,
         "Dashboard/Start KSP Dashboard.bat": b"old batch\r\n",
         "Dashboard/web/index.html": b"old index\n",
     }
@@ -258,6 +262,7 @@ class ManifestAndArchiveTests(unittest.TestCase):
     def test_managed_surface_excludes_state_gallery_readme_and_venv(self):
         accepted = (
             "Dashboard/runtime_update.py",
+            "Dashboard/runtime-update-contract.json",
             "Dashboard/web/assets/index-abc.js",
             "GameData/KRPC.StageStats/KRPC.StageStats.dll",
             "SOURCE/KRPC.WoobiesMechJeb-1.0.0-source.zip",
@@ -275,6 +280,28 @@ class ManifestAndArchiveTests(unittest.TestCase):
             self.assertTrue(update.is_allowed_managed_path(path), path)
         for path in rejected:
             self.assertFalse(update.is_allowed_managed_path(path), path)
+
+    def test_shared_contract_is_the_runtime_limit_and_allowlist_authority(self):
+        contract = json.loads(CONTRACT_BYTES)
+
+        self.assertEqual(
+            update.MAX_UPDATE_DOWNLOAD_BYTES,
+            contract["limits"]["download_bytes"],
+        )
+        self.assertEqual(
+            update.MAX_ARCHIVE_ENTRIES,
+            contract["limits"]["archive_entries"],
+        )
+        self.assertEqual(
+            update.MAX_ARCHIVE_FILE_BYTES,
+            contract["limits"]["archive_file_bytes"],
+        )
+        self.assertEqual(
+            update.MAX_ARCHIVE_EXPANDED_BYTES,
+            contract["limits"]["archive_expanded_bytes"],
+        )
+        for path in contract["root_managed_files"]:
+            self.assertTrue(update.is_allowed_managed_path(path), path)
 
     def test_archive_and_target_manifest_must_match_exactly(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -354,6 +381,7 @@ class TransactionTests(unittest.TestCase):
             "Dashboard/ksp_dashboard_app.py": b"new launcher\n",
             "Dashboard/runtime_update.py": b"new update module\n",
             "Dashboard/runtime_update_helper.py": b"new helper\n",
+            "Dashboard/runtime-update-contract.json": CONTRACT_BYTES,
             "Dashboard/Start KSP Dashboard.bat": b"new batch\r\n",
             "Dashboard/web/assets/index-new.js": b"new bundle\n",
             "Dashboard/web/index.html": b"new index\n",
@@ -750,7 +778,17 @@ class TransactionTests(unittest.TestCase):
             paths = activate_staged_for_test(root, staged["transaction_id"])
             plan = update._validate_plan(paths)
             update._prepare_backup(paths, plan)
-            update._journal(paths, "applying", helper_pid=os.getpid())
+            helper_identity = (
+                update._windows_process_identity(os.getpid())
+                if os.name == "nt"
+                else None
+            )
+            update._journal(
+                paths,
+                "applying",
+                helper_pid=os.getpid(),
+                helper_identity=update._identity_record(helper_identity),
+            )
 
             busy = update.recover_pending_update(root)
             self.assertEqual(busy["status"], "busy")
@@ -761,6 +799,21 @@ class TransactionTests(unittest.TestCase):
             recovered = update.recover_pending_update(root)
             self.assertEqual(recovered["status"], "recovered")
             self.assertEqual(update.load_install_manifest(root), current)
+
+    @unittest.skipUnless(os.name == "nt", "process identity is Windows-specific")
+    def test_pid_reuse_identity_never_matches_or_signals_an_unrelated_process(self):
+        identity = update._windows_process_identity(os.getpid())
+        reused = update.WindowsProcessIdentity(
+            pid=identity.pid,
+            creation_time=identity.creation_time + 1,
+            executable=identity.executable,
+        )
+
+        self.assertTrue(update._pid_is_running(os.getpid(), identity))
+        self.assertFalse(update._pid_is_running(os.getpid(), reused))
+        update._wait_for_pid_exit(os.getpid(), 0.01, reused)
+        update._terminate_restarted_process(os.getpid())
+        self.assertTrue(update._pid_is_running(os.getpid(), identity))
 
     def test_next_launch_retries_a_previous_incomplete_rollback(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_runtime_update.py
+++ b/tests/test_runtime_update.py
@@ -1,0 +1,796 @@
+import hashlib
+import io
+import json
+import os
+import stat
+import tempfile
+import unittest
+import warnings
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+import runtime_update as update
+
+
+def digest_bytes(value):
+    return hashlib.sha256(value).hexdigest()
+
+
+def file_record(path, value):
+    return {"path": path, "size": len(value), "sha256": digest_bytes(value)}
+
+
+def install_manifest(version, commit, files, protocol=1, services=None):
+    records = [file_record(path, value) for path, value in files.items()]
+    return {
+        "schema": 1,
+        "product_version": version,
+        "updater_protocol": protocol,
+        "source_commit": commit,
+        "services": services or [],
+        "files": sorted(records, key=lambda item: item["path"].casefold()),
+    }
+
+
+def write_installation(root, version="1.0.0", commit="a" * 40, files=None):
+    root = Path(root)
+    files = files or {
+        "Dashboard/ksp_dashboard_app.py": b"old launcher\n",
+        "Dashboard/runtime_update.py": b"old update module\n",
+        "Dashboard/runtime_update_helper.py": b"old helper\n",
+        "Dashboard/Start KSP Dashboard.bat": b"old batch\r\n",
+        "Dashboard/web/index.html": b"old index\n",
+    }
+    for relative, value in files.items():
+        path = root / Path(relative)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(value)
+    manifest = install_manifest(version, commit, files)
+    (root / update.INSTALL_MANIFEST_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return manifest, files
+
+
+def make_update_archive(path, target_manifest, target_files, *, update_manifest_changes=None):
+    install_bytes = (
+        json.dumps(target_manifest, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+    payload = {
+        **{f"payload/{name}": value for name, value in target_files.items()},
+        f"payload/{update.INSTALL_MANIFEST_NAME}": install_bytes,
+    }
+    update_manifest = {
+        "schema": 1,
+        "product_version": target_manifest["product_version"],
+        "source_commit": target_manifest["source_commit"],
+        "compatible_updater_protocols": [1],
+        "services": target_manifest["services"],
+        "files": sorted(
+            (file_record(name, value) for name, value in payload.items()),
+            key=lambda item: item["path"].casefold(),
+        ),
+    }
+    if update_manifest_changes:
+        update_manifest.update(update_manifest_changes)
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            update.UPDATE_MANIFEST_NAME,
+            json.dumps(update_manifest, indent=2, sort_keys=True) + "\n",
+        )
+        for name, value in payload.items():
+            archive.writestr(name, value)
+    return update_manifest
+
+
+def activate_staged_for_test(root, transaction_id):
+    paths = update._transaction_paths(root, transaction_id)
+    update._atomic_write_json(
+        paths["active"], {"schema": 1, "transaction_id": transaction_id}
+    )
+    update._journal(paths, "activated", launcher_pid=None, helper_pid=None)
+    return paths
+
+
+class ReleaseValidationTests(unittest.TestCase):
+    def valid_payload(self, version="1.1.0", immutable=True):
+        tag = f"v{version}"
+        archive_name, checksum_name = update.update_asset_names(version)
+        return {
+            "tag_name": tag,
+            "html_url": (
+                "https://github.com/SacredWoobie/"
+                f"woobies-mission-control/releases/tag/{tag}"
+            ),
+            "draft": False,
+            "prerelease": False,
+            "immutable": immutable,
+            "body": "Release notes",
+            "assets": [
+                {
+                    "name": archive_name,
+                    "size": 100,
+                    "state": "uploaded",
+                    "digest": "sha256:" + "a" * 64,
+                    "browser_download_url": (
+                        "https://github.com/SacredWoobie/woobies-mission-control/"
+                        f"releases/download/{tag}/{archive_name}"
+                    ),
+                },
+                {
+                    "name": checksum_name,
+                    "size": 103,
+                    "state": "uploaded",
+                    "digest": "sha256:" + "b" * 64,
+                    "browser_download_url": (
+                        "https://github.com/SacredWoobie/woobies-mission-control/"
+                        f"releases/download/{tag}/{checksum_name}"
+                    ),
+                },
+            ],
+        }
+
+    def test_accepts_exact_immutable_stable_release_assets(self):
+        release = update.validate_release_payload(self.valid_payload())
+        archive, checksum = update.select_update_assets(release)
+        self.assertTrue(release["immutable"])
+        self.assertTrue(archive["name"].endswith("runtime-update.zip"))
+        self.assertTrue(checksum["name"].endswith("runtime-update.zip.sha256"))
+
+        # The normalized value is safe to persist for display and can be
+        # validated again without dropping the API digests.
+        cached = update.validate_release_payload(release)
+        cached_archive, _cached_checksum = update.select_update_assets(cached)
+        self.assertEqual(cached_archive["sha256"], "a" * 64)
+
+    def test_mutable_release_remains_readable_but_not_installable(self):
+        release = update.validate_release_payload(self.valid_payload(immutable=False))
+        with self.assertRaisesRegex(update.ReleaseValidationError, "mutable"):
+            update.select_update_assets(release)
+
+    def test_first_updater_release_can_report_current_without_fake_successor(self):
+        release = update.validate_release_payload(
+            self.valid_payload(version="1.0.0", immutable=True)
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            dashboard = root / "Dashboard"
+            write_installation(root, version="1.0.0")
+            offer = update.assess_release_offer(release, "1.0.0", dashboard)
+        self.assertFalse(offer["installable"])
+        self.assertIn("not newer", offer["reason"])
+
+    def test_rejects_prerelease_wrong_owner_and_duplicate_asset_names(self):
+        payload = self.valid_payload()
+        payload["prerelease"] = True
+        with self.assertRaises(update.ReleaseValidationError):
+            update.validate_release_payload(payload)
+
+        payload = self.valid_payload()
+        payload["html_url"] = payload["html_url"].replace("SacredWoobie", "attacker")
+        with self.assertRaises(update.ReleaseValidationError):
+            update.validate_release_payload(payload)
+
+        payload = self.valid_payload()
+        payload["assets"].append(dict(payload["assets"][0]))
+        with self.assertRaisesRegex(update.ReleaseValidationError, "duplicate"):
+            update.validate_release_payload(payload)
+
+    def test_rejects_noncanonical_tag_and_unfinished_asset(self):
+        payload = self.valid_payload()
+        payload["tag_name"] = "v01.1.0"
+        payload["html_url"] = payload["html_url"].replace("v1.1.0", "v01.1.0")
+        for asset in payload["assets"]:
+            asset["browser_download_url"] = asset["browser_download_url"].replace(
+                "v1.1.0", "v01.1.0"
+            )
+        with self.assertRaisesRegex(update.ReleaseValidationError, "canonical"):
+            update.validate_release_payload(payload)
+
+        payload = self.valid_payload()
+        payload["assets"][0]["state"] = "starter"
+        with self.assertRaisesRegex(update.ReleaseValidationError, "fully uploaded"):
+            update.validate_release_payload(payload)
+
+    def test_download_requires_api_digest_sidecar_and_exact_sizes(self):
+        archive_bytes = b"verified update bytes"
+        archive_name, checksum_name = update.update_asset_names("1.1.0")
+        checksum_bytes = f"{digest_bytes(archive_bytes)}  {archive_name}\n".encode()
+        payload = self.valid_payload()
+        payload["assets"][0]["size"] = len(archive_bytes)
+        payload["assets"][0]["digest"] = "sha256:" + digest_bytes(archive_bytes)
+        payload["assets"][1]["size"] = len(checksum_bytes)
+        payload["assets"][1]["digest"] = "sha256:" + digest_bytes(checksum_bytes)
+        release = update.validate_release_payload(payload)
+
+        responses = {
+            archive_name: archive_bytes,
+            checksum_name: checksum_bytes,
+        }
+
+        class Response(io.BytesIO):
+            def __init__(self, value, url):
+                super().__init__(value)
+                self._url = url
+                self.headers = {"Content-Length": str(len(value))}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                self.close()
+                return False
+
+            def geturl(self):
+                return self._url
+
+        def opener(request, timeout):
+            del timeout
+            name = request.full_url.rsplit("/", 1)[-1]
+            self.assertIn(name, responses)
+            return Response(responses[name], request.full_url)
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = update.download_verified_update(release, directory, opener=opener)
+            self.assertEqual(path.read_bytes(), archive_bytes)
+
+            responses[checksum_name] = (
+                f"{'0' * 64}  {archive_name}\n".encode()
+            )
+            release["assets"][1]["size"] = len(responses[checksum_name])
+            release["assets"][1]["sha256"] = digest_bytes(responses[checksum_name])
+            with self.assertRaisesRegex(update.ReleaseValidationError, "published checksum"):
+                update.download_verified_update(release, directory, opener=opener)
+
+            def off_host_opener(request, timeout):
+                del timeout
+                name = request.full_url.rsplit("/", 1)[-1]
+                return Response(responses[name], "https://attacker.example/payload")
+
+            with self.assertRaisesRegex(update.ReleaseValidationError, "unexpected host"):
+                update.download_verified_update(
+                    release, directory, opener=off_host_opener
+                )
+
+
+class ManifestAndArchiveTests(unittest.TestCase):
+    def test_managed_surface_excludes_state_gallery_readme_and_venv(self):
+        accepted = (
+            "Dashboard/runtime_update.py",
+            "Dashboard/web/assets/index-abc.js",
+            "GameData/KRPC.StageStats/KRPC.StageStats.dll",
+            "SOURCE/KRPC.WoobiesMechJeb-1.0.0-source.zip",
+            "THIRD-PARTY/NOTICES.md",
+        )
+        rejected = (
+            "Dashboard/.venv/Scripts/python.exe",
+            "Dashboard/launcher_error.log",
+            "docs/images/v1.0.0/screenshot.png",
+            "README.md",
+            "../outside.txt",
+            "Dashboard/web/assets/CON.js",
+        )
+        for path in accepted:
+            self.assertTrue(update.is_allowed_managed_path(path), path)
+        for path in rejected:
+            self.assertFalse(update.is_allowed_managed_path(path), path)
+
+    def test_archive_and_target_manifest_must_match_exactly(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target_files = {"Dashboard/ksp_dashboard_app.py": b"new\n"}
+            target = install_manifest("1.1.0", "b" * 40, target_files)
+            archive = root / "update.zip"
+            make_update_archive(archive, target, target_files)
+            update_manifest, install = update.inspect_update_archive(archive)
+            self.assertEqual(install, target)
+            self.assertEqual(update_manifest["product_version"], "1.1.0")
+
+            with zipfile.ZipFile(archive, "a") as unsafe:
+                unsafe.writestr("payload/unknown.txt", b"surprise")
+            with self.assertRaisesRegex(update.ArchiveValidationError, "do not match"):
+                update.inspect_update_archive(archive)
+
+    def test_rejects_traversal_case_collisions_and_payload_tampering(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target_files = {"Dashboard/ksp_dashboard_app.py": b"new\n"}
+            target = install_manifest("1.1.0", "b" * 40, target_files)
+
+            traversal = root / "traversal.zip"
+            make_update_archive(traversal, target, target_files)
+            with zipfile.ZipFile(traversal, "a") as archive:
+                archive.writestr("../escape.txt", b"escape")
+            with self.assertRaises(update.ArchiveValidationError):
+                update.inspect_update_archive(traversal)
+
+            collision = root / "collision.zip"
+            make_update_archive(collision, target, target_files)
+            with zipfile.ZipFile(collision, "a") as archive:
+                archive.writestr("PAYLOAD/dashboard/KSP_DASHBOARD_APP.PY", b"collision")
+            with self.assertRaisesRegex(update.ArchiveValidationError, "collision"):
+                update.inspect_update_archive(collision)
+
+            tampered = root / "tampered.zip"
+            make_update_archive(tampered, target, target_files)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                with zipfile.ZipFile(tampered, "a") as archive:
+                    archive.writestr(
+                        "payload/Dashboard/ksp_dashboard_app.py", b"tampered"
+                    )
+            with self.assertRaises(update.ArchiveValidationError):
+                update.inspect_update_archive(tampered)
+
+    def test_rejects_link_entries_and_expansion_limits(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target_files = {"Dashboard/ksp_dashboard_app.py": b"new launcher\n"}
+            target = install_manifest("1.1.0", "b" * 40, target_files)
+
+            linked = root / "linked.zip"
+            make_update_archive(linked, target, target_files)
+            link_info = zipfile.ZipInfo("payload/link")
+            link_info.create_system = 3
+            link_info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            with zipfile.ZipFile(linked, "a") as archive:
+                archive.writestr(link_info, "target")
+            with self.assertRaisesRegex(update.ArchiveValidationError, "link"):
+                update.inspect_update_archive(linked)
+
+            limited = root / "limited.zip"
+            make_update_archive(limited, target, target_files)
+            with mock.patch.object(update, "MAX_ARCHIVE_EXPANDED_BYTES", 4):
+                with self.assertRaisesRegex(
+                    update.ArchiveValidationError, "safe limit"
+                ):
+                    update.inspect_update_archive(limited)
+
+
+class TransactionTests(unittest.TestCase):
+    def target(self):
+        files = {
+            "Dashboard/ksp_dashboard_app.py": b"new launcher\n",
+            "Dashboard/runtime_update.py": b"new update module\n",
+            "Dashboard/runtime_update_helper.py": b"new helper\n",
+            "Dashboard/Start KSP Dashboard.bat": b"new batch\r\n",
+            "Dashboard/web/assets/index-new.js": b"new bundle\n",
+            "Dashboard/web/index.html": b"new index\n",
+        }
+        return install_manifest("1.1.0", "b" * 40, files), files
+
+    def stage(self, root):
+        current, current_files = write_installation(root)
+        target, target_files = self.target()
+        archive = Path(root) / "candidate-update.zip"
+        make_update_archive(archive, target, target_files)
+        staged = update.stage_transaction(root, archive)
+        return current, current_files, target, target_files, staged
+
+    def test_success_converges_managed_tree_and_preserves_user_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            live_ksp = Path(directory) / "live-ksp" / "GameData" / "sentinel.dll"
+            live_ksp.parent.mkdir(parents=True)
+            live_ksp.write_bytes(b"live KSP must remain unchanged")
+            live_ksp_hash = update.sha256_file(live_ksp)
+            current, _old_files, target, target_files, staged = self.stage(root)
+            del current
+            user_files = {
+                "Dashboard/.venv/user-marker.txt": b"venv state",
+                "Dashboard/mission_control_setup.log": b"user log",
+                "README.md": b"local readme",
+                "custom-user-file.txt": b"unknown file",
+            }
+            for relative, value in user_files.items():
+                path = root / Path(relative)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(value)
+
+            activate_staged_for_test(root, staged["transaction_id"])
+            backup = update.apply_transaction(
+                root,
+                staged["transaction_id"],
+                health_check=lambda _paths: None,
+                restart_required=False,
+            )
+
+            self.assertTrue(backup.is_dir())
+            self.assertEqual(update.load_install_manifest(root, verify_files=True), target)
+            for relative, value in target_files.items():
+                self.assertEqual((root / Path(relative)).read_bytes(), value)
+            self.assertFalse((root / "Dashboard/web/assets/index-old.js").exists())
+            for relative, value in user_files.items():
+                self.assertEqual((root / Path(relative)).read_bytes(), value)
+            self.assertEqual(update.sha256_file(live_ksp), live_ksp_hash)
+            self.assertFalse((root / update.UPDATE_DIRECTORY_NAME / update.ACTIVE_TRANSACTION_NAME).exists())
+
+    def test_failure_after_apply_restores_exact_preupdate_tree(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            current, old_files, _target, _target_files, staged = self.stage(root)
+            modified = root / "Dashboard/web/index.html"
+            modified.write_bytes(b"locally modified index\n")
+            unknown = root / "Dashboard/custom.txt"
+            unknown.write_bytes(b"unknown")
+            activate_staged_for_test(root, staged["transaction_id"])
+
+            def fail_health(_paths):
+                raise update.TransactionError("injected post-apply failure")
+
+            with self.assertRaisesRegex(update.TransactionError, "injected"):
+                update.apply_transaction(
+                    root,
+                    staged["transaction_id"],
+                    health_check=fail_health,
+                    restart_required=False,
+                )
+            self.assertEqual(update.load_install_manifest(root), current)
+            for relative, value in old_files.items():
+                expected = b"locally modified index\n" if relative == "Dashboard/web/index.html" else value
+                self.assertEqual((root / Path(relative)).read_bytes(), expected)
+            self.assertEqual(unknown.read_bytes(), b"unknown")
+            self.assertFalse((root / "Dashboard/web/assets/index-new.js").exists())
+            self.assertFalse((root / update.UPDATE_DIRECTORY_NAME / update.ACTIVE_TRANSACTION_NAME).exists())
+
+    def test_interrupted_apply_is_rolled_back_on_next_launch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            current, _old_files, _target, target_files, staged = self.stage(root)
+            paths = activate_staged_for_test(root, staged["transaction_id"])
+            plan = update._validate_plan(paths)
+            update._prepare_backup(paths, plan)
+            update._journal(paths, "applying", helper_pid=None)
+            destination = root / "Dashboard/ksp_dashboard_app.py"
+            destination.unlink()
+
+            result = update.recover_pending_update(root)
+            self.assertEqual(result["status"], "recovered")
+            self.assertEqual(update.load_install_manifest(root), current)
+            self.assertEqual(destination.read_bytes(), b"old launcher\n")
+
+    def test_mid_apply_copy_failure_rolls_back_every_changed_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            current, old_files, _target, _target_files, staged = self.stage(root)
+            paths = activate_staged_for_test(root, staged["transaction_id"])
+            real_copy = update._copy_verified
+            target_copy_count = 0
+
+            def fail_during_target_copy(source, destination, *args, **kwargs):
+                nonlocal target_copy_count
+                source = Path(source)
+                try:
+                    source.relative_to(paths["stage"])
+                except ValueError:
+                    pass
+                else:
+                    target_copy_count += 1
+                    if target_copy_count == 3:
+                        raise PermissionError("injected locked target")
+                return real_copy(source, destination, *args, **kwargs)
+
+            with mock.patch.object(update, "_copy_verified", fail_during_target_copy):
+                with self.assertRaisesRegex(PermissionError, "locked target"):
+                    update.apply_transaction(
+                        root,
+                        staged["transaction_id"],
+                        health_check=lambda _paths: None,
+                        restart_required=False,
+                    )
+            self.assertEqual(update.load_install_manifest(root), current)
+            for relative, value in old_files.items():
+                self.assertEqual((root / Path(relative)).read_bytes(), value)
+
+    @unittest.skipUnless(os.name == "nt", "Windows sharing locks are platform-specific")
+    def test_windows_read_shared_lock_rolls_back_without_rewriting_unchanged_file(self):
+        import ctypes
+        from ctypes import wintypes
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            current, old_files, _target, _target_files, staged = self.stage(root)
+            activate_staged_for_test(root, staged["transaction_id"])
+            locked_path = root / "Dashboard/web/index.html"
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.CreateFileW.argtypes = (
+                wintypes.LPCWSTR,
+                wintypes.DWORD,
+                wintypes.DWORD,
+                wintypes.LPVOID,
+                wintypes.DWORD,
+                wintypes.DWORD,
+                wintypes.HANDLE,
+            )
+            kernel32.CreateFileW.restype = wintypes.HANDLE
+            kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+            kernel32.CloseHandle.restype = wintypes.BOOL
+            handle = kernel32.CreateFileW(
+                str(locked_path),
+                0x80000000,  # GENERIC_READ
+                0x00000001,  # FILE_SHARE_READ, but not write/delete
+                None,
+                3,  # OPEN_EXISTING
+                0x00000080,  # FILE_ATTRIBUTE_NORMAL
+                None,
+            )
+            invalid_handle = wintypes.HANDLE(-1).value
+            if handle == invalid_handle:
+                self.skipTest(f"could not create Windows test lock: {ctypes.get_last_error()}")
+            try:
+                with self.assertRaises(OSError):
+                    update.apply_transaction(
+                        root,
+                        staged["transaction_id"],
+                        health_check=lambda _paths: None,
+                        restart_required=False,
+                    )
+            finally:
+                kernel32.CloseHandle(handle)
+
+            self.assertEqual(update.load_install_manifest(root), current)
+            for relative, value in old_files.items():
+                self.assertEqual((root / Path(relative)).read_bytes(), value)
+            self.assertFalse((root / "Dashboard/web/assets/index-new.js").exists())
+
+    def test_restart_acknowledgement_is_required_before_commit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            _current, _old, target, _new, staged = self.stage(root)
+            paths = activate_staged_for_test(root, staged["transaction_id"])
+
+            def restart(transaction_paths):
+                journal = json.loads(
+                    transaction_paths["journal"].read_text(encoding="utf-8")
+                )
+                self.assertEqual(journal["state"], "awaiting_restart")
+                update.acknowledge_restart(root, staged["transaction_id"])
+
+            update.apply_transaction(
+                root,
+                staged["transaction_id"],
+                health_check=lambda _paths: None,
+                restart=restart,
+            )
+            self.assertEqual(update.load_install_manifest(root, verify_files=True), target)
+            journal = json.loads(paths["journal"].read_text(encoding="utf-8"))
+            self.assertEqual(journal["state"], "complete")
+            self.assertTrue(paths["ack"].is_file())
+
+    def test_restart_failure_restores_preupdate_package(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            current, old_files, _target, _new, staged = self.stage(root)
+            activate_staged_for_test(root, staged["transaction_id"])
+
+            def fail_restart(_paths):
+                raise update.TransactionError("restart never acknowledged")
+
+            with self.assertRaisesRegex(update.TransactionError, "never acknowledged"):
+                update.apply_transaction(
+                    root,
+                    staged["transaction_id"],
+                    health_check=lambda _paths: None,
+                    restart=fail_restart,
+                )
+            self.assertEqual(update.load_install_manifest(root), current)
+            for relative, value in old_files.items():
+                self.assertEqual((root / Path(relative)).read_bytes(), value)
+
+    def test_modified_updater_critical_file_forces_manual_full_package(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            write_installation(root)
+            (root / "Dashboard/runtime_update.py").write_bytes(b"modified")
+            target, target_files = self.target()
+            archive = root / "candidate-update.zip"
+            make_update_archive(archive, target, target_files)
+            with self.assertRaisesRegex(update.InstallationError, "full package"):
+                update.stage_transaction(root, archive)
+
+    def test_target_missing_updater_critical_file_forces_manual_package(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            write_installation(root)
+            target, target_files = self.target()
+            del target_files["Dashboard/runtime_update_helper.py"]
+            target = install_manifest("1.1.0", "b" * 40, target_files)
+            archive = root / "candidate-update.zip"
+            make_update_archive(archive, target, target_files)
+            with self.assertRaisesRegex(update.InstallationError, "updater-critical"):
+                update.stage_transaction(root, archive)
+
+    def test_new_managed_path_never_overwrites_an_unknown_user_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            write_installation(root)
+            collision = root / "Dashboard/new_module.py"
+            collision.write_bytes(b"user-owned file")
+            target, target_files = self.target()
+            target_files["Dashboard/new_module.py"] = b"product file"
+            target = install_manifest("1.1.0", "b" * 40, target_files)
+            archive = root / "candidate-update.zip"
+            make_update_archive(archive, target, target_files)
+
+            with self.assertRaisesRegex(update.InstallationError, "user-owned"):
+                update.stage_transaction(root, archive)
+            self.assertEqual(collision.read_bytes(), b"user-owned file")
+
+    def test_user_file_created_after_staging_is_not_overwritten(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            current, _old, _target, _new, staged = self.stage(root)
+            collision = root / "Dashboard/web/assets/index-new.js"
+            collision.parent.mkdir(parents=True, exist_ok=True)
+            collision.write_bytes(b"appeared after staging")
+            activate_staged_for_test(root, staged["transaction_id"])
+
+            with self.assertRaisesRegex(update.TransactionError, "appeared"):
+                update.apply_transaction(
+                    root,
+                    staged["transaction_id"],
+                    health_check=lambda _paths: None,
+                    restart_required=False,
+                )
+            self.assertEqual(update.load_install_manifest(root), current)
+            self.assertEqual(collision.read_bytes(), b"appeared after staging")
+
+    def test_failed_helper_spawn_can_be_retried_from_a_clean_helper_copy(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            _current, _old, _target, _new, staged = self.stage(root)
+            fake_python = root / "python.exe"
+            fake_python.write_bytes(b"fixture")
+            paths = update._transaction_paths(root, staged["transaction_id"])
+
+            with mock.patch.object(
+                update.subprocess, "Popen", side_effect=OSError("spawn denied")
+            ):
+                with self.assertRaisesRegex(OSError, "spawn denied"):
+                    update.activate_transaction(
+                        root,
+                        staged["transaction_id"],
+                        launcher_pid=os.getpid(),
+                        python_executable=fake_python,
+                    )
+            self.assertFalse(paths["active"].exists())
+            self.assertFalse(paths["helper"].exists())
+            self.assertEqual(
+                json.loads(paths["journal"].read_text(encoding="utf-8"))["state"],
+                "activation_failed",
+            )
+
+            class FakeHandle:
+                def Close(self):
+                    return None
+
+            class FakeProcess:
+                pid = 424242
+                returncode = None
+                _handle = FakeHandle()
+
+            with mock.patch.object(
+                update.subprocess, "Popen", return_value=FakeProcess()
+            ):
+                helper_pid = update.activate_transaction(
+                    root,
+                    staged["transaction_id"],
+                    launcher_pid=os.getpid(),
+                    python_executable=fake_python,
+                )
+            self.assertEqual(helper_pid, 424242)
+            self.assertTrue(paths["active"].is_file())
+            self.assertTrue((paths["helper"] / "runtime_update.py").is_file())
+            paths["active"].unlink()
+
+    def test_activation_refuses_managed_changes_made_after_review(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            _current, _old, _target, _new, staged = self.stage(root)
+            (root / "Dashboard/web/index.html").write_bytes(b"changed after review")
+            fake_python = root / "python.exe"
+            fake_python.write_bytes(b"fixture")
+
+            with self.assertRaisesRegex(update.InstallationError, "after update review"):
+                update.activate_transaction(
+                    root,
+                    staged["transaction_id"],
+                    launcher_pid=os.getpid(),
+                    python_executable=fake_python,
+                )
+
+    def test_corrupt_active_marker_type_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            write_installation(root)
+            marker = root / update.UPDATE_DIRECTORY_NAME / update.ACTIVE_TRANSACTION_NAME
+            marker.mkdir(parents=True)
+            status = update.pending_update_status(root)
+            self.assertTrue(status["pending"])
+            self.assertEqual(status["state"], "invalid")
+
+    def test_check_status_is_read_only_and_token_scoped(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            _current, _old, _target, _new, staged = self.stage(root)
+            paths = activate_staged_for_test(root, staged["transaction_id"])
+            update._journal(paths, "awaiting_restart", helper_pid=None)
+
+            ordinary = update.pending_update_status(root)
+            helper = update.pending_update_status(root, staged["transaction_id"])
+            self.assertTrue(ordinary["pending"])
+            self.assertFalse(helper["pending"])
+            self.assertEqual(
+                json.loads(paths["active"].read_text(encoding="utf-8"))["transaction_id"],
+                staged["transaction_id"],
+            )
+
+    def test_stale_helper_pid_does_not_block_recovery_forever(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            current, _old, _target, _new, staged = self.stage(root)
+            paths = activate_staged_for_test(root, staged["transaction_id"])
+            plan = update._validate_plan(paths)
+            update._prepare_backup(paths, plan)
+            update._journal(paths, "applying", helper_pid=os.getpid())
+
+            busy = update.recover_pending_update(root)
+            self.assertEqual(busy["status"], "busy")
+
+            journal = json.loads(paths["journal"].read_text(encoding="utf-8"))
+            journal["updated_at"] = 0
+            update._atomic_write_json(paths["journal"], journal)
+            recovered = update.recover_pending_update(root)
+            self.assertEqual(recovered["status"], "recovered")
+            self.assertEqual(update.load_install_manifest(root), current)
+
+    def test_next_launch_retries_a_previous_incomplete_rollback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            root.mkdir()
+            current, _old, _target, target_files, staged = self.stage(root)
+            paths = activate_staged_for_test(root, staged["transaction_id"])
+            plan = update._validate_plan(paths)
+            update._prepare_backup(paths, plan)
+            changed = root / "Dashboard/ksp_dashboard_app.py"
+            changed.write_bytes(target_files["Dashboard/ksp_dashboard_app.py"])
+            update._journal(paths, "applying", helper_pid=None)
+
+            with mock.patch.object(
+                update, "_copy_verified", side_effect=PermissionError("still locked")
+            ):
+                with self.assertRaisesRegex(update.TransactionError, "incomplete"):
+                    update.rollback_transaction(
+                        root, staged["transaction_id"], reason="injected interruption"
+                    )
+            self.assertEqual(
+                json.loads(paths["journal"].read_text(encoding="utf-8"))["state"],
+                "rollback_failed",
+            )
+
+            recovered = update.recover_pending_update(root)
+            self.assertEqual(recovered["status"], "recovered")
+            self.assertEqual(update.load_install_manifest(root), current)
+            self.assertEqual(changed.read_bytes(), b"old launcher\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_update_e2e.py
+++ b/tests/test_runtime_update_e2e.py
@@ -1,0 +1,295 @@
+import json
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+import venv
+from pathlib import Path
+
+import runtime_update as update
+from tests.test_runtime_update import install_manifest, make_update_archive, write_installation
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CREATE_NO_WINDOW = 0x08000000 if os.name == "nt" else 0
+
+
+@unittest.skipUnless(os.name == "nt", "external self-update acceptance is Windows-specific")
+class WindowsRuntimeUpdateAcceptanceTests(unittest.TestCase):
+    def test_first_updater_build_can_complete_a_synthetic_successor_update(self):
+        """Prove the first updater without inventing a public successor release."""
+        with tempfile.TemporaryDirectory() as directory:
+            sandbox = Path(directory)
+            package = sandbox / "installed package with spaces"
+            dashboard = package / "Dashboard"
+            dashboard.mkdir(parents=True)
+
+            venv.EnvBuilder(with_pip=False, clear=True).create(dashboard / ".venv")
+            python = dashboard / ".venv" / "Scripts" / "python.exe"
+            self.assertTrue(python.is_file())
+            (dashboard / ".venv" / "preserved.txt").write_bytes(b"venv sentinel")
+
+            updater_source = (ROOT / "runtime_update.py").read_bytes()
+            helper_source = (ROOT / "runtime_update_helper.py").read_bytes()
+            check_batch = (
+                "@echo off\r\n"
+                "if /I not \"%~1\"==\"--check\" exit /b 2\r\n"
+                "\"%~dp0.venv\\Scripts\\python.exe\" "
+                "\"%~dp0runtime_update_helper.py\" status \"%~dp0..\" "
+                "--transaction-token \"%WMC_UPDATE_TRANSACTION%\"\r\n"
+                "exit /b %ERRORLEVEL%\r\n"
+            ).encode("utf-8")
+            restart_app = (
+                "import os\n"
+                "import time\n"
+                "from pathlib import Path\n"
+                "import runtime_update\n"
+                "root = Path(__file__).resolve().parent.parent\n"
+                "token = os.environ['WMC_UPDATE_TRANSACTION']\n"
+                "runtime_update.acknowledge_restart(root, token)\n"
+                "(root / 'restart-observed.txt').write_text("
+                "token + ':' + str(os.getpid()), encoding='utf-8')\n"
+                "time.sleep(1.5)\n"
+            ).encode("utf-8")
+
+            current_files = {
+                "Dashboard/ksp_dashboard_app.py": b"# synthetic predecessor launcher\n",
+                "Dashboard/runtime_update.py": updater_source,
+                "Dashboard/runtime_update_helper.py": helper_source,
+                "Dashboard/Start KSP Dashboard.bat": check_batch,
+                "Dashboard/web/index.html": b"synthetic predecessor\n",
+            }
+            current_manifest, _ = write_installation(
+                package,
+                version="1.0.0",
+                commit="a" * 40,
+                files=current_files,
+            )
+            target_files = {
+                **current_files,
+                "Dashboard/ksp_dashboard_app.py": restart_app,
+                "Dashboard/web/index.html": b"synthetic successor\n",
+                "QUICKSTART.txt": b"synthetic successor instructions\n",
+            }
+            target_manifest = install_manifest("1.1.0", "b" * 40, target_files)
+            archive = sandbox / "synthetic-successor.zip"
+            make_update_archive(archive, target_manifest, target_files)
+
+            user_files = {
+                package / "README.md": b"preserved readme",
+                package / "unknown-user-file.txt": b"preserved unknown file",
+                dashboard / "mission_control_setup.log": b"preserved log",
+            }
+            for path, value in user_files.items():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(value)
+            live_ksp = sandbox / "live-ksp" / "GameData" / "sentinel.dll"
+            live_ksp.parent.mkdir(parents=True)
+            live_ksp.write_bytes(b"live KSP sentinel")
+            live_ksp_hash = update.sha256_file(live_ksp)
+
+            staged = update.stage_transaction(package, archive)
+            launcher = subprocess.Popen(
+                [str(python), "-c", "import time; time.sleep(0.5)"],
+                creationflags=CREATE_NO_WINDOW,
+            )
+            try:
+                helper_pid = update.activate_transaction(
+                    package,
+                    staged["transaction_id"],
+                    launcher_pid=launcher.pid,
+                    python_executable=python,
+                )
+                paths = update._transaction_paths(package, staged["transaction_id"])
+                deadline = time.monotonic() + 45
+                state = None
+                while time.monotonic() < deadline:
+                    if paths["journal"].is_file():
+                        state = json.loads(
+                            paths["journal"].read_text(encoding="utf-8")
+                        ).get("state")
+                        if state == "complete":
+                            break
+                    if not update._pid_is_running(helper_pid) and state != "complete":
+                        break
+                    time.sleep(0.1)
+                if state != "complete":
+                    log = (
+                        paths["log"].read_text(encoding="utf-8", errors="replace")
+                        if paths["log"].is_file()
+                        else "no helper log"
+                    )
+                    self.fail(f"external updater stopped in state {state!r}:\n{log}")
+            finally:
+                if launcher.poll() is None:
+                    launcher.terminate()
+                launcher.wait(timeout=5)
+
+            self.assertNotEqual(current_manifest, target_manifest)
+            self.assertEqual(
+                update.load_install_manifest(package, verify_files=True),
+                target_manifest,
+            )
+            restart_token, restart_pid_text = (
+                package / "restart-observed.txt"
+            ).read_text(encoding="utf-8").split(":", 1)
+            self.assertEqual(restart_token, staged["transaction_id"])
+            self.assertEqual(
+                (dashboard / ".venv" / "preserved.txt").read_bytes(),
+                b"venv sentinel",
+            )
+            for path, value in user_files.items():
+                self.assertEqual(path.read_bytes(), value)
+            self.assertEqual(update.sha256_file(live_ksp), live_ksp_hash)
+            self.assertTrue(paths["backup"].is_dir())
+            self.assertFalse(paths["active"].exists())
+            self.assertIn(
+                "runtime update completed",
+                paths["log"].read_text(encoding="utf-8").casefold(),
+            )
+            restart_pid = int(restart_pid_text)
+            restart_deadline = time.monotonic() + 5
+            while update._pid_is_running(restart_pid) and time.monotonic() < restart_deadline:
+                time.sleep(0.05)
+            self.assertFalse(update._pid_is_running(restart_pid))
+
+    def test_forced_external_helper_termination_is_recovered_on_next_launch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            sandbox = Path(directory)
+            package = sandbox / "interruptible installed package"
+            dashboard = package / "Dashboard"
+            dashboard.mkdir(parents=True)
+            venv.EnvBuilder(with_pip=False, clear=True).create(dashboard / ".venv")
+            python = dashboard / ".venv" / "Scripts" / "python.exe"
+
+            updater_source = (ROOT / "runtime_update.py").read_bytes()
+            production_helper = (ROOT / "runtime_update_helper.py").read_bytes()
+            interruptible_helper = b"""\
+import argparse
+import time
+from pathlib import Path
+import runtime_update as update
+
+parser = argparse.ArgumentParser()
+parser.add_argument('command')
+parser.add_argument('root', type=Path)
+parser.add_argument('transaction_id')
+parser.add_argument('--launcher-pid', type=int, required=True)
+args = parser.parse_args()
+paths = update._transaction_paths(args.root, args.transaction_id)
+real_copy = update._copy_verified
+triggered = False
+
+def interruptible_copy(source, destination, *copy_args, **copy_kwargs):
+    global triggered
+    result = real_copy(source, destination, *copy_args, **copy_kwargs)
+    try:
+        Path(source).resolve().relative_to(paths['stage'])
+    except ValueError:
+        return result
+    if not triggered:
+        triggered = True
+        (paths['transaction_root'] / 'kill-ready.txt').write_text(
+            'target replacement completed', encoding='utf-8'
+        )
+        time.sleep(30)
+    return result
+
+update._copy_verified = interruptible_copy
+update.apply_transaction(
+    args.root, args.transaction_id, launcher_pid=args.launcher_pid
+)
+"""
+            current_files = {
+                "Dashboard/ksp_dashboard_app.py": b"old launcher\n",
+                "Dashboard/runtime_update.py": updater_source,
+                "Dashboard/runtime_update_helper.py": interruptible_helper,
+                "Dashboard/Start KSP Dashboard.bat": b"@echo off\r\nexit /b 0\r\n",
+                "Dashboard/web/index.html": b"old dashboard\n",
+            }
+            current_manifest, _ = write_installation(
+                package,
+                version="1.0.0",
+                commit="a" * 40,
+                files=current_files,
+            )
+            target_files = {
+                **current_files,
+                "Dashboard/ksp_dashboard_app.py": b"new launcher\n",
+                "Dashboard/runtime_update_helper.py": production_helper,
+                "Dashboard/Start KSP Dashboard.bat": b"@echo off\r\nexit /b 0\r\n",
+                "Dashboard/web/index.html": b"new dashboard\n",
+            }
+            target_manifest = install_manifest("1.1.0", "b" * 40, target_files)
+            archive = sandbox / "interrupted-successor.zip"
+            make_update_archive(archive, target_manifest, target_files)
+            staged = update.stage_transaction(package, archive)
+            paths = update._transaction_paths(package, staged["transaction_id"])
+
+            user_file = package / "unknown-user-file.txt"
+            user_file.write_bytes(b"preserve me")
+            live_ksp = sandbox / "live-ksp" / "GameData" / "sentinel.dll"
+            live_ksp.parent.mkdir(parents=True)
+            live_ksp.write_bytes(b"never mutate live KSP")
+            live_ksp_hash = update.sha256_file(live_ksp)
+
+            launcher = subprocess.Popen(
+                [str(python), "-c", "import time; time.sleep(0.4)"],
+                creationflags=CREATE_NO_WINDOW,
+            )
+            helper_pid = None
+            try:
+                helper_pid = update.activate_transaction(
+                    package,
+                    staged["transaction_id"],
+                    launcher_pid=launcher.pid,
+                    python_executable=python,
+                )
+                deadline = time.monotonic() + 20
+                while (
+                    not (paths["transaction_root"] / "kill-ready.txt").is_file()
+                    and time.monotonic() < deadline
+                ):
+                    if not update._pid_is_running(helper_pid):
+                        break
+                    time.sleep(0.02)
+                self.assertTrue(
+                    (paths["transaction_root"] / "kill-ready.txt").is_file(),
+                    paths["log"].read_text(encoding="utf-8", errors="replace")
+                    if paths["log"].is_file()
+                    else "helper exited before its interruption point",
+                )
+                os.kill(helper_pid, 15)
+                stop_deadline = time.monotonic() + 5
+                while update._pid_is_running(helper_pid) and time.monotonic() < stop_deadline:
+                    time.sleep(0.05)
+                self.assertFalse(update._pid_is_running(helper_pid))
+            finally:
+                if launcher.poll() is None:
+                    launcher.terminate()
+                launcher.wait(timeout=5)
+                if helper_pid is not None and update._pid_is_running(helper_pid):
+                    os.kill(helper_pid, 15)
+
+            self.assertEqual(
+                json.loads(paths["journal"].read_text(encoding="utf-8"))["state"],
+                "applying",
+            )
+            self.assertEqual(
+                (package / "Dashboard/ksp_dashboard_app.py").read_bytes(),
+                b"new launcher\n",
+            )
+
+            recovered = update.recover_pending_update(package)
+            self.assertEqual(recovered["status"], "recovered")
+            self.assertEqual(update.load_install_manifest(package), current_manifest)
+            for relative, value in current_files.items():
+                self.assertEqual((package / Path(relative)).read_bytes(), value)
+            self.assertEqual(user_file.read_bytes(), b"preserve me")
+            self.assertEqual(update.sha256_file(live_ksp), live_ksp_hash)
+            self.assertFalse(paths["active"].exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_update_e2e.py
+++ b/tests/test_runtime_update_e2e.py
@@ -32,6 +32,7 @@ class WindowsRuntimeUpdateAcceptanceTests(unittest.TestCase):
 
             updater_source = (ROOT / "runtime_update.py").read_bytes()
             helper_source = (ROOT / "runtime_update_helper.py").read_bytes()
+            contract_source = (ROOT / "runtime-update-contract.json").read_bytes()
             check_batch = (
                 "@echo off\r\n"
                 "if /I not \"%~1\"==\"--check\" exit /b 2\r\n"
@@ -57,6 +58,7 @@ class WindowsRuntimeUpdateAcceptanceTests(unittest.TestCase):
                 "Dashboard/ksp_dashboard_app.py": b"# synthetic predecessor launcher\n",
                 "Dashboard/runtime_update.py": updater_source,
                 "Dashboard/runtime_update_helper.py": helper_source,
+                "Dashboard/runtime-update-contract.json": contract_source,
                 "Dashboard/Start KSP Dashboard.bat": check_batch,
                 "Dashboard/web/index.html": b"synthetic predecessor\n",
             }
@@ -165,6 +167,7 @@ class WindowsRuntimeUpdateAcceptanceTests(unittest.TestCase):
 
             updater_source = (ROOT / "runtime_update.py").read_bytes()
             production_helper = (ROOT / "runtime_update_helper.py").read_bytes()
+            contract_source = (ROOT / "runtime-update-contract.json").read_bytes()
             interruptible_helper = b"""\
 import argparse
 import time
@@ -205,6 +208,7 @@ update.apply_transaction(
                 "Dashboard/ksp_dashboard_app.py": b"old launcher\n",
                 "Dashboard/runtime_update.py": updater_source,
                 "Dashboard/runtime_update_helper.py": interruptible_helper,
+                "Dashboard/runtime-update-contract.json": contract_source,
                 "Dashboard/Start KSP Dashboard.bat": b"@echo off\r\nexit /b 0\r\n",
                 "Dashboard/web/index.html": b"old dashboard\n",
             }

--- a/tests/test_update_changelog.py
+++ b/tests/test_update_changelog.py
@@ -59,6 +59,11 @@ class UpdateAndChangelogTests(unittest.TestCase):
                 "https://github.com/SacredWoobie/"
                 "woobies-mission-control/releases/tag/v0.2.2"
             ),
+            "draft": False,
+            "prerelease": False,
+            "immutable": False,
+            "body": "Cached release notes",
+            "assets": [],
         }
         self.assertIsNotNone(app.get_fresh_cached_release(state, now=now))
         state["app_version"] = "0.2.2"

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 import sys
 import time
 import tempfile
@@ -45,20 +44,35 @@ class UpdateCheckerTests(unittest.TestCase):
         end = source.index('self.main_panes = tk.PanedWindow', start)
         update_bar = source[start:end]
 
-        self.assertEqual(
-            re.findall(
-                r'text="(Check now|Review & install|Changelog|View release)"',
-                update_bar,
-            ),
-            ["Check now", "Review & install", "Changelog", "View release"],
+        workflow = (
+            ("check_updates_control", '"AUTOMATIC UPDATE CHECKS"'),
+            ("check_updates_button", 'text="Check now"'),
+            ("install_update_button", 'text="Review & install"'),
+            ("changelog_button", 'text="Changelog"'),
+            ("view_release_button", 'text="View release"'),
         )
+        positions = [
+            update_bar.index(f"self.{attribute} =") for attribute, _label in workflow
+        ]
+        self.assertEqual(positions, sorted(positions))
+        boundaries = positions[1:] + [len(update_bar)]
+        for (attribute, label), assignment, next_assignment in zip(
+            workflow, positions, boundaries
+        ):
+            definition = update_bar[assignment:next_assignment]
+            self.assertIn("update_actions,", definition)
+            self.assertIn(label, definition)
+            self.assertIn(f'self.{attribute}.pack(side="left"', definition)
+
+        self.assertIn('update_actions = ttk.Frame(update_bar', update_bar)
         for attribute in (
+            "check_updates_control",
             "check_updates_button",
             "install_update_button",
             "changelog_button",
             "view_release_button",
         ):
-            self.assertIn(f'{attribute}.pack(side="left"', update_bar)
+            self.assertEqual(update_bar.count(f"self.{attribute}.pack("), 1)
 
     def test_delayed_changelog_does_not_steal_an_update_decision(self):
         class Probe:

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -12,6 +13,11 @@ VALID_RELEASE = {
         "https://github.com/SacredWoobie/"
         "woobies-mission-control/releases/tag/v0.3.0"
     ),
+    "draft": False,
+    "prerelease": False,
+    "immutable": False,
+    "body": "Release notes",
+    "assets": [],
 }
 
 
@@ -25,8 +31,8 @@ class FakeResponse:
     def __exit__(self, _exc_type, _exc, _traceback):
         return False
 
-    def read(self):
-        return self.payload
+    def read(self, size=-1):
+        return self.payload if size < 0 else self.payload[:size]
 
 
 class UpdateCheckerTests(unittest.TestCase):
@@ -121,6 +127,54 @@ class UpdateCheckerTests(unittest.TestCase):
 
             self.assertEqual(ksp_dashboard_app.load_update_state(path), state)
             self.assertFalse(path.with_suffix(".json.tmp").exists())
+
+    def test_packaged_startup_blocks_pending_update_without_exact_token(self):
+        update = ksp_dashboard_app.runtime_update
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "package"
+            dashboard = root / "Dashboard"
+            dashboard.mkdir(parents=True)
+            (root / update.INSTALL_MANIFEST_NAME).write_text("{}", encoding="utf-8")
+            transaction_id = "1" * 32
+            paths = update._transaction_paths(root, transaction_id)
+            paths["transaction_root"].mkdir(parents=True)
+            update._atomic_write_json(
+                paths["active"],
+                {"schema": 1, "transaction_id": transaction_id},
+            )
+            update._journal(paths, "awaiting_restart", helper_pid=None)
+            before = paths["journal"].read_bytes()
+
+            with self.assertRaises(update.TransactionError):
+                ksp_dashboard_app.runtime_start_context(dashboard, {})
+            package_root, token = ksp_dashboard_app.runtime_start_context(
+                dashboard, {"WMC_UPDATE_TRANSACTION": transaction_id}
+            )
+
+            self.assertEqual(package_root, root.resolve())
+            self.assertEqual(token, transaction_id)
+            self.assertEqual(paths["journal"].read_bytes(), before)
+
+    def test_source_checkout_has_no_managed_startup_guard(self):
+        with tempfile.TemporaryDirectory() as directory:
+            dashboard = Path(directory) / "Dashboard"
+            dashboard.mkdir()
+            self.assertEqual(
+                ksp_dashboard_app.runtime_start_context(dashboard, {}),
+                (None, None),
+            )
+
+    @unittest.skipUnless(os.name == "nt", "launcher mutex is Windows-specific")
+    def test_only_one_launcher_instance_owns_a_package_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first = ksp_dashboard_app.LauncherInstanceGuard(directory)
+            try:
+                with self.assertRaisesRegex(RuntimeError, "already running"):
+                    ksp_dashboard_app.LauncherInstanceGuard(directory)
+            finally:
+                first.close()
+            replacement = ksp_dashboard_app.LauncherInstanceGuard(directory)
+            replacement.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -36,6 +36,15 @@ class FakeResponse:
 
 
 class UpdateCheckerTests(unittest.TestCase):
+    def test_delayed_changelog_does_not_steal_an_update_decision(self):
+        class Probe:
+            staged_update = {"transaction_id": "synthetic"}
+            update_install_dialog = None
+
+        # This deliberately supplies none of the changelog attributes. Reaching
+        # past the modal guard would therefore fail the test immediately.
+        self.assertIsNone(ksp_dashboard_app.App._maybe_show_changelog(Probe()))
+
     def test_parse_version_tag_accepts_release_versions(self):
         self.assertEqual(ksp_dashboard_app.parse_version_tag("v1.2.3"), (1, 2, 3))
         self.assertEqual(ksp_dashboard_app.parse_version_tag("1.2.3"), (1, 2, 3))

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,5 +1,7 @@
 import json
 import os
+import sys
+import time
 import tempfile
 import unittest
 from pathlib import Path
@@ -184,6 +186,43 @@ class UpdateCheckerTests(unittest.TestCase):
                 first.close()
             replacement = ksp_dashboard_app.LauncherInstanceGuard(directory)
             replacement.close()
+
+    @unittest.skipUnless(os.name == "nt", "component process jobs are Windows-specific")
+    def test_backend_stop_terminates_its_descendant_process_tree(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            child_pid_path = root / "child.pid"
+            script = root / "component.py"
+            script.write_text(
+                "import subprocess, sys, time\n"
+                f"marker = {str(child_pid_path)!r}\n"
+                "child = subprocess.Popen([sys.executable, '-c', "
+                "'import time; time.sleep(30)'])\n"
+                "open(marker, 'w', encoding='utf-8').write(str(child.pid))\n"
+                "time.sleep(30)\n",
+                encoding="utf-8",
+            )
+            backend = ksp_dashboard_app.Backend(
+                "synthetic tree", script, lambda *_args: None
+            )
+            self.assertTrue(backend.start())
+            deadline = time.monotonic() + 10
+            while not child_pid_path.is_file() and time.monotonic() < deadline:
+                time.sleep(0.05)
+            self.assertTrue(child_pid_path.is_file())
+            child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+            self.assertTrue(ksp_dashboard_app.runtime_update._pid_is_running(child_pid))
+
+            backend.stop()
+            deadline = time.monotonic() + 5
+            while (
+                ksp_dashboard_app.runtime_update._pid_is_running(child_pid)
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.05)
+            self.assertFalse(
+                ksp_dashboard_app.runtime_update._pid_is_running(child_pid)
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 import time
 import tempfile
@@ -38,6 +39,27 @@ class FakeResponse:
 
 
 class UpdateCheckerTests(unittest.TestCase):
+    def test_update_buttons_follow_the_check_review_reference_workflow(self):
+        source = Path(ksp_dashboard_app.__file__).read_text(encoding="utf-8")
+        start = source.index('update_actions = ttk.Frame')
+        end = source.index('self.main_panes = tk.PanedWindow', start)
+        update_bar = source[start:end]
+
+        self.assertEqual(
+            re.findall(
+                r'text="(Check now|Review & install|Changelog|View release)"',
+                update_bar,
+            ),
+            ["Check now", "Review & install", "Changelog", "View release"],
+        )
+        for attribute in (
+            "check_updates_button",
+            "install_update_button",
+            "changelog_button",
+            "view_release_button",
+        ):
+            self.assertIn(f'{attribute}.pack(side="left"', update_bar)
+
     def test_delayed_changelog_does_not_steal_an_update_decision(self):
         class Probe:
             staged_update = {"transaction_id": "synthetic"}

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -87,6 +87,60 @@ function Copy-AllowlistedFile {
     Copy-Item -LiteralPath $source -Destination $destination -Force
 }
 
+function Write-Utf8Json {
+    param(
+        [string]$Path,
+        [Parameter(Mandatory)]
+        $Value
+    )
+
+    $json = $Value | ConvertTo-Json -Depth 10
+    [System.IO.File]::WriteAllText(
+        $Path,
+        $json + [Environment]::NewLine,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
+function Get-PackageFileRecord {
+    param(
+        [string]$StageRoot,
+        [string]$RelativePath,
+        [string]$ManifestPath = $RelativePath
+    )
+
+    $path = Join-Path $StageRoot $RelativePath
+    Assert-RequiredFile $path
+    $file = Get-Item -LiteralPath $path
+    return [ordered]@{
+        path = $ManifestPath.Replace('\', '/')
+        size = [long]$file.Length
+        sha256 = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+}
+
+function Test-ManagedRuntimePath {
+    param([string]$RelativePath)
+
+    $path = $RelativePath.Replace('\', '/')
+    if ($path.StartsWith('Dashboard/', [System.StringComparison]::Ordinal)) {
+        return $true
+    }
+    if ($path.StartsWith('GameData/', [System.StringComparison]::Ordinal) -or
+        $path.StartsWith('SOURCE/', [System.StringComparison]::Ordinal)) {
+        return $true
+    }
+    return $path -in @(
+        'BUILD-INFO.txt',
+        'CHANGELOG.md',
+        'LICENSE',
+        'QUICKSTART.txt',
+        'THIRD-PARTY/NOTICES.md',
+        'docs/CONTROL_PAD_PROTOCOL.md',
+        'firmware/KSP_control.ino'
+    )
+}
+
 $repoRoot = Get-FullPath (Join-Path $PSScriptRoot '..')
 $manifestPath = Join-Path $PSScriptRoot 'Release-Manifest.psd1'
 $frontendBuildScript = Join-Path $PSScriptRoot 'Build-Frontend.ps1'
@@ -138,6 +192,9 @@ $packageName = "Woobies-Mission-Control-v$Version"
 $stageRoot = Join-Path $OutputDirectory $packageName
 $zipPath = Join-Path $OutputDirectory "$packageName.zip"
 $checksumPath = Join-Path $OutputDirectory "$packageName.zip.sha256"
+$updateArchivePath = Join-Path $OutputDirectory "$packageName.zz-90-runtime-update.zip"
+$updateChecksumPath = "$updateArchivePath.sha256"
+$updateStageRoot = Join-Path $OutputDirectory "$packageName-runtime-update-stage"
 $notesPath = Join-Path $OutputDirectory "release-notes-v$Version.md"
 $releaseImages = @(
     @{ Source = 'docs/images/v0.6.0/space-center-overview.png'; Name = "$packageName.zz-01-space-center-overview.png" },
@@ -166,7 +223,8 @@ $sourceArchiveAssets = @(
         }
 )
 $sourceArchiveOutputPaths = @($sourceArchiveAssets | ForEach-Object { $_.OutputPath })
-foreach ($path in @($stageRoot, $zipPath, $checksumPath, $notesPath) + $releaseImagePaths + $sourceArchiveOutputPaths) {
+$releaseUpdatePaths = @($updateArchivePath, $updateChecksumPath)
+foreach ($path in @($stageRoot, $zipPath, $checksumPath, $updateStageRoot, $notesPath) + $releaseUpdatePaths + $releaseImagePaths + $sourceArchiveOutputPaths) {
     Assert-SafeChildPath -Parent $OutputDirectory -Child $path
 }
 
@@ -174,6 +232,8 @@ $sourceFiles = @(
     @{ Source = 'Start KSP Dashboard.bat'; Destination = 'Dashboard/Start KSP Dashboard.bat' },
     @{ Source = 'Select Mission Control Setup.ps1'; Destination = 'Dashboard/Select Mission Control Setup.ps1' },
     @{ Source = 'ksp_dashboard_app.py'; Destination = 'Dashboard/ksp_dashboard_app.py' },
+    @{ Source = 'runtime_update.py'; Destination = 'Dashboard/runtime_update.py' },
+    @{ Source = 'runtime_update_helper.py'; Destination = 'Dashboard/runtime_update_helper.py' },
     @{ Source = 'panel_bridge.py'; Destination = 'Dashboard/panel_bridge.py' },
     @{ Source = 'damage.py'; Destination = 'Dashboard/damage.py' },
     @{ Source = 'electricity.py'; Destination = 'Dashboard/electricity.py' },
@@ -328,6 +388,20 @@ if ($CreateDraftRelease) {
         throw "Local '$Target' does not match origin/$Target."
     }
     Invoke-CheckedCommand -Command 'gh' -Arguments @('auth', 'status', '--hostname', 'github.com')
+    $immutableJson = & gh api `
+        -H 'Accept: application/vnd.github+json' `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$Repository/immutable-releases"
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unable to verify the repository immutable-release setting.'
+    }
+    $immutableSetting = $immutableJson | ConvertFrom-Json
+    if ($immutableSetting.enabled -ne $true) {
+        throw (
+            'GitHub release immutability must be enabled before creating an ' +
+            'updater-capable draft release.'
+        )
+    }
     $existingJson = & gh release list --repo $Repository --limit 1000 --json tagName
     if ($LASTEXITCODE -ne 0) {
         throw 'Unable to inspect existing GitHub releases.'
@@ -346,7 +420,10 @@ New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 if (Test-Path -LiteralPath $stageRoot) {
     Remove-Item -LiteralPath $stageRoot -Recurse -Force
 }
-foreach ($path in @($zipPath, $checksumPath, $notesPath) + $releaseImagePaths + $sourceArchiveOutputPaths) {
+if (Test-Path -LiteralPath $updateStageRoot) {
+    Remove-Item -LiteralPath $updateStageRoot -Recurse -Force
+}
+foreach ($path in @($zipPath, $checksumPath, $notesPath) + $releaseUpdatePaths + $releaseImagePaths + $sourceArchiveOutputPaths) {
     if (Test-Path -LiteralPath $path) {
         Remove-Item -LiteralPath $path -Force
     }
@@ -379,16 +456,18 @@ Assert-RequiredFile (Join-Path $frontendDist 'index.html')
 New-Item -ItemType Directory -Path $webTarget -Force | Out-Null
 Copy-Item -Path (Join-Path $frontendDist '*') -Destination $webTarget -Recurse -Force
 
-$sourceCommit = 'not-a-git-checkout'
+$sourceCommit = $null
 if ((Test-Path -LiteralPath (Join-Path $repoRoot '.git')) -and (Get-Command 'git' -ErrorAction SilentlyContinue)) {
     $sourceCommit = (& git -C $repoRoot rev-parse HEAD 2>$null).Trim()
-    if (-not $sourceCommit) {
-        $sourceCommit = 'unknown'
-    }
-    elseif (@(& git -C $repoRoot status --porcelain).Count -gt 0) {
-        $sourceCommit += ' (working tree modified)'
-    }
+    $sourceDirty = @(& git -C $repoRoot status --porcelain)
 }
+if (-not $sourceCommit -or $sourceCommit -notmatch '^[0-9a-fA-F]{40}$') {
+    throw 'Runtime-update packages require an exact Git source commit.'
+}
+if ($sourceDirty.Count -gt 0) {
+    throw 'Runtime-update packages must be assembled from a clean Git checkout.'
+}
+$sourceCommit = $sourceCommit.ToLowerInvariant()
 $buildLines = @(
     "Woobie's Mission Control v$Version",
     "Assembled UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))",
@@ -409,6 +488,135 @@ foreach ($sourceArchive in $sourceArchiveInputs) {
     $buildLines,
     [System.Text.UTF8Encoding]::new($false)
 )
+
+Write-Step 'Creating managed installation and runtime-update manifests'
+$managedPaths = @(
+    Get-ChildItem -LiteralPath $stageRoot -Recurse -File |
+        ForEach-Object {
+            $_.FullName.Substring($stageRoot.Length).TrimStart('\').Replace('\', '/')
+        } |
+        Where-Object { Test-ManagedRuntimePath $_ } |
+        Sort-Object { $_.ToLowerInvariant() }
+)
+if ($managedPaths.Count -eq 0) {
+    throw 'The managed runtime file set is empty.'
+}
+$managedRecords = @(
+    $managedPaths |
+        ForEach-Object { Get-PackageFileRecord -StageRoot $stageRoot -RelativePath $_ }
+)
+$serviceRecords = @(
+    $serviceInputs |
+        Sort-Object { $_.Folder.ToLowerInvariant() } |
+        ForEach-Object {
+            [ordered]@{
+                name = $_.Folder
+                version = $_.Version
+                sha256 = $_.Hash
+            }
+        }
+)
+$installManifest = [ordered]@{
+    schema = 1
+    product_version = $Version
+    updater_protocol = 1
+    source_commit = $sourceCommit
+    services = $serviceRecords
+    files = $managedRecords
+}
+$installManifestPath = Join-Path $stageRoot 'WMC-INSTALL-MANIFEST.json'
+Write-Utf8Json -Path $installManifestPath -Value $installManifest
+
+New-Item -ItemType Directory -Path (Join-Path $updateStageRoot 'payload') -Force | Out-Null
+foreach ($relativePath in $managedPaths + @('WMC-INSTALL-MANIFEST.json')) {
+    $source = Join-Path $stageRoot $relativePath
+    $destination = Join-Path (Join-Path $updateStageRoot 'payload') $relativePath
+    New-Item -ItemType Directory -Path (Split-Path $destination -Parent) -Force | Out-Null
+    Copy-Item -LiteralPath $source -Destination $destination -Force
+}
+$payloadPaths = @(
+    Get-ChildItem -LiteralPath (Join-Path $updateStageRoot 'payload') -Recurse -File |
+        ForEach-Object {
+            $_.FullName.Substring($updateStageRoot.Length).TrimStart('\').Replace('\', '/')
+        } |
+        Sort-Object { $_.ToLowerInvariant() }
+)
+$payloadRecords = @(
+    $payloadPaths |
+        ForEach-Object { Get-PackageFileRecord -StageRoot $updateStageRoot -RelativePath $_ }
+)
+$updateManifest = [ordered]@{
+    schema = 1
+    product_version = $Version
+    source_commit = $sourceCommit
+    compatible_updater_protocols = @(1)
+    services = $serviceRecords
+    files = $payloadRecords
+}
+Write-Utf8Json -Path (Join-Path $updateStageRoot 'update-manifest.json') -Value $updateManifest
+
+Write-Step 'Creating runtime-update archive and checksum'
+Compress-Archive `
+    -Path (Join-Path $updateStageRoot '*') `
+    -DestinationPath $updateArchivePath `
+    -CompressionLevel Optimal
+$updateHash = Get-FileHash -LiteralPath $updateArchivePath -Algorithm SHA256
+$updateChecksumLine = (
+    "$($updateHash.Hash.ToLowerInvariant())  " +
+    "$([System.IO.Path]::GetFileName($updateArchivePath))" +
+    [Environment]::NewLine
+)
+[System.IO.File]::WriteAllText(
+    $updateChecksumPath,
+    $updateChecksumLine,
+    [System.Text.UTF8Encoding]::new($false)
+)
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$updateArchive = [System.IO.Compression.ZipFile]::OpenRead($updateArchivePath)
+try {
+    $updateEntries = @(
+        $updateArchive.Entries |
+            Where-Object { -not $_.FullName.EndsWith('/') }
+    )
+    $expectedUpdateEntries = @('update-manifest.json') + $payloadRecords.path
+    $actualUpdateEntries = @($updateEntries | ForEach-Object { $_.FullName.Replace('\', '/') })
+    if ($actualUpdateEntries.Count -ne $expectedUpdateEntries.Count -or
+        @($expectedUpdateEntries | Where-Object { $actualUpdateEntries -notcontains $_ }).Count -gt 0 -or
+        @($actualUpdateEntries | Where-Object { $expectedUpdateEntries -notcontains $_ }).Count -gt 0) {
+        throw 'Runtime-update ZIP entries do not exactly match update-manifest.json.'
+    }
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        foreach ($record in $payloadRecords) {
+            $entry = $updateEntries |
+                Where-Object { $_.FullName.Replace('\', '/') -eq $record.path } |
+                Select-Object -First 1
+            if (-not $entry -or $entry.Length -ne $record.size) {
+                throw "Runtime-update ZIP size mismatch: $($record.path)"
+            }
+            $stream = $entry.Open()
+            try {
+                $entryHash = [System.BitConverter]::ToString(
+                    $sha256.ComputeHash($stream)
+                ).Replace('-', '').ToLowerInvariant()
+            }
+            finally {
+                $stream.Dispose()
+            }
+            if ($entryHash -ne $record.sha256) {
+                throw "Runtime-update ZIP hash mismatch: $($record.path)"
+            }
+        }
+    }
+    finally {
+        $sha256.Dispose()
+    }
+}
+finally {
+    $updateArchive.Dispose()
+}
+Remove-Item -LiteralPath $updateStageRoot -Recurse -Force
 
 $notesPattern = "(?ms)^## v$([regex]::Escape($Version))[^\r\n]*\r?\n(?<body>.*?)(?=^## |\z)"
 $notesMatch = [regex]::Match($changelog, $notesPattern)
@@ -439,7 +647,7 @@ $requiredEntries = @(
     $serviceInputs.Destination +
     $serviceCompanionInputs.Destination +
     $sourceArchiveInputs.Destination +
-    @('Dashboard/web/index.html', 'BUILD-INFO.txt')
+    @('Dashboard/web/index.html', 'BUILD-INFO.txt', 'WMC-INSTALL-MANIFEST.json')
 )
 foreach ($required in $requiredEntries) {
     if ($relativeStageFiles -notcontains $required) {
@@ -456,6 +664,11 @@ if ($forbidden.Count -gt 0) {
 Write-Step 'Creating ZIP and checksum'
 Compress-Archive -Path (Join-Path $stageRoot '*') -DestinationPath $zipPath -CompressionLevel Optimal
 $hash = Get-FileHash -LiteralPath $zipPath -Algorithm SHA256
+$fullZipFile = Get-Item -LiteralPath $zipPath
+$updateZipFile = Get-Item -LiteralPath $updateArchivePath
+if ($updateZipFile.Length -ge $fullZipFile.Length) {
+    throw 'The runtime-update asset must be smaller than the normal release ZIP.'
+}
 $checksumLine = "$($hash.Hash.ToLowerInvariant())  $([System.IO.Path]::GetFileName($zipPath))$([Environment]::NewLine)"
 [System.IO.File]::WriteAllText($checksumPath, $checksumLine, [System.Text.UTF8Encoding]::new($false))
 
@@ -488,6 +701,8 @@ Write-Host "`nRelease candidate verified:" -ForegroundColor Green
 Write-Host "  Unpacked: $stageRoot"
 Write-Host "  ZIP:      $zipPath"
 Write-Host "  SHA-256:  $($hash.Hash.ToLowerInvariant())"
+Write-Host "  Update:   $updateArchivePath"
+Write-Host "  Update SHA-256: $($updateHash.Hash.ToLowerInvariant())"
 Write-Host "  Notes:    $notesPath"
 if ($releaseImagePaths.Count -gt 0) {
     Write-Host '  Images:'
@@ -512,7 +727,7 @@ Write-Step 'Creating draft GitHub release'
 $releaseArguments = @(
     'release', 'create', "v$Version",
     $zipPath, $checksumPath
-) + $sourceArchiveOutputPaths + $releaseImagePaths + @(
+) + $sourceArchiveOutputPaths + $releaseImagePaths + $releaseUpdatePaths + @(
     '--repo', $Repository,
     '--target', $Target,
     '--title', "Woobie's Mission Control v$Version",

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -490,13 +490,16 @@ foreach ($sourceArchive in $sourceArchiveInputs) {
 )
 
 Write-Step 'Creating managed installation and runtime-update manifests'
-$managedPaths = @(
+$managedPaths = [string[]]@(
     Get-ChildItem -LiteralPath $stageRoot -Recurse -File |
         ForEach-Object {
             $_.FullName.Substring($stageRoot.Length).TrimStart('\').Replace('\', '/')
         } |
-        Where-Object { Test-ManagedRuntimePath $_ } |
-        Sort-Object { $_.ToLowerInvariant() }
+        Where-Object { Test-ManagedRuntimePath $_ }
+)
+[System.Array]::Sort(
+    $managedPaths,
+    [System.StringComparer]::OrdinalIgnoreCase
 )
 if ($managedPaths.Count -eq 0) {
     throw 'The managed runtime file set is empty.'
@@ -534,12 +537,15 @@ foreach ($relativePath in $managedPaths + @('WMC-INSTALL-MANIFEST.json')) {
     New-Item -ItemType Directory -Path (Split-Path $destination -Parent) -Force | Out-Null
     Copy-Item -LiteralPath $source -Destination $destination -Force
 }
-$payloadPaths = @(
+$payloadPaths = [string[]]@(
     Get-ChildItem -LiteralPath (Join-Path $updateStageRoot 'payload') -Recurse -File |
         ForEach-Object {
             $_.FullName.Substring($updateStageRoot.Length).TrimStart('\').Replace('\', '/')
-        } |
-        Sort-Object { $_.ToLowerInvariant() }
+        }
+)
+[System.Array]::Sort(
+    $payloadPaths,
+    [System.StringComparer]::OrdinalIgnoreCase
 )
 $payloadRecords = @(
     $payloadPaths |

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -556,10 +556,38 @@ $updateManifest = [ordered]@{
 Write-Utf8Json -Path (Join-Path $updateStageRoot 'update-manifest.json') -Value $updateManifest
 
 Write-Step 'Creating runtime-update archive and checksum'
-Compress-Archive `
-    -Path (Join-Path $updateStageRoot '*') `
-    -DestinationPath $updateArchivePath `
-    -CompressionLevel Optimal
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$updateArchiveStream = [System.IO.File]::Open(
+    $updateArchivePath,
+    [System.IO.FileMode]::CreateNew,
+    [System.IO.FileAccess]::ReadWrite,
+    [System.IO.FileShare]::None
+)
+try {
+    $updateArchiveWriter = [System.IO.Compression.ZipArchive]::new(
+        $updateArchiveStream,
+        [System.IO.Compression.ZipArchiveMode]::Create,
+        $false
+    )
+    try {
+        $updateArchiveInputs = @('update-manifest.json') + $payloadPaths
+        foreach ($relativePath in $updateArchiveInputs) {
+            $entryName = $relativePath.Replace('\', '/')
+            [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+                $updateArchiveWriter,
+                (Join-Path $updateStageRoot $relativePath),
+                $entryName,
+                [System.IO.Compression.CompressionLevel]::Optimal
+            ) | Out-Null
+        }
+    }
+    finally {
+        $updateArchiveWriter.Dispose()
+    }
+}
+finally {
+    $updateArchiveStream.Dispose()
+}
 $updateHash = Get-FileHash -LiteralPath $updateArchivePath -Algorithm SHA256
 $updateChecksumLine = (
     "$($updateHash.Hash.ToLowerInvariant())  " +
@@ -572,7 +600,6 @@ $updateChecksumLine = (
     [System.Text.UTF8Encoding]::new($false)
 )
 
-Add-Type -AssemblyName System.IO.Compression.FileSystem
 $updateArchive = [System.IO.Compression.ZipFile]::OpenRead($updateArchivePath)
 try {
     $updateEntries = @(

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -556,6 +556,7 @@ $updateManifest = [ordered]@{
 Write-Utf8Json -Path (Join-Path $updateStageRoot 'update-manifest.json') -Value $updateManifest
 
 Write-Step 'Creating runtime-update archive and checksum'
+Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 $updateArchiveStream = [System.IO.File]::Open(
     $updateArchivePath,

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -123,25 +123,51 @@ function Test-ManagedRuntimePath {
     param([string]$RelativePath)
 
     $path = $RelativePath.Replace('\', '/')
-    if ($path.StartsWith('Dashboard/', [System.StringComparison]::Ordinal)) {
+    $segments = @($path.Split('/'))
+    if ($script:RuntimeUpdateContract.root_managed_files -ccontains $path) {
         return $true
     }
-    if ($path.StartsWith('GameData/', [System.StringComparison]::Ordinal) -or
-        $path.StartsWith('SOURCE/', [System.StringComparison]::Ordinal)) {
+    if ($path -ceq $script:RuntimeUpdateContract.dashboard_contract_path) {
         return $true
     }
-    return $path -in @(
-        'BUILD-INFO.txt',
-        'CHANGELOG.md',
-        'LICENSE',
-        'QUICKSTART.txt',
-        'THIRD-PARTY/NOTICES.md',
-        'docs/CONTROL_PAD_PROTOCOL.md',
-        'firmware/KSP_control.ino'
-    )
+    if ($segments.Count -eq 2 -and $segments[0] -ceq 'Dashboard') {
+        $extension = [System.IO.Path]::GetExtension($segments[1]).ToLowerInvariant()
+        return $script:RuntimeUpdateContract.dashboard_top_level_extensions -ccontains $extension
+    }
+    if ($path -ceq $script:RuntimeUpdateContract.dashboard_web_index) {
+        return $true
+    }
+    if ($segments.Count -eq 4 -and
+        $segments[0] -ceq 'Dashboard' -and
+        $segments[1] -ceq 'web' -and
+        $segments[2] -ceq 'assets') {
+        $extension = [System.IO.Path]::GetExtension($segments[3]).ToLowerInvariant()
+        return $script:RuntimeUpdateContract.dashboard_asset_extensions -ccontains $extension
+    }
+    if ($segments.Count -ge 3 -and
+        $segments[0] -ceq 'GameData' -and
+        $script:RuntimeUpdateContract.service_folders -ccontains $segments[1]) {
+        return $true
+    }
+    if ($segments.Count -eq 2 -and
+        $segments[0] -ceq 'SOURCE' -and
+        $segments[1].EndsWith(
+            $script:RuntimeUpdateContract.source_archive_suffix,
+            [System.StringComparison]::OrdinalIgnoreCase
+        )) {
+        return $true
+    }
+    return $false
 }
 
 $repoRoot = Get-FullPath (Join-Path $PSScriptRoot '..')
+$runtimeUpdateContractPath = Join-Path $repoRoot 'runtime-update-contract.json'
+Assert-RequiredFile $runtimeUpdateContractPath
+$script:RuntimeUpdateContract = Get-Content -LiteralPath $runtimeUpdateContractPath `
+    -Raw -Encoding UTF8 | ConvertFrom-Json
+if ($script:RuntimeUpdateContract.schema -ne 1) {
+    throw 'runtime-update-contract.json has an unsupported schema.'
+}
 $manifestPath = Join-Path $PSScriptRoot 'Release-Manifest.psd1'
 $frontendBuildScript = Join-Path $PSScriptRoot 'Build-Frontend.ps1'
 $frontendRoot = Join-Path $repoRoot 'frontend'
@@ -234,6 +260,7 @@ $sourceFiles = @(
     @{ Source = 'ksp_dashboard_app.py'; Destination = 'Dashboard/ksp_dashboard_app.py' },
     @{ Source = 'runtime_update.py'; Destination = 'Dashboard/runtime_update.py' },
     @{ Source = 'runtime_update_helper.py'; Destination = 'Dashboard/runtime_update_helper.py' },
+    @{ Source = 'runtime-update-contract.json'; Destination = 'Dashboard/runtime-update-contract.json' },
     @{ Source = 'panel_bridge.py'; Destination = 'Dashboard/panel_bridge.py' },
     @{ Source = 'damage.py'; Destination = 'Dashboard/damage.py' },
     @{ Source = 'electricity.py'; Destination = 'Dashboard/electricity.py' },
@@ -490,6 +517,26 @@ foreach ($sourceArchive in $sourceArchiveInputs) {
 )
 
 Write-Step 'Creating managed installation and runtime-update manifests'
+$runtimeSurfacePaths = @(
+    Get-ChildItem -LiteralPath $stageRoot -Recurse -File |
+        ForEach-Object {
+            $_.FullName.Substring($stageRoot.Length).TrimStart('\').Replace('\', '/')
+        } |
+        Where-Object {
+            $_.StartsWith('Dashboard/', [System.StringComparison]::Ordinal) -or
+            $_.StartsWith('GameData/', [System.StringComparison]::Ordinal) -or
+            $_.StartsWith('SOURCE/', [System.StringComparison]::Ordinal)
+        }
+)
+$unmanagedRuntimePaths = @(
+    $runtimeSurfacePaths | Where-Object { -not (Test-ManagedRuntimePath $_) }
+)
+if ($unmanagedRuntimePaths.Count -gt 0) {
+    throw (
+        'Packaged runtime paths are absent from runtime-update-contract.json: ' +
+        ($unmanagedRuntimePaths -join ', ')
+    )
+}
 $managedPaths = [string[]]@(
     Get-ChildItem -LiteralPath $stageRoot -Recurse -File |
         ForEach-Object {
@@ -561,6 +608,28 @@ $updateManifest = [ordered]@{
 }
 Write-Utf8Json -Path (Join-Path $updateStageRoot 'update-manifest.json') -Value $updateManifest
 
+$contractLimits = $script:RuntimeUpdateContract.limits
+$updateManifestFile = Get-Item -LiteralPath (Join-Path $updateStageRoot 'update-manifest.json')
+if ($payloadRecords.Count + 1 -gt [long]$contractLimits.archive_entries) {
+    throw 'Runtime-update payload exceeds the updater archive entry limit.'
+}
+if ($updateManifestFile.Length -gt [long]$contractLimits.archive_file_bytes) {
+    throw 'Runtime-update manifest exceeds the updater per-file limit.'
+}
+$expandedBytes = [long]$updateManifestFile.Length
+foreach ($record in $payloadRecords) {
+    if ($record.path.Length -gt [long]$contractLimits.relative_path_length) {
+        throw "Runtime-update path exceeds the updater length limit: $($record.path)"
+    }
+    if ([long]$record.size -gt [long]$contractLimits.archive_file_bytes) {
+        throw "Runtime-update file exceeds the updater per-file limit: $($record.path)"
+    }
+    $expandedBytes += [long]$record.size
+}
+if ($expandedBytes -gt [long]$contractLimits.archive_expanded_bytes) {
+    throw 'Runtime-update payload exceeds the updater expanded-size limit.'
+}
+
 Write-Step 'Creating runtime-update archive and checksum'
 Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -595,6 +664,10 @@ try {
 finally {
     $updateArchiveStream.Dispose()
 }
+$updateArchiveFile = Get-Item -LiteralPath $updateArchivePath
+if ($updateArchiveFile.Length -gt [long]$contractLimits.download_bytes) {
+    throw 'Runtime-update ZIP exceeds the updater download limit.'
+}
 $updateHash = Get-FileHash -LiteralPath $updateArchivePath -Algorithm SHA256
 $updateChecksumLine = (
     "$($updateHash.Hash.ToLowerInvariant())  " +
@@ -606,6 +679,9 @@ $updateChecksumLine = (
     $updateChecksumLine,
     [System.Text.UTF8Encoding]::new($false)
 )
+if ((Get-Item -LiteralPath $updateChecksumPath).Length -gt [long]$contractLimits.checksum_bytes) {
+    throw 'Runtime-update checksum exceeds the updater checksum limit.'
+}
 
 $updateArchive = [System.IO.Compression.ZipFile]::OpenRead($updateArchivePath)
 try {
@@ -613,6 +689,19 @@ try {
         $updateArchive.Entries |
             Where-Object { -not $_.FullName.EndsWith('/') }
     )
+    if ($updateEntries.Count -gt [long]$contractLimits.archive_entries) {
+        throw 'Runtime-update ZIP exceeds the updater archive entry limit.'
+    }
+    $archiveExpandedBytes = [long]0
+    foreach ($entry in $updateEntries) {
+        if ($entry.Length -gt [long]$contractLimits.archive_file_bytes) {
+            throw "Runtime-update ZIP entry exceeds the updater per-file limit: $($entry.FullName)"
+        }
+        $archiveExpandedBytes += [long]$entry.Length
+    }
+    if ($archiveExpandedBytes -gt [long]$contractLimits.archive_expanded_bytes) {
+        throw 'Runtime-update ZIP exceeds the updater expanded-size limit.'
+    }
     $expectedUpdateEntries = @('update-manifest.json') + $payloadRecords.path
     $actualUpdateEntries = @($updateEntries | ForEach-Object { $_.FullName.Replace('\', '/') })
     if ($actualUpdateEntries.Count -ne $expectedUpdateEntries.Count -or


### PR DESCRIPTION
## Summary

- Add an opt-in **Review & install** workflow that downloads a compact managed-runtime update instead of requiring the complete release ZIP.
- Authenticate updates against an immutable stable GitHub release, the GitHub asset digest, the SHA-256 sidecar, and a strict manifest/ZIP contract.
- Apply replacements through an external helper with backups, rollback, interrupted-transaction recovery, Windows process identity checks, and owned process-tree shutdown.
- Extend release tooling to build and validate the runtime update ZIP, manifest, and checksum alongside the normal portable package.
- Document the bootstrap path: v0.6.1 is installed manually from the full ZIP; the next release is the first real live-update smoke test.

## User and developer impact

The updater changes only package-managed runtime files. It preserves the local virtual environment, settings, planner data, logs, and unknown user files, and it does not mutate the selected live KSP `GameData` tree. The package's bundled service-repair copies remain managed, while the selected service DLL versions are unchanged.

The launcher now keeps the update workflow together in this order:

`Automatic update checks → Check now → Review & install → Changelog → View release`

## Validation

- 419 Python tests pass with `ResourceWarning` treated as an error.
- 431 frontend tests pass; frontend typecheck and production build pass.
- Source and unpacked-package `Start KSP Dashboard.bat --check` validations pass.
- Release packaging, exact manifests/hashes, compact-archive limits, synthetic predecessor upgrade, forced helper termination/recovery, PID-reuse protection, and descendant-process cleanup were exercised.
- Independent PR-readiness audit approved the current head, `1014e237aebeef564beea57c5051e7d08cf7c48d`.
- Repository release immutability is enabled.

## Release plan

This PR keeps the changelog under **Unreleased**. After review and squash merge, the clean merged candidate will receive the narrow release preflight and v0.6.1 version/release changes. v0.6.1 must still be installed manually; a later feature release will exercise the first live v0.6.1-to-successor update.