### PR TITLE
Fix missing runtime decoder in release packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable public changes will be recorded here.
 
+## Unreleased
+
+- Fixed full and managed-update packaging so the Editor electrical snapshot
+  decoder required by the telemetry server is included. Release-contract tests
+  now verify that every packaged Python runtime closes over its repository-local
+  imports before an archive can ship.
+
 ## v0.7.0 - Flight instruments and Editor electricity
 
 - Extended Managed runtime updates to the first public successor: v0.6.1 can

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -1,3 +1,4 @@
+import ast
 import importlib.util
 import json
 import re
@@ -628,6 +629,7 @@ class ReleaseContractTests(unittest.TestCase):
         for module in (
             "damage.py",
             "electricity.py",
+            "editor_electrical_snapshot.py",
             "flight_core_snapshot.py",
             "heat.py",
             "heat_electricity_snapshot.py",
@@ -649,6 +651,45 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn("RequiredPackageFiles", publish_script)
         self.assertIn("SourceArchiveSha256", publish_script)
         self.assertIn('Destination = "SOURCE/', publish_script)
+
+    def test_packaged_python_runtime_closes_over_local_imports(self):
+        publish_script = (ROOT / "tools" / "Publish-Release.ps1").read_text(
+            encoding="utf-8"
+        )
+        packaged_sources = re.findall(
+            r"@\{ Source = '([^']+\.py)'; Destination = "
+            r"'Dashboard/([^']+\.py)' \}",
+            publish_script,
+        )
+        self.assertIn(
+            ("telemetry_server.py", "telemetry_server.py"), packaged_sources
+        )
+        packaged_modules = {
+            Path(destination).stem for _, destination in packaged_sources
+        }
+        local_modules = {path.stem for path in ROOT.glob("*.py")}
+        missing_imports = {}
+
+        for source, destination in packaged_sources:
+            tree = ast.parse((ROOT / source).read_text(encoding="utf-8"), source)
+            imported_modules = set()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    imported_modules.update(
+                        alias.name.split(".", 1)[0] for alias in node.names
+                    )
+                elif (
+                    isinstance(node, ast.ImportFrom)
+                    and node.level == 0
+                    and node.module
+                ):
+                    imported_modules.add(node.module.split(".", 1)[0])
+
+            missing = sorted(imported_modules & local_modules - packaged_modules)
+            if missing:
+                missing_imports[destination] = missing
+
+        self.assertEqual(missing_imports, {})
 
 
 if __name__ == "__main__":

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -283,6 +283,7 @@ $sourceFiles = @(
     @{ Source = 'panel_bridge.py'; Destination = 'Dashboard/panel_bridge.py' },
     @{ Source = 'damage.py'; Destination = 'Dashboard/damage.py' },
     @{ Source = 'electricity.py'; Destination = 'Dashboard/electricity.py' },
+    @{ Source = 'editor_electrical_snapshot.py'; Destination = 'Dashboard/editor_electrical_snapshot.py' },
     @{ Source = 'flight_core_snapshot.py'; Destination = 'Dashboard/flight_core_snapshot.py' },
     @{ Source = 'heat.py'; Destination = 'Dashboard/heat.py' },
     @{ Source = 'heat_electricity_snapshot.py'; Destination = 'Dashboard/heat_electricity_snapshot.py' },


### PR DESCRIPTION
## What changed

- include `editor_electrical_snapshot.py` in the full and managed-update package allowlist
- add a release-contract test that parses packaged Python sources and rejects omitted repository-local imports
- record the fix under `Unreleased`

## Root cause and impact

v0.7.0 packaged `telemetry_server.py` without the Editor electrical snapshot decoder it imports, so both a fresh full install and a v0.6.1 managed update fail to start the telemetry feed with `ModuleNotFoundError`.

## Validation

- 28/28 focused release-contract tests
- 433/433 full Python tests
- 46 frontend test files / 476 tests, CSS contract, strict TypeScript, and production Vite build
- full and managed-update acceptance ZIPs assembled from exact commit `bbbcafe2833973ec618a6519f27da3d8bcad4623`
- both extracted artifacts contain the decoder in their manifests with the exact source hash and successfully import `telemetry_server`

No service DLL, frontend behavior, KSP, or GameData change.