### PR TITLE
Add dashboard settings, themes, and integration visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ All notable public changes will be recorded here.
   About sections. Preferences retain the dashboard time system and local
   science-alarm defaults, and can restore hidden panels. About reports the
   current Mission Control Dark palette without exposing a theme chooser yet.
-- Added capability-aware Features & Mods status copy: Available, Installed but
-  not observed here, Stock fallback active, Not detected, Unavailable, and
-  Unknown. Stock fallback is shown only from live backend evidence; finding an
-  installed provider without current-scene evidence is not mislabeled Unknown,
-  and a missing fixed marker does not imply that Stock is active. The inventory
-  is limited to known Mission Control integrations and does not scan arbitrary
+- Added dashboard-wide Features & Mods status based on the configured KSP
+  installation rather than the current game scene: Available, Available - Stock,
+  Unavailable, and Detection unavailable. Expanded rows show only the fixed,
+  known integration checks used to drive that status. The inventory remains
+  limited to known Mission Control integrations and does not scan arbitrary
   installed mods.
 - Added a curated external-link Help table of contents and an About card that
   explains the browser/launcher boundary. Setup, KSP selection, service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable public changes will be recorded here.
   science-alarm defaults, can restore hidden panels, and offer four persistent
   color themes: Mission Control Dark, Daylight Console, Warm CRT, and Green
   Phosphor. Theme changes apply immediately without changing dashboard layout
-  or typography.
+  or typography. Flight hardware, inactive annunciators, Plan state washes,
+  and advisory text use theme-specific contrast while lit warning lamps and
+  graphic instruments retain their operational colors.
 - Added dashboard-wide Features & Mods status based on the configured KSP
   installation rather than the current game scene: Available, Available - Stock,
   Unavailable, and Detection unavailable. Expanded rows show only the fixed,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ All notable public changes will be recorded here.
   About sections. Preferences retain the dashboard time system and local
   science-alarm defaults, and can restore hidden panels. About reports the
   current Mission Control Dark palette without exposing a theme chooser yet.
-- Added capability-aware Features & Mods status copy: Available, Stock
-  fallback active, Unavailable, and Unknown. Unknown means that an authoritative
-  provider observation is not available; it is not the same as Missing. The
-  inventory is limited to known Mission Control integrations and does not scan
-  arbitrary installed mods.
+- Added capability-aware Features & Mods status copy: Available, Installed but
+  not observed here, Stock fallback active, Not detected, Unavailable, and
+  Unknown. Stock fallback is shown only from live backend evidence; finding an
+  installed provider without current-scene evidence is not mislabeled Unknown,
+  and a missing fixed marker does not imply that Stock is active. The inventory
+  is limited to known Mission Control integrations and does not scan arbitrary
+  installed mods.
 - Added a curated external-link Help table of contents and an About card that
   explains the browser/launcher boundary. Setup, KSP selection, service
   Install / Repair, updates, and Dashboard feed control remain launcher tasks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable public changes will be recorded here.
 
 - Added a Settings rail drawer with Preferences, Features & Mods, Help, and
   About sections. Preferences retain the dashboard time system and local
-  science-alarm defaults, and can restore hidden panels. About reports the
-  current Mission Control Dark palette without exposing a theme chooser yet.
+  science-alarm defaults, can restore hidden panels, and offer four persistent
+  color themes: Mission Control Dark, Daylight Console, Warm CRT, and Green
+  Phosphor. Theme changes apply immediately without changing dashboard layout
+  or typography.
 - Added dashboard-wide Features & Mods status based on the configured KSP
   installation rather than the current game scene: Available, Available - Stock,
   Unavailable, and Detection unavailable. Expanded rows show only the fixed,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable public changes will be recorded here.
 
+## Unreleased
+
+- Added a Settings rail drawer with Preferences, Features & Mods, Help, and
+  About sections. Preferences retain the dashboard time system and local
+  science-alarm defaults, and can restore hidden panels. About reports the
+  current Mission Control Dark palette without exposing a theme chooser yet.
+- Added capability-aware Features & Mods status copy: Available, Stock
+  fallback active, Unavailable, and Unknown. Unknown means that an authoritative
+  provider observation is not available; it is not the same as Missing. The
+  inventory is limited to known Mission Control integrations and does not scan
+  arbitrary installed mods.
+- Added a curated external-link Help table of contents and an About card that
+  explains the browser/launcher boundary. Setup, KSP selection, service
+  Install / Repair, updates, and Dashboard feed control remain launcher tasks.
+
 ## v0.7.1 - Release packaging repair
 
 - Fixed full and managed-update packaging so the Editor electrical snapshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable public changes will be recorded here.
   Tools groups, with a wider name field, distinct Update and Save as new
   actions, inline save feedback, and a non-redundant planner title. Saved-plan,
   reset, and model dialogs now inherit the selected dashboard color theme.
+  Simple / Advanced transfer planning now sits with the mission-wide Planning
+  Budget rather than inside the per-stop arrival builder.
 
 ## v0.7.1 - Release packaging repair
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable public changes will be recorded here.
 - Added a curated external-link Help table of contents and an About card that
   explains the browser/launcher boundary. Setup, KSP selection, service
   Install / Repair, updates, and Dashboard feed control remain launcher tasks.
+- Reworked Delta-V plan management into clearly labeled Plan Name and Plan
+  Tools groups, with a wider name field, distinct Update and Save as new
+  actions, inline save feedback, and a non-redundant planner title. Saved-plan,
+  reset, and model dialogs now inherit the selected dashboard color theme.
 
 ## v0.7.1 - Release packaging repair
 

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -121,5 +121,18 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    Use A- and A+ in either Notes view to adjust text size; click the size value
    to return to the default.
 
+   SETTINGS RAIL: The Settings rail groups browser-local Preferences, known
+   Features & Mods, curated external Help links, and About information.
+   Preferences controls Kerbin/Earth time, Science alarm defaults, and hidden
+   panel restoration. About reports Mission Control Dark and has no theme
+   chooser. Features & Mods uses Available, Stock fallback active, Unavailable,
+   and Unknown; Unknown means that a provider was not authoritatively observed,
+   not that the integration is Missing. Only known Mission Control providers
+   and integrations are shown, not an arbitrary inventory of installed mods.
+   Setup, KSP-folder selection, service Install / Repair, package updates, and
+   Dashboard feed start/stop remain launcher tasks in
+   Dashboard\Start KSP Dashboard.bat; the browser does not write the selected
+   live KSP GameData.
+
 For component choices, compatibility information, troubleshooting, and ESP32
 control-pad instructions, see README.md.

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -124,8 +124,10 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    SETTINGS RAIL: The Settings rail groups browser-local Preferences, known
    Features & Mods, curated external Help links, and About information.
    Preferences controls Kerbin/Earth time, Science alarm defaults, and hidden
-   panel restoration. About reports Mission Control Dark and has no theme
-   chooser. Features & Mods reports dashboard-wide status from the configured
+   panel restoration. It also offers Mission Control Dark, Daylight Console,
+   Warm CRT, and Green Phosphor color themes; the selected colors apply
+   immediately and persist in the browser without changing layout or type.
+   About reports the active theme. Features & Mods reports dashboard-wide status from the configured
    KSP installation, independent of the current game scene: Available,
    Available - Stock, Unavailable, or Detection unavailable. Expanded rows show
    the fixed known integration checks behind the result. This is not an

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -125,10 +125,11 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    Features & Mods, curated external Help links, and About information.
    Preferences controls Kerbin/Earth time, Science alarm defaults, and hidden
    panel restoration. About reports Mission Control Dark and has no theme
-   chooser. Features & Mods uses Available, Stock fallback active, Unavailable,
-   and Unknown; Unknown means that a provider was not authoritatively observed,
-   not that the integration is Missing. Only known Mission Control providers
-   and integrations are shown, not an arbitrary inventory of installed mods.
+   chooser. Features & Mods separates Available, Installed but not observed in
+   this scene, Stock fallback active, Not detected, Unavailable, and Unknown.
+   Stock fallback requires live runtime evidence; a missing fixed marker does
+   not imply that Stock is active. Only known Mission Control providers and
+   integrations are shown, not an arbitrary inventory of installed mods.
    Setup, KSP-folder selection, service Install / Repair, package updates, and
    Dashboard feed start/stop remain launcher tasks in
    Dashboard\Start KSP Dashboard.bat; the browser does not write the selected

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -125,11 +125,11 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    Features & Mods, curated external Help links, and About information.
    Preferences controls Kerbin/Earth time, Science alarm defaults, and hidden
    panel restoration. About reports Mission Control Dark and has no theme
-   chooser. Features & Mods separates Available, Installed but not observed in
-   this scene, Stock fallback active, Not detected, Unavailable, and Unknown.
-   Stock fallback requires live runtime evidence; a missing fixed marker does
-   not imply that Stock is active. Only known Mission Control providers and
-   integrations are shown, not an arbitrary inventory of installed mods.
+   chooser. Features & Mods reports dashboard-wide status from the configured
+   KSP installation, independent of the current game scene: Available,
+   Available - Stock, Unavailable, or Detection unavailable. Expanded rows show
+   the fixed known integration checks behind the result. This is not an
+   arbitrary inventory of installed mods.
    Setup, KSP-folder selection, service Install / Repair, package updates, and
    Dashboard feed start/stop remain launcher tasks in
    Dashboard\Start KSP Dashboard.bat; the browser does not write the selected

--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ The dashboard adds a Settings rail drawer with four sections:
 - **Preferences** keeps the Kerbin/Earth time system and Science alarm defaults
   in browser-local storage, and can restore hidden dashboard panels.
 - **Features & Mods** reports only known Mission Control capabilities and
-  integrations. **Available** means an active provider is ready; **Installed ·
-  not observed here** means its known dependencies were found but the current
-  scene cannot prove that it is active; **Stock fallback active** requires live
-  evidence that the feature is using its stock backend; **Not detected** means
-  a fixed known marker was not found; **Unavailable** means runtime evidence
-  says the provider cannot serve the feature; and **Unknown** means the feed
-  cannot classify it. This view is not an inventory of arbitrary installed
-  mods.
+  integrations for the dashboard as a whole, independent of the current game
+  scene. **Available** means the required known integrations were detected;
+  **Available · Stock** means an optional integration was not detected but the
+  dashboard retains its built-in stock path; **Unavailable** means a required
+  known integration was not detected; and **Detection unavailable** means the
+  configured KSP installation could not be checked. Expanded rows show the
+  fixed installation checks behind the result. This view is not an inventory
+  of arbitrary installed mods.
 - **Help** is a curated table of contents of external setup, dashboard,
   compatibility, safety, and troubleshooting guides. It opens the existing
   project wiki and support links rather than copying documentation into the

--- a/README.md
+++ b/README.md
@@ -122,12 +122,14 @@ The dashboard adds a Settings rail drawer with four sections:
 - **Preferences** keeps the Kerbin/Earth time system and Science alarm defaults
   in browser-local storage, and can restore hidden dashboard panels.
 - **Features & Mods** reports only known Mission Control capabilities and
-  integrations. **Available** means an active provider is ready; **Stock
-  fallback active** means the feature is working through its stock fallback;
-  **Unavailable** means a known provider or dependency cannot provide it; and
-  **Unknown** means that an authoritative observation is not available. Unknown
-  is not Missing. This view checks a fixed set of known markers and runtime
-  providers; it is not an inventory of arbitrary installed mods.
+  integrations. **Available** means an active provider is ready; **Installed ·
+  not observed here** means its known dependencies were found but the current
+  scene cannot prove that it is active; **Stock fallback active** requires live
+  evidence that the feature is using its stock backend; **Not detected** means
+  a fixed known marker was not found; **Unavailable** means runtime evidence
+  says the provider cannot serve the feature; and **Unknown** means the feed
+  cannot classify it. This view is not an inventory of arbitrary installed
+  mods.
 - **Help** is a curated table of contents of external setup, dashboard,
   compatibility, safety, and troubleshooting guides. It opens the existing
   project wiki and support links rather than copying documentation into the

--- a/README.md
+++ b/README.md
@@ -115,6 +115,35 @@ does not execute nodes, warp, steer, stage, or change throttle.
 - Optional Notes, Kerbal Alarm Clock, RemoteTech, System Heat, and ESP32
   integrations without making them requirements for the rest of the dashboard.
 
+## Settings, Help, and About
+
+The dashboard adds a Settings rail drawer with four sections:
+
+- **Preferences** keeps the Kerbin/Earth time system and Science alarm defaults
+  in browser-local storage, and can restore hidden dashboard panels.
+- **Features & Mods** reports only known Mission Control capabilities and
+  integrations. **Available** means an active provider is ready; **Stock
+  fallback active** means the feature is working through its stock fallback;
+  **Unavailable** means a known provider or dependency cannot provide it; and
+  **Unknown** means that an authoritative observation is not available. Unknown
+  is not Missing. This view checks a fixed set of known markers and runtime
+  providers; it is not an inventory of arbitrary installed mods.
+- **Help** is a curated table of contents of external setup, dashboard,
+  compatibility, safety, and troubleshooting guides. It opens the existing
+  project wiki and support links rather than copying documentation into the
+  dashboard.
+- **About** identifies the product, version, build channel, and local dashboard
+  endpoint, reports the current **Mission Control Dark** palette as read-only,
+  and explains where installation belongs. There is no theme chooser yet; the
+  theme identifier leaves room for a future palette without promising one
+  today. The browser dashboard does not select a KSP folder, install or repair
+  service DLLs, apply package updates, or write the selected live KSP
+  `GameData`; use `Dashboard\Start KSP Dashboard.bat` for those launcher
+  responsibilities.
+
+The public baseline remains v0.7.1 until a later release is selected and
+published.
+
 ## Packaged KSP services
 
 The v0.7.1 public release selects four independently versioned kRPC extensions.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ does not execute nodes, warp, steer, stage, or change throttle.
 The dashboard adds a Settings rail drawer with four sections:
 
 - **Preferences** keeps the Kerbin/Earth time system and Science alarm defaults
-  in browser-local storage, and can restore hidden dashboard panels.
+  in browser-local storage, can restore hidden dashboard panels, and offers
+  Mission Control Dark, Daylight Console, Warm CRT, and Green Phosphor color
+  themes. A selection applies immediately and persists in that browser. The
+  themes change semantic color and surface treatments while retaining the same
+  typography and layout.
 - **Features & Mods** reports only known Mission Control capabilities and
   integrations for the dashboard as a whole, independent of the current game
   scene. **Available** means the required known integrations were detected;
@@ -134,11 +138,9 @@ The dashboard adds a Settings rail drawer with four sections:
   compatibility, safety, and troubleshooting guides. It opens the existing
   project wiki and support links rather than copying documentation into the
   dashboard.
-- **About** identifies the product, version, build channel, and local dashboard
-  endpoint, reports the current **Mission Control Dark** palette as read-only,
-  and explains where installation belongs. There is no theme chooser yet; the
-  theme identifier leaves room for a future palette without promising one
-  today. The browser dashboard does not select a KSP folder, install or repair
+- **About** identifies the product, version, build channel, current theme, and
+  local dashboard endpoint, and explains where installation belongs. The
+  browser dashboard does not select a KSP folder, install or repair
   service DLLs, apply package updates, or write the selected live KSP
   `GameData`; use `Dashboard\Start KSP Dashboard.bat` for those launcher
   responsibilities.

--- a/dashboard_capabilities.py
+++ b/dashboard_capabilities.py
@@ -54,9 +54,9 @@ _SCAN_WHITELIST = {
     "system_heat_mod": (("GameData", "SystemHeat", "Plugin", "SystemHeat.dll"), False),
     "woobies_mechjeb": (("GameData", "KRPC.WoobiesMechJeb", "KRPC.WoobiesMechJeb.dll"), False),
     "mechjeb": (("GameData", "MechJeb2", "Plugins", "MechJeb2.dll"), False),
-    "remote_tech": (("GameData", "RemoteTech", "RemoteTech.dll"), False),
-    "kac": (("GameData", "TriggerTech", "KerbalAlarmClock", "KerbalAlarmClock.dll"), False),
-    "dynamic_battery_storage": (("GameData", "DynamicBatteryStorage", "DynamicBatteryStorage.dll"), False),
+    "remote_tech": (("GameData", "RemoteTech", "Plugins", "RemoteTech.dll"), False),
+    "kac": (("GameData", "TriggerTech", "KerbalAlarmClock", "Plugins", "KerbalAlarmClock.dll"), False),
+    "dynamic_battery_storage": (("GameData", "DynamicBatteryStorage", "Plugins", "DynamicBatteryStorage.dll"), False),
 }
 
 _FEATURE_DEPENDENCIES = {
@@ -329,16 +329,18 @@ def build_dashboard_capabilities(
             evidence = evidence + scan_evidence
             if status == "unknown" and any(item["status"] == "missing" for item in scan_evidence):
                 if feature in _STOCK_FALLBACK_FEATURES:
-                    status, reason = "fallback", "fallback_active"
+                    # A missing optional-provider marker is installation
+                    # evidence, not proof that the stock backend is active in
+                    # the current scene. Keep the runtime state unobserved.
+                    status, reason = "unknown", "dependency_missing"
                 else:
                     status, reason = "unavailable", "dependency_missing"
         elif scan_evidence and configured and not scan_error:
             statuses = {item["status"] for item in scan_evidence}
             if "missing" in statuses:
-                if feature in _STOCK_FALLBACK_FEATURES:
-                    status, reason = "fallback", "fallback_active"
-                else:
-                    status, reason = "unavailable", "dependency_missing"
+                # A scan can say that a fixed marker was not detected, but it
+                # cannot claim a runtime fallback or current unavailability.
+                status, reason = "unknown", "dependency_missing"
             elif statuses == {"detected"}:
                 status, reason = "unknown", "not_observed"
             else:

--- a/dashboard_capabilities.py
+++ b/dashboard_capabilities.py
@@ -1,0 +1,365 @@
+"""Pure dashboard capability contract and bounded installation scan.
+
+The telemetry server owns the transport and supplies a normalised snapshot
+dictionary to :func:`build_dashboard_capabilities`.  This module deliberately
+has no kRPC or UI dependencies.  Runtime observations are preferred over the
+small fixed whitelist scan, while an unobserved provider is never reported as
+missing merely because a scene did not expose it.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+TELEMETRY_KEY = "dashboard.capabilities"
+
+FEATURE_IDS = (
+    "notes",
+    "science_telemetry",
+    "science_alarms",
+    "communications",
+    "stage_analysis",
+    "live_transfer_calculations",
+    "heat_monitoring",
+    "heat_controls",
+    "editor_electricity",
+    "damage_monitoring",
+)
+STATUSES = ("available", "fallback", "unavailable", "unknown")
+REASONS = (
+    "ready",
+    "fallback_active",
+    "dependency_missing",
+    "provider_unavailable",
+    "not_observed",
+    "scan_unconfigured",
+    "probe_error",
+)
+EVIDENCE_SOURCES = ("runtime", "root_scan")
+EVIDENCE_STATUSES = ("active", "detected", "missing", "unavailable", "unknown")
+
+# Only these fixed relative paths are ever inspected.  The values are internal
+# implementation details and are never included in the returned contract.
+_SCAN_WHITELIST = {
+    "notes": (("GameData", "Notes", "Plugins", "PluginData", "notes"), True),
+    "wcs": (("GameData", "WoobiesControlStats", "WoobiesControlStats.dll"), False),
+    "stage_stats": (("GameData", "KRPC.StageStats", "KRPC.StageStats.dll"), False),
+    "system_heat_service": (("GameData", "KRPC.SystemHeat", "KRPC.SystemHeat.dll"), False),
+    "system_heat_mod": (("GameData", "SystemHeat", "Plugin", "SystemHeat.dll"), False),
+    "woobies_mechjeb": (("GameData", "KRPC.WoobiesMechJeb", "KRPC.WoobiesMechJeb.dll"), False),
+    "mechjeb": (("GameData", "MechJeb2", "Plugins", "MechJeb2.dll"), False),
+    "remote_tech": (("GameData", "RemoteTech", "RemoteTech.dll"), False),
+    "kac": (("GameData", "TriggerTech", "KerbalAlarmClock", "KerbalAlarmClock.dll"), False),
+    "dynamic_battery_storage": (("GameData", "DynamicBatteryStorage", "DynamicBatteryStorage.dll"), False),
+}
+
+_FEATURE_DEPENDENCIES = {
+    "notes": ("notes",),
+    "science_telemetry": ("wcs",),
+    "science_alarms": ("kac",),
+    "communications": ("remote_tech",),
+    "stage_analysis": ("stage_stats", "mechjeb"),
+    "live_transfer_calculations": ("woobies_mechjeb", "mechjeb"),
+    "heat_monitoring": ("system_heat_service", "system_heat_mod"),
+    "heat_controls": ("system_heat_service", "system_heat_mod"),
+    "editor_electricity": ("dynamic_battery_storage",),
+    "damage_monitoring": ("wcs",),
+}
+
+_STOCK_FALLBACK_FEATURES = frozenset({
+    "science_telemetry",
+    "science_alarms",
+    "communications",
+    "heat_monitoring",
+    "editor_electricity",
+    "damage_monitoring",
+})
+
+_scan_cache: dict[str, dict[str, Any]] = {}
+
+
+def reset_scan_cache() -> None:
+    """Clear the process-local root-scan cache (primarily for tests)."""
+
+    _scan_cache.clear()
+
+
+def _casefold_child(parent: Path, wanted: str) -> Path | None:
+    """Resolve one child by name without exposing directory contents."""
+
+    try:
+        for child in parent.iterdir():
+            if child.name.casefold() == wanted.casefold():
+                return child
+    except (OSError, RuntimeError):
+        return None
+    return None
+
+
+def _whitelist_target(root: Path, parts: tuple[str, ...]) -> Path | None:
+    current = root
+    for part in parts:
+        current = _casefold_child(current, part)
+        if current is None:
+            return None
+    return current
+
+
+def _scan_uncached(root: Any) -> dict[str, Any]:
+    """Scan only known dependency markers and return sanitised evidence."""
+
+    if not isinstance(root, (str, os.PathLike)) or not str(root).strip():
+        return {
+            "configured": False,
+            "dependencies": {},
+            "error": False,
+        }
+    try:
+        resolved = Path(os.path.expandvars(os.fspath(root))).expanduser().resolve()
+    except (OSError, RuntimeError, TypeError):
+        return {"configured": True, "dependencies": {}, "error": True}
+    try:
+        game_data = _casefold_child(resolved, "GameData") if resolved.is_dir() else None
+        if game_data is None or not game_data.is_dir():
+            return {"configured": True, "dependencies": {}, "error": True}
+    except OSError:
+        return {"configured": True, "dependencies": {}, "error": True}
+    try:
+        if not resolved.is_dir():
+            return {"configured": True, "dependencies": {}, "error": True}
+    except OSError:
+        return {"configured": True, "dependencies": {}, "error": True}
+
+    dependencies: dict[str, dict[str, str]] = {}
+    for dependency, (parts, directory) in _SCAN_WHITELIST.items():
+        target = _whitelist_target(resolved, parts)
+        present = target is not None
+        if present and directory:
+            try:
+                present = target.is_dir()
+            except OSError:
+                present = False
+        elif present:
+            try:
+                present = target.is_file()
+            except OSError:
+                present = False
+        dependencies[dependency] = {
+            "source": "root_scan",
+            "status": "detected" if present else "missing",
+        }
+    return {
+        "configured": True,
+        "dependencies": dependencies,
+        "error": False,
+    }
+
+
+def scan_root_capabilities(root: Any) -> dict[str, Any]:
+    """Return cached, fixed-whitelist dependency evidence for ``root``.
+
+    The returned value contains no paths, hashes, filenames, or raw errors.
+    Empty/unusable roots are represented as an unconfigured/error result and
+    never trigger a broad filesystem inventory.
+    """
+
+    if not isinstance(root, (str, os.PathLike)) or not str(root).strip():
+        return _scan_uncached(root)
+    try:
+        key = os.path.normcase(str(Path(os.path.expandvars(os.fspath(root))).expanduser().resolve()))
+    except (OSError, RuntimeError, TypeError):
+        return _scan_uncached(root)
+    cached = _scan_cache.get(key)
+    if cached is None:
+        cached = _scan_uncached(root)
+        _scan_cache[key] = cached
+    return cached
+
+
+def _clean_version(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate or len(candidate) > 64:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+-]*", candidate):
+        return None
+    return candidate
+
+
+def _evidence(identifier: str, status: str, source: str, version: str | None = None) -> dict[str, str]:
+    record = {
+        "id": identifier,
+        "status": status,
+        "source": source,
+    }
+    if version:
+        record["version"] = version
+    return record
+
+
+def _runtime_evidence(telemetry: Mapping[str, Any], feature: str) -> tuple[str, str, list[dict[str, str]]] | None:
+    """Map observed telemetry to ``(status, reason, evidence)``."""
+
+    if feature == "notes" and "notes.available" in telemetry:
+        active = telemetry.get("notes.available") is True
+        status, reason = ("available", "ready") if active else ("unavailable", "provider_unavailable")
+        return status, reason, [_evidence("notes", "active" if active else "unavailable", "runtime")]
+
+    if feature == "science_telemetry":
+        backend = str(telemetry.get("sci.krpc.backend") or "")
+        if backend.casefold() == "vesselscience":
+            return "available", "ready", [_evidence("vessel_science", "active", "runtime")]
+        if backend:
+            return "fallback", "fallback_active", [_evidence("stock_science", "active", "runtime")]
+        if telemetry.get("sci.krpc.labTelemetryAvailable") is True:
+            return "available", "ready", [_evidence("vessel_science", "active", "runtime")]
+
+    if feature == "science_alarms" and "sci.alarmProviders" in telemetry:
+        providers = telemetry.get("sci.alarmProviders")
+        if isinstance(providers, Mapping):
+            evidence = []
+            for identifier in ("kac", "stock"):
+                enabled = providers.get(identifier) is True
+                evidence.append(_evidence(identifier, "active" if enabled else "unavailable", "runtime"))
+            if providers.get("kac") is True:
+                status, reason = "available", "ready"
+            elif providers.get("stock") is True:
+                status, reason = "fallback", "fallback_active"
+            else:
+                status, reason = "unavailable", "provider_unavailable"
+            return status, reason, evidence
+
+    if feature == "communications":
+        if telemetry.get("rt.available") is True:
+            return "available", "ready", [_evidence("remote_tech", "active", "runtime")]
+        if any(key in telemetry for key in ("comm.krpc.canCommunicate", "comm.krpc.signalStrength")):
+            return "fallback", "fallback_active", [_evidence("stock_commnet", "active", "runtime")]
+        if "rt.available" in telemetry:
+            return "unknown", "not_observed", [_evidence("remote_tech", "unavailable", "runtime")]
+
+    if feature == "stage_analysis" and "stage.available" in telemetry:
+        if telemetry.get("stage.available") is True:
+            return "available", "ready", [_evidence("stage_stats", "active", "runtime")]
+        # False means no usable current-vessel sample, not an absent install.
+        return "unknown", "not_observed", [_evidence("stage_stats", "unavailable", "runtime")]
+
+    if feature == "live_transfer_calculations" and "mj.transfer.available" in telemetry:
+        available = telemetry.get("mj.transfer.available") is True
+        compatible = telemetry.get("mj.transfer.compatibilityReady") is True
+        evidence = [_evidence("woobies_mechjeb", "active" if available else "unavailable", "runtime")]
+        version = _clean_version(telemetry.get("mj.transfer.detectedVersion"))
+        target = _clean_version(telemetry.get("mj.transfer.compatibilityTarget"))
+        if version:
+            evidence.append(_evidence("mechjeb", "detected", "runtime", version))
+        if target:
+            evidence.append(_evidence("compatibility_target", "detected", "runtime", target))
+        if available and compatible:
+            return "available", "ready", evidence
+        if available and not compatible:
+            evidence.append(_evidence("mechjeb", "unavailable", "runtime"))
+            return "unavailable", "provider_unavailable", evidence
+        return "unknown", "not_observed", evidence
+
+    if feature in {"heat_monitoring", "heat_controls"} and "heat.backend" in telemetry:
+        backend = str(telemetry.get("heat.backend") or "").casefold()
+        if backend == "system_heat":
+            return "available", "ready", [_evidence("system_heat", "active", "runtime")]
+        if backend == "stock":
+            status = "fallback" if feature == "heat_monitoring" else "unavailable"
+            reason = "fallback_active" if status == "fallback" else "provider_unavailable"
+            return status, reason, [_evidence("stock_thermal", "active", "runtime")]
+
+    if feature == "editor_electricity" and "editor.elec.backend" in telemetry:
+        backend = str(telemetry.get("editor.elec.backend") or "").casefold()
+        if backend == "dynamic_battery_storage":
+            version = _clean_version(telemetry.get("editor.elec.backendVersion"))
+            return "available", "ready", [_evidence("dynamic_battery_storage", "active", "runtime", version)]
+        if backend == "stock":
+            return "fallback", "fallback_active", [_evidence("stock_electricity", "active", "runtime")]
+
+    if feature == "damage_monitoring" and "damage.source" in telemetry:
+        source = str(telemetry.get("damage.source") or "").casefold()
+        if source == "vessel_damage":
+            return "available", "ready", [_evidence("vessel_damage", "active", "runtime")]
+        if source == "stock_krpc":
+            return "fallback", "fallback_active", [_evidence("stock_damage", "active", "runtime")]
+
+    return None
+
+
+def _scan_evidence(scan: Mapping[str, Any], feature: str) -> list[dict[str, str]]:
+    dependencies = scan.get("dependencies") if isinstance(scan, Mapping) else None
+    if not isinstance(dependencies, Mapping):
+        return []
+    evidence = []
+    for dependency in _FEATURE_DEPENDENCIES.get(feature, ()):
+        item = dependencies.get(dependency)
+        if not isinstance(item, Mapping):
+            continue
+        status = item.get("status") if item.get("status") in {"detected", "missing", "unknown"} else "unknown"
+        evidence.append(_evidence(dependency, status, "root_scan"))
+    return evidence
+
+
+def build_dashboard_capabilities(
+    telemetry: Mapping[str, Any] | None = None,
+    scan: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a complete, stable capability snapshot from safe observations."""
+
+    telemetry = telemetry if isinstance(telemetry, Mapping) else {}
+    scan = scan if isinstance(scan, Mapping) else {"configured": False, "dependencies": {}}
+    configured = scan.get("configured") is True
+    scan_error = scan.get("error") is True
+    rows: dict[str, dict[str, Any]] = {}
+    for feature in FEATURE_IDS:
+        runtime = _runtime_evidence(telemetry, feature)
+        scan_evidence = _scan_evidence(scan, feature)
+        if runtime is not None:
+            status, reason, evidence = runtime
+            # Runtime evidence outranks scan evidence, but dependency context is
+            # retained as expandable evidence.
+            evidence = evidence + scan_evidence
+            if status == "unknown" and any(item["status"] == "missing" for item in scan_evidence):
+                if feature in _STOCK_FALLBACK_FEATURES:
+                    status, reason = "fallback", "fallback_active"
+                else:
+                    status, reason = "unavailable", "dependency_missing"
+        elif scan_evidence and configured and not scan_error:
+            statuses = {item["status"] for item in scan_evidence}
+            if "missing" in statuses:
+                if feature in _STOCK_FALLBACK_FEATURES:
+                    status, reason = "fallback", "fallback_active"
+                else:
+                    status, reason = "unavailable", "dependency_missing"
+            elif statuses == {"detected"}:
+                status, reason = "unknown", "not_observed"
+            else:
+                status, reason = "unknown", "probe_error"
+            evidence = scan_evidence
+        else:
+            status = "unknown"
+            reason = "probe_error" if scan_error else "scan_unconfigured" if not configured else "not_observed"
+            evidence = scan_evidence
+        rows[feature] = {
+            "status": status,
+            "reason": reason,
+            "evidence": evidence,
+        }
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "features": rows,
+    }
+
+
+# Concise aliases make parent integration and tests self-documenting without
+# adding another contract surface.
+build_capabilities = build_dashboard_capabilities
+scan_root = scan_root_capabilities

--- a/frontend/browser-tests/compatibility.e2e.ts
+++ b/frontend/browser-tests/compatibility.e2e.ts
@@ -106,6 +106,30 @@ test("Settings remains the last usable Tool without horizontal overflow across t
   }
 });
 
+test("Settings applies and persists every dashboard color theme", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const drawer = page.getByRole("dialog", { name: "Mission Control Settings" });
+
+  for (const theme of [
+    { id: "daylight-console", label: "Daylight Console", scheme: "light" },
+    { id: "warm-crt", label: "Warm CRT", scheme: "dark" },
+    { id: "green-phosphor", label: "Green Phosphor", scheme: "dark" },
+    { id: "mission-control-dark", label: "Mission Control Dark", scheme: "dark" },
+  ]) {
+    const option = drawer.getByRole("radio", { name: new RegExp(theme.label) });
+    await option.click();
+    await expect(option).toHaveAttribute("aria-checked", "true");
+    expect(await page.locator("html").getAttribute("data-theme")).toBe(theme.id);
+    expect(await page.locator("html").evaluate((root) => getComputedStyle(root).colorScheme)).toBe(theme.scheme);
+    expect(await page.evaluate(() => JSON.parse(localStorage.getItem("wmc-theme-v1") ?? "null"))).toBe(theme.id);
+  }
+
+  await page.reload();
+  expect(await page.locator("html").getAttribute("data-theme")).toBe("mission-control-dark");
+});
+
 test("Settings provides 44px targets on a coarse 390px mobile viewport", async ({ browser, baseURL }) => {
   const context = await browser.newContext({ baseURL, hasTouch: true, viewport: { width: 390, height: 844 } });
   const page = await context.newPage();
@@ -119,6 +143,7 @@ test("Settings provides 44px targets on a coarse 390px mobile viewport", async (
     const targets = await drawer.evaluate((element) => {
       const controls = [
         ...element.querySelectorAll<HTMLElement>(".settings-section-nav button"),
+        ...element.querySelectorAll<HTMLElement>(".settings-theme-option"),
         element.querySelector<HTMLElement>("header > button")!,
       ];
       return {

--- a/frontend/browser-tests/compatibility.e2e.ts
+++ b/frontend/browser-tests/compatibility.e2e.ts
@@ -442,12 +442,15 @@ test("Delta-v density keeps the route primary on fine and coarse pointers", asyn
       routeHeaderHeight: bounds(".delta-v-route > header").height,
       routeListHeight: bounds(".delta-v-route-list").height,
       summaryHeight: bounds(".delta-v-summary").height,
+      transferModeInMissionSummary: Boolean(drawer.querySelector(".delta-v-summary .delta-v-transfer-mode"))
+        && !drawer.querySelector(".delta-v-controls .delta-v-transfer-mode"),
     };
   });
 
   expect(desktop.headerHeight).toBeLessThanOrEqual(65);
   expect(desktop.configurationHeight).toBeLessThanOrEqual(115);
-  expect(desktop.summaryHeight).toBeLessThanOrEqual(115);
+  expect(desktop.summaryHeight).toBeLessThanOrEqual(122);
+  expect(desktop.transferModeInMissionSummary).toBe(true);
   expect(desktop.routeHeaderHeight).toBeLessThanOrEqual(36);
   expect(desktop.routeListHeight).toBeGreaterThanOrEqual(500);
   expect(desktop.footerHeight).toBeLessThanOrEqual(27);
@@ -473,8 +476,8 @@ test("Delta-v density keeps the route primary on fine and coarse pointers", asyn
   await page.getByRole("radio", { name: "Parking orbit" }).check({ force: true });
   await expect(page.getByRole("spinbutton", { name: "Planned altitude" })).toBeVisible();
   await expect(page.getByText(/ATMO Ends at 50.0/)).toBeVisible();
-  await expect(page.getByText("Simple: ideal dates")).toBeVisible();
-  await expect(page.getByText("Advanced: per-leg porkchops")).toHaveCount(0);
+  await expect(page.getByText("Ideal dates")).toBeVisible();
+  await expect(page.getByText("Per-leg porkchops")).toHaveCount(0);
   const portraitMargin = await page.getByRole("dialog", { name: "Delta-v planner" }).evaluate((drawer) => {
     const card = drawer.querySelector<HTMLElement>(".delta-v-margin-card")!.getBoundingClientRect();
     const controls = drawer.querySelector<HTMLElement>(".delta-v-margin-controls")!.getBoundingClientRect();

--- a/frontend/browser-tests/compatibility.e2e.ts
+++ b/frontend/browser-tests/compatibility.e2e.ts
@@ -45,6 +45,111 @@ test("developer controls stay out of screenshots until the corner is engaged", a
   await expect(tab).toHaveCSS("opacity", "1");
 });
 
+test("Settings remains the last usable Tool without horizontal overflow across the acceptance viewports", async ({ page }) => {
+  for (const viewport of [
+    { width: 1920, height: 889 },
+    { width: 1280, height: 800 },
+    { width: 1080, height: 1920 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto("/");
+
+    const tools = page.getByRole("group", { name: "Tools" });
+    const opener = page.getByRole("button", { name: "Settings", exact: true });
+    await expect(opener).toBeVisible();
+    expect(await tools.evaluate((group) => group.lastElementChild?.getAttribute("aria-label"))).toBe("Settings");
+
+    await opener.click();
+    const drawer = page.getByRole("dialog", { name: "Mission Control Settings" });
+    const navigation = drawer.getByRole("navigation", { name: "Settings sections" });
+    await expect(drawer).toBeVisible();
+    await expect(navigation.getByRole("button", { name: "Preferences" })).toHaveAttribute("aria-current", "page");
+
+    for (const [section, heading] of [
+      ["Features & Mods", "Features & Mods"],
+      ["Help", "Help"],
+      ["About", "About"],
+      ["Preferences", "Preferences"],
+    ]) {
+      await navigation.getByRole("button", { name: section, exact: true }).click();
+      await expect(drawer.getByRole("heading", { name: heading, exact: true })).toBeVisible();
+    }
+
+    const layout = await drawer.evaluate((element) => {
+      const body = element.querySelector<HTMLElement>(".settings-drawer-body")!;
+      const navigationElement = element.querySelector<HTMLElement>(".settings-section-nav")!;
+      const section = element.querySelector<HTMLElement>(".settings-section")!;
+      return {
+        bodyClientWidth: body.clientWidth,
+        bodyOverflowX: getComputedStyle(body).overflowX,
+        bodyScrollWidth: body.scrollWidth,
+        documentClientWidth: document.documentElement.clientWidth,
+        documentScrollWidth: document.documentElement.scrollWidth,
+        drawerClientWidth: element.clientWidth,
+        drawerScrollWidth: element.scrollWidth,
+        navigationOverflowX: getComputedStyle(navigationElement).overflowX,
+        sectionClientWidth: section.clientWidth,
+        sectionScrollWidth: section.scrollWidth,
+      };
+    });
+    expect(layout.documentScrollWidth).toBeLessThanOrEqual(layout.documentClientWidth);
+    expect(layout.drawerScrollWidth).toBeLessThanOrEqual(layout.drawerClientWidth + 1);
+    expect(layout.bodyScrollWidth).toBeLessThanOrEqual(layout.bodyClientWidth + 1);
+    expect(layout.bodyOverflowX).toBe("hidden");
+    expect(layout.sectionScrollWidth).toBeLessThanOrEqual(layout.sectionClientWidth + 1);
+    if (viewport.width === 390) expect(layout.navigationOverflowX).toBe("auto");
+
+    await page.keyboard.press("Escape");
+    await expect(drawer).toBeHidden();
+    await expect(opener).toBeFocused();
+  }
+});
+
+test("Settings provides 44px targets on a coarse 390px mobile viewport", async ({ browser, baseURL }) => {
+  const context = await browser.newContext({ baseURL, hasTouch: true, viewport: { width: 390, height: 844 } });
+  const page = await context.newPage();
+  try {
+    await page.goto("/");
+    const opener = page.getByRole("button", { name: "Settings", exact: true });
+    await opener.click();
+    const drawer = page.getByRole("dialog", { name: "Mission Control Settings" });
+    await expect(drawer).toBeVisible();
+
+    const targets = await drawer.evaluate((element) => {
+      const controls = [
+        ...element.querySelectorAll<HTMLElement>(".settings-section-nav button"),
+        element.querySelector<HTMLElement>("header > button")!,
+      ];
+      return {
+        coarsePointer: matchMedia("(pointer: coarse)").matches,
+        documentClientWidth: document.documentElement.clientWidth,
+        documentScrollWidth: document.documentElement.scrollWidth,
+        drawerClientWidth: element.clientWidth,
+        drawerScrollWidth: element.scrollWidth,
+        openerHeight: document.querySelector<HTMLElement>(".settings-rail-tab")?.getBoundingClientRect().height,
+        openerWidth: document.querySelector<HTMLElement>(".settings-rail-tab")?.getBoundingClientRect().width,
+        controls: controls.map((control) => {
+          const bounds = control.getBoundingClientRect();
+          return { height: bounds.height, width: bounds.width };
+        }),
+      };
+    });
+    expect(targets.coarsePointer).toBe(true);
+    expect(targets.documentScrollWidth).toBeLessThanOrEqual(targets.documentClientWidth);
+    expect(targets.drawerScrollWidth).toBeLessThanOrEqual(targets.drawerClientWidth + 1);
+    expect(targets.openerWidth).toBeGreaterThanOrEqual(44);
+    expect(targets.openerHeight).toBeGreaterThanOrEqual(44);
+    expect(targets.controls.every((control) => control.width >= 44 && control.height >= 44)).toBe(true);
+
+    await page.keyboard.press("Escape");
+    await expect(drawer).toBeHidden();
+    await expect(opener).toBeFocused();
+  } finally {
+    await context.close();
+  }
+});
+
 test("both mission planners remain usable at a normal desktop viewport", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.goto("/");

--- a/frontend/browser-tests/compatibility.e2e.ts
+++ b/frontend/browser-tests/compatibility.e2e.ts
@@ -74,6 +74,12 @@ test("Settings remains the last usable Tool without horizontal overflow across t
     ]) {
       await navigation.getByRole("button", { name: section, exact: true }).click();
       await expect(drawer.getByRole("heading", { name: heading, exact: true })).toBeVisible();
+      if (section === "Features & Mods") {
+        await expect(drawer.getByText("AVAILABLE", { exact: true })).toHaveCount(10);
+        await expect(drawer.getByText("AVAILABLE · STOCK", { exact: true })).toHaveCount(0);
+        await expect(drawer.getByText("UNAVAILABLE", { exact: true })).toHaveCount(0);
+        await expect(drawer.getByText("DETECTION UNAVAILABLE", { exact: true })).toHaveCount(0);
+      }
     }
 
     const layout = await drawer.evaluate((element) => {

--- a/frontend/browser-tests/compatibility.e2e.ts
+++ b/frontend/browser-tests/compatibility.e2e.ts
@@ -303,9 +303,20 @@ test("saved Delta-v plan feedback reserves visible header space", async ({ page 
     const header = element.querySelector<HTMLElement>(":scope > header")!.getBoundingClientRect();
     const body = element.querySelector<HTMLElement>(":scope > .delta-v-drawer-body")!.getBoundingClientRect();
     const message = element.querySelector<HTMLElement>(".delta-v-save-feedback")!.getBoundingClientRect();
+    const nameHeading = element.querySelector<HTMLElement>(".delta-v-save-heading > span")!.getBoundingClientRect();
+    const nameInput = element.querySelector<HTMLElement>(".delta-v-save-bar input")!.getBoundingClientRect();
+    const saveActions = Array.from(element.querySelectorAll<HTMLElement>(".delta-v-save-actions button")).map((button) => button.getBoundingClientRect());
+    const planTools = element.querySelector<HTMLElement>(".delta-v-header-actions")!.getBoundingClientRect();
     return {
       containedByHeader: message.top >= header.top && message.bottom <= header.bottom + 1,
       clearOfBody: message.bottom <= body.top + 1,
+      headerHeight: header.height,
+      nameHeadingHeight: nameHeading.height,
+      nameHeadingWidth: nameHeading.width,
+      nameInputWidth: nameInput.width,
+      planToolsSeparated: saveActions.at(-1)!.right < planTools.left,
+      saveControlsSeparated: nameInput.right <= saveActions[0].left
+        && saveActions.every((button, index) => index === 0 || saveActions[index - 1].right <= button.left),
       visibleHeight: message.height,
       drawerClientWidth: element.clientWidth,
       drawerScrollWidth: element.scrollWidth,
@@ -313,8 +324,62 @@ test("saved Delta-v plan feedback reserves visible header space", async ({ page 
   });
   expect(layout.containedByHeader).toBe(true);
   expect(layout.clearOfBody).toBe(true);
-  expect(layout.visibleHeight).toBeGreaterThanOrEqual(18);
+  expect(layout.headerHeight).toBeLessThanOrEqual(65);
+  expect(layout.nameHeadingHeight).toBeLessThanOrEqual(16);
+  expect(layout.nameHeadingWidth).toBeGreaterThanOrEqual(65);
+  expect(layout.nameInputWidth).toBeGreaterThanOrEqual(240);
+  expect(layout.planToolsSeparated).toBe(true);
+  expect(layout.saveControlsSeparated).toBe(true);
+  expect(layout.visibleHeight).toBeGreaterThanOrEqual(10);
   expect(layout.drawerScrollWidth).toBeLessThanOrEqual(layout.drawerClientWidth + 1);
+  await expect(drawer.getByRole("heading", { name: "Delta-V Mission Planner" })).toBeVisible();
+  await expect(drawer.getByText("MISSION PLANNING · DELTA-V", { exact: true })).toHaveCount(0);
+});
+
+test("saved Delta-v plans inherit the active dashboard theme", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Delta-v planner" }).click();
+  const planner = page.getByRole("dialog", { name: "Delta-v planner" });
+  const profile = planner.getByRole("button", { name: /SYSTEM PROFILE & MISSION SETUP/ });
+  if (await profile.getAttribute("aria-expanded") === "false") await profile.click();
+  if (await planner.getByRole("combobox", { name: "Start" }).count()) {
+    await planner.getByRole("button", { name: /Add next stop/ }).click();
+  }
+  await planner.getByRole("combobox", { name: "Next stop" }).selectOption("Duna");
+  await planner.getByRole("button", { name: /Add next stop/ }).click();
+  await planner.getByRole("textbox", { name: "Delta-v plan name" }).fill("Theme inheritance check");
+  await planner.getByRole("button", { name: "Save plan", exact: true }).click();
+  await planner.getByRole("button", { name: "Load saved plans" }).click();
+
+  const library = planner.getByRole("dialog", { name: "Saved Delta-V plans" });
+  const readSurfaces = () => library.evaluate((element) => ({
+    card: getComputedStyle(element.querySelector<HTMLElement>(".delta-v-plan-library-list article")!).backgroundColor,
+    header: getComputedStyle(element.querySelector<HTMLElement>(":scope > header")!).backgroundImage,
+    modal: getComputedStyle(element).backgroundImage,
+  }));
+  const darkSurfaces = await readSurfaces();
+  await library.getByRole("button", { name: "Close saved plans" }).click();
+  await planner.getByRole("button", { name: "Close delta-v planner" }).click();
+
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const settings = page.getByRole("dialog", { name: "Mission Control Settings" });
+  await settings.getByRole("radio", { name: /Daylight Console/ }).click();
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Delta-v planner" }).click();
+  const daylightPlanner = page.getByRole("dialog", { name: "Delta-v planner" });
+  await daylightPlanner.getByRole("button", { name: "Load saved plans" }).click();
+  const daylightLibrary = daylightPlanner.getByRole("dialog", { name: "Saved Delta-V plans" });
+  const daylightSurfaces = await daylightLibrary.evaluate((element) => ({
+    card: getComputedStyle(element.querySelector<HTMLElement>(".delta-v-plan-library-list article")!).backgroundColor,
+    header: getComputedStyle(element.querySelector<HTMLElement>(":scope > header")!).backgroundImage,
+    modal: getComputedStyle(element).backgroundImage,
+  }));
+
+  expect(await page.locator("html").getAttribute("data-theme")).toBe("daylight-console");
+  expect(daylightSurfaces.modal).not.toBe(darkSurfaces.modal);
+  expect(daylightSurfaces.header).not.toBe(darkSurfaces.header);
+  expect(daylightSurfaces.card).not.toBe(darkSurfaces.card);
 });
 
 test("Delta-v density keeps the route primary on fine and coarse pointers", async ({ page, browser, baseURL }) => {
@@ -380,7 +445,7 @@ test("Delta-v density keeps the route primary on fine and coarse pointers", asyn
     };
   });
 
-  expect(desktop.headerHeight).toBeLessThanOrEqual(50);
+  expect(desktop.headerHeight).toBeLessThanOrEqual(65);
   expect(desktop.configurationHeight).toBeLessThanOrEqual(115);
   expect(desktop.summaryHeight).toBeLessThanOrEqual(115);
   expect(desktop.routeHeaderHeight).toBeLessThanOrEqual(36);

--- a/frontend/browser-tests/compatibility.e2e.ts
+++ b/frontend/browser-tests/compatibility.e2e.ts
@@ -130,6 +130,80 @@ test("Settings applies and persists every dashboard color theme", async ({ page 
   expect(await page.locator("html").getAttribute("data-theme")).toBe("mission-control-dark");
 });
 
+test("Daylight Flight chrome keeps inactive hardware quiet and exposes light Plan state roles", async ({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await page.goto("/");
+
+  const litIndicator = page.locator(".annunciator-indicator.new").first();
+  const darkLitFace = await litIndicator.evaluate((element) => getComputedStyle(element).backgroundImage);
+
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const drawer = page.getByRole("dialog", { name: "Mission Control Settings" });
+  await drawer.getByRole("radio", { name: /Daylight Console/ }).click();
+  await page.keyboard.press("Escape");
+
+  const inactiveIndicator = page.locator(".annunciator-indicator:not(.new):not(.acknowledged)").first();
+  const flightChrome = await inactiveIndicator.evaluate((element) => {
+    const root = getComputedStyle(document.documentElement);
+    const inactive = getComputedStyle(element);
+    const identity = getComputedStyle(document.querySelector<HTMLElement>(".flight-context-identity strong")!);
+    const clock = getComputedStyle(document.querySelector<HTMLElement>(".clockcell .big")!);
+    return {
+      clockShadow: clock.textShadow,
+      identityShadow: identity.textShadow,
+      inactiveBackground: inactive.backgroundImage,
+      inactiveBorder: inactive.borderColor,
+      inactiveText: inactive.color,
+      planGround: root.getPropertyValue("--plan-panel-ground").trim(),
+      planStep: root.getPropertyValue("--plan-step-face").trim(),
+      stateCyan: root.getPropertyValue("--state-wash-cyan").trim(),
+    };
+  });
+  expect(flightChrome.clockShadow).toBe("none");
+  expect(flightChrome.identityShadow).toBe("none");
+  expect(flightChrome.inactiveBackground).toContain("rgb(233, 238, 243)");
+  expect(flightChrome.inactiveBorder).toBe("rgb(167, 179, 192)");
+  expect(flightChrome.inactiveText).toBe("rgb(102, 116, 130)");
+  expect(flightChrome.planGround).toBe("#ffffff");
+  expect(flightChrome.planStep).toContain("#f1f5f9");
+  expect(flightChrome.stateCyan).toContain("rgba(255,255,255,.9)");
+  expect(await litIndicator.evaluate((element) => getComputedStyle(element).backgroundImage)).toBe(darkLitFace);
+
+  await page.getByRole("button", { name: "Delta-v planner" }).click();
+  const planner = page.getByRole("dialog", { name: "Delta-v planner" });
+  const profile = planner.getByRole("button", { name: /SYSTEM PROFILE & MISSION SETUP/ });
+  if (await profile.getAttribute("aria-expanded") === "false") await profile.click();
+  if (await planner.getByRole("combobox", { name: "Start" }).count()) {
+    await planner.getByRole("button", { name: /Add next stop/ }).click();
+  }
+  await planner.getByRole("combobox", { name: "Next stop" }).selectOption("Duna");
+  await planner.getByRole("button", { name: /Add next stop/ }).click();
+  await planner.getByRole("textbox", { name: "Delta-v plan name" }).fill("Daylight state review");
+  await planner.getByRole("button", { name: "Save plan", exact: true }).click();
+  await planner.getByRole("button", { name: "Load saved plans" }).click();
+  const savedPlans = page.getByRole("dialog", { name: "Saved Delta-v plans" });
+  await savedPlans.getByRole("button", { name: "Pin to active vessel" }).click();
+  await savedPlans.getByRole("button", { name: "Close saved plans" }).click();
+  await planner.getByRole("button", { name: "Close delta-v planner" }).click();
+  await page.getByRole("tab", { name: "PLAN", exact: true }).click();
+  await expect(page.locator('.flight-workspace-selector[data-active-view="plan"]')).toBeVisible();
+
+  const comparison = page.locator(".delta-v-pinned-comparison");
+  const launchSuggestion = page.locator(".delta-v-progress-suggestion");
+  await expect(comparison).toBeVisible();
+  await expect(launchSuggestion).toBeVisible();
+  const planState = await comparison.evaluate((element) => ({
+    background: getComputedStyle(element).backgroundImage,
+    body: getComputedStyle(element.querySelector("p")!).color,
+    shortfall: getComputedStyle(element.querySelector("header strong")!).color,
+    suggestion: getComputedStyle(document.querySelector<HTMLElement>(".delta-v-progress-suggestion span")!).color,
+  }));
+  expect(planState.background).toContain("rgba(255, 255, 255, 0.9)");
+  expect(planState.body).toBe("rgb(43, 56, 70)");
+  expect(planState.shortfall).toBe("rgb(143, 41, 34)");
+  expect(planState.suggestion).toBe("rgb(78, 92, 108)");
+});
+
 test("Settings provides 44px targets on a coarse 390px mobile viewport", async ({ browser, baseURL }) => {
   const context = await browser.newContext({ baseURL, hasTouch: true, viewport: { width: 390, height: 844 } });
   const page = await context.newPage();

--- a/frontend/scripts/check-css-contract.mjs
+++ b/frontend/scripts/check-css-contract.mjs
@@ -103,6 +103,12 @@ const contrastContracts = [
   { foreground: "--surface-amber-face-text", background: "--surface-amber-face-top", minimum: 4.5 },
 ];
 
+const alternateThemeIds = ["daylight-console", "warm-crt", "green-phosphor"];
+const requiredThemeColorTokens = new Set([
+  "--page-background",
+  ...contrastContracts.flatMap(({ foreground, background }) => [foreground, background]),
+]);
+
 const minimumPixelFontSize = 8;
 
 export function maskCommentsAndStrings(source) {
@@ -203,6 +209,13 @@ export function contrastRatio(foreground, background) {
   return (Math.max(first, second) + 0.05) / (Math.min(first, second) + 0.05);
 }
 
+function colorDefinitions(block) {
+  return new Map(
+    [...block.matchAll(/(--[a-z0-9-]+)\s*:\s*(#[0-9a-f]{3}|#[0-9a-f]{6})\s*;/gi)]
+      .map((match) => [match[1], expandHex(match[2])]),
+  );
+}
+
 export function checkCssContract(sources) {
   const failures = [];
   const declarations = new Map();
@@ -246,6 +259,13 @@ export function checkCssContract(sources) {
       }]),
   );
   const rootColors = new Map([...rootColorDefinitions].map(([name, definition]) => [name, definition.literal]));
+  const rootDeclarationLines = new Set();
+  for (const blockMatch of rootSource?.text.matchAll(/:root(?:\[data-theme=["'][^"']+["']\])?\s*\{([\s\S]*?)\}/g) ?? []) {
+    const blockStart = (blockMatch.index ?? 0) + blockMatch[0].indexOf(blockMatch[1]);
+    for (const declaration of blockMatch[1].matchAll(/--[a-z0-9-]+\s*:/gi)) {
+      rootDeclarationLines.add(lineNumberAt(rootSource.text, blockStart + (declaration.index ?? 0)));
+    }
+  }
 
   for (const token of opaqueSurfaceBackgroundTokens) {
     if (!rootColors.has(token)) {
@@ -265,6 +285,7 @@ export function checkCssContract(sources) {
       lines.forEach((line, index) => {
         const definition = rootColorDefinitions.get(token);
         if (source.file === rootSource?.file && index + 1 === definition?.line) return;
+        if (source.file === rootSource?.file && rootDeclarationLines.has(index + 1)) return;
         const literals = [...line.matchAll(/#[0-9a-f]{3}(?:[0-9a-f]{3})?\b/gi)].map((match) => expandHex(match[0]));
         if (literals.includes(literal)) {
           failures.push(`${source.file}:${index + 1} uses ${literal} directly; use var(${token}).`);
@@ -280,6 +301,29 @@ export function checkCssContract(sources) {
     const ratio = contrastRatio(foreground, background);
     if (ratio + Number.EPSILON < contract.minimum) {
       failures.push(`${contract.foreground} contrast against ${contract.background} is ${ratio.toFixed(2)}:1; expected at least ${contract.minimum.toFixed(1)}:1.`);
+    }
+  }
+
+
+  for (const themeId of alternateThemeIds) {
+    const escapedThemeId = themeId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const themeBlock = rootSource?.text.match(new RegExp(`:root\\[data-theme=["']${escapedThemeId}["']\\]\\s*\\{([\\s\\S]*?)\\}`))?.[1] ?? "";
+    if (!themeBlock) {
+      failures.push(`Theme ${themeId} must define a :root[data-theme="${themeId}"] block.`);
+      continue;
+    }
+    const themeColors = colorDefinitions(themeBlock);
+    for (const token of requiredThemeColorTokens) {
+      if (!themeColors.has(token)) failures.push(`Theme ${themeId} must override ${token} with an opaque hex color.`);
+    }
+    for (const contract of contrastContracts) {
+      const foreground = themeColors.get(contract.foreground);
+      const background = themeColors.get(contract.background);
+      if (!foreground || !background) continue;
+      const ratio = contrastRatio(foreground, background);
+      if (ratio + Number.EPSILON < contract.minimum) {
+        failures.push(`Theme ${themeId}: ${contract.foreground} contrast against ${contract.background} is ${ratio.toFixed(2)}:1; expected at least ${contract.minimum.toFixed(1)}:1.`);
+      }
     }
   }
 

--- a/frontend/scripts/check-css-contract.mjs
+++ b/frontend/scripts/check-css-contract.mjs
@@ -106,7 +106,32 @@ const contrastContracts = [
 const alternateThemeIds = ["daylight-console", "warm-crt", "green-phosphor"];
 const requiredThemeColorTokens = new Set([
   "--page-background",
+  "--state-amber-text",
+  "--state-body-muted",
+  "--state-body-text",
+  "--state-red-text",
   ...contrastContracts.flatMap(({ foreground, background }) => [foreground, background]),
+]);
+const requiredThemeCompositeTokens = new Set([
+  "--flight-screw-shadow",
+  "--flight-status-border-top",
+  "--flight-label-shadow",
+  "--flight-selector-face",
+  "--flight-rebalance-face",
+  "--flight-context-face",
+  "--flight-unlit-border",
+  "--flight-unlit-text",
+  "--flight-unlit-face",
+  "--stage-current-face",
+  "--state-wash-amber",
+  "--state-wash-cyan",
+  "--state-wash-green",
+  "--state-wash-red",
+  "--state-wash-depth",
+  "--plan-panel-ground",
+  "--plan-step-face",
+  "--plan-route-wash",
+  "--plan-control-face",
 ]);
 
 const minimumPixelFontSize = 8;
@@ -315,6 +340,11 @@ export function checkCssContract(sources) {
     const themeColors = colorDefinitions(themeBlock);
     for (const token of requiredThemeColorTokens) {
       if (!themeColors.has(token)) failures.push(`Theme ${themeId} must override ${token} with an opaque hex color.`);
+    }
+    for (const token of requiredThemeCompositeTokens) {
+      if (!new RegExp(`${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*:`).test(themeBlock)) {
+        failures.push(`Theme ${themeId} must override composite token ${token}.`);
+      }
     }
     for (const contract of contrastContracts) {
       const foreground = themeColors.get(contract.foreground);

--- a/frontend/scripts/check-css-contract.test.mjs
+++ b/frontend/scripts/check-css-contract.test.mjs
@@ -74,6 +74,16 @@ describe("CSS contract checker", () => {
     expect(checkCssContract(productionSources).failures).toEqual([]);
   });
 
+  it("checks every alternate theme instead of inheriting an unreviewed default token", () => {
+    const mutated = productionSources.map((source) => source.file === "src/styles.css"
+      ? { ...source, text: source.text.replace(/(:root\[data-theme="daylight-console"\][\s\S]*?)--text-primary:\s*#[0-9a-f]+;/, "$1") }
+      : source);
+
+    expect(checkCssContract(mutated).failures).toContain(
+      "Theme daylight-console must override --text-primary with an opaque hex color.",
+    );
+  });
+
   it("rejects a migrated literal reintroduced through a local alias", () => {
     const mutated = productionSources.map((source) => source.file === "src/resonantOrbit/resonantOrbit.css"
       ? { ...source, text: `${source.text}\n.regression { --local-border: #315166; border-color: var(--local-border); }` }

--- a/frontend/scripts/check-css-contract.test.mjs
+++ b/frontend/scripts/check-css-contract.test.mjs
@@ -84,6 +84,16 @@ describe("CSS contract checker", () => {
     );
   });
 
+  it("requires theme-specific Flight and Plan composite roles", () => {
+    const mutated = productionSources.map((source) => source.file === "src/styles.css"
+      ? { ...source, text: source.text.replace(/(:root\[data-theme="daylight-console"\][\s\S]*?)--flight-unlit-face:\s*[^;]+;/, "$1") }
+      : source);
+
+    expect(checkCssContract(mutated).failures).toContain(
+      "Theme daylight-console must override composite token --flight-unlit-face.",
+    );
+  });
+
   it("rejects a migrated literal reintroduced through a local alias", () => {
     const mutated = productionSources.map((source) => source.file === "src/resonantOrbit/resonantOrbit.css"
       ? { ...source, text: `${source.text}\n.regression { --local-border: #315166; border-color: var(--local-border); }` }

--- a/frontend/src/App.production.test.tsx
+++ b/frontend/src/App.production.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App.production";
 import { liveTelemetryStore } from "./telemetry/store";
@@ -21,9 +21,16 @@ describe("Production dashboard entry", () => {
 
     expect(connect).toHaveBeenCalledWith("ws://127.0.0.1:8090");
     expect(screen.getByRole("button", { name: "Notes" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Settings" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "DEV" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull();
     expect(screen.getByText("Woobie's Mission Control · React dashboard · v0.7.1 · Production")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    expect(screen.getByRole("dialog", { name: "Mission Control Settings" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "About" }));
+    expect(screen.getByText("Production", { exact: true })).toBeTruthy();
+    expect(within(screen.getByRole("dialog", { name: "Mission Control Settings" })).getByText("ws://127.0.0.1:8090", { exact: true })).toBeTruthy();
 
     view.unmount();
     expect(disconnect).toHaveBeenCalledOnce();

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -156,6 +156,8 @@ describe("Dashboard lifecycle", () => {
     const drawer = screen.getByRole("dialog", { name: "Mission Control Settings" });
     expect(settingsButton.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByRole("button", { name: "Preferences" }).getAttribute("aria-current")).toBe("page");
+    expect((screen.getByRole("button", { name: "KAC" }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole("button", { name: "STOCK" }) as HTMLButtonElement).disabled).toBe(false);
     fireEvent.click(screen.getByRole("button", { name: "EARTH TIME" }));
     expect(localStorage.getItem("wmc-time-system-v1")).toBe("earth");
     fireEvent.click(screen.getByRole("radio", { name: /Daylight Console/ }));
@@ -164,7 +166,10 @@ describe("Dashboard lifecycle", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Features & Mods" }));
     expect(drawer.querySelectorAll(".settings-feature-toggle")).toHaveLength(10);
-    expect(screen.getAllByText("AVAILABLE").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("AVAILABLE", { exact: true })).toHaveLength(10);
+    expect(screen.queryByText("AVAILABLE · STOCK", { exact: true })).toBeNull();
+    expect(screen.queryByText("UNAVAILABLE", { exact: true })).toBeNull();
+    expect(screen.queryByText("DETECTION UNAVAILABLE", { exact: true })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "About" }));
     expect(screen.getByText("Daylight Console", { exact: true })).toBeTruthy();
     expect(screen.getByText("Development", { exact: true })).toBeTruthy();

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -141,6 +141,60 @@ describe("Dashboard lifecycle", () => {
     expect(screen.getByRole("button", { name: "Time system: Earth" })).toBeTruthy();
   });
 
+  it("opens one global Settings drawer, applies preferences, and restores its opener", () => {
+    const view = render(<App />);
+    const settingsButton = screen.getByRole("button", { name: "Settings" });
+    const tools = screen.getByRole("group", { name: "Tools" });
+    expect(tools.lastElementChild).toBe(settingsButton);
+    expect(settingsButton.getAttribute("aria-controls")).toBe("settings-drawer");
+    expect(settingsButton.getAttribute("aria-expanded")).toBe("false");
+
+    settingsButton.focus();
+    fireEvent.click(settingsButton);
+    const drawer = screen.getByRole("dialog", { name: "Mission Control Settings" });
+    expect(settingsButton.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("button", { name: "Preferences" }).getAttribute("aria-current")).toBe("page");
+    fireEvent.click(screen.getByRole("button", { name: "EARTH TIME" }));
+    expect(localStorage.getItem("wmc-time-system-v1")).toBe("earth");
+
+    fireEvent.click(screen.getByRole("button", { name: "Features & Mods" }));
+    expect(drawer.querySelectorAll(".settings-feature-toggle")).toHaveLength(10);
+    expect(screen.getAllByText("AVAILABLE").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: "About" }));
+    expect(screen.getByText("Mission Control Dark (read-only)", { exact: true })).toBeTruthy();
+    expect(screen.getByText("Development", { exact: true })).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Mission Control Settings" })).toBeNull();
+    expect(document.activeElement).toBe(settingsButton);
+
+    const scienceSettings = screen.getByRole("button", { name: "Science alarm settings" });
+    scienceSettings.focus();
+    fireEvent.click(scienceSettings);
+    expect(screen.getByRole("heading", { name: "Science alarm defaults" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Preferences" }).getAttribute("aria-current")).toBe("page");
+    expect(screen.queryByRole("button", { name: "KERBIN TIME" })).toBeNull();
+    fireEvent.mouseDown(view.container.querySelector(".settings-drawer-backdrop")!);
+    expect(screen.queryByRole("dialog", { name: "Mission Control Settings" })).toBeNull();
+    expect(document.activeElement).toBe(scienceSettings);
+  });
+
+  it("keeps Settings mutually exclusive with other global utility drawers", () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    expect(screen.getByRole("dialog", { name: "Mission Control Settings" })).toBeTruthy();
+
+    fireEvent.click(document.querySelector<HTMLButtonElement>('button[aria-label="Datalink"]')!);
+    expect(screen.queryByRole("dialog", { name: "Mission Control Settings" })).toBeNull();
+    expect(screen.getByRole("dialog", { name: "Datalink controls" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Close Datalink drawer" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    fireEvent.click(document.querySelector<HTMLButtonElement>('button[aria-label="Notes"]')!);
+    expect(screen.queryByRole("dialog", { name: "Mission Control Settings" })).toBeNull();
+    expect(screen.getByRole("dialog", { name: "Notes continuity preview" })).toBeTruthy();
+  });
+
   it("renders the complete flight dashboard with in-place Flight panel collapse", () => {
     const firstView = render(<App />);
     expect(screen.getByText("Woobie's Mission Control · React dashboard · v0.7.1 · Development")).toBeTruthy();
@@ -188,16 +242,21 @@ describe("Dashboard lifecycle", () => {
     const toolsGroup = screen.getByRole("group", { name: "Tools" });
     const resonantTool = screen.getByRole("button", { name: "Resonant orbit planner" });
     const deltaVTool = screen.getByRole("button", { name: "Delta-v planner" });
+    const settingsTool = screen.getByRole("button", { name: "Settings" });
     expect(toolsGroup.textContent).toContain("Tools");
     expect(toolsGroup.firstElementChild?.classList.contains("dashboard-rail-section-label")).toBe(true);
     expect(toolsGroup.contains(screen.getByRole("button", { name: "Datalink" }))).toBe(true);
     expect(toolsGroup.contains(screen.getByRole("button", { name: "Notes" }))).toBe(true);
     expect(toolsGroup.contains(resonantTool)).toBe(true);
     expect(toolsGroup.contains(deltaVTool)).toBe(true);
+    expect(toolsGroup.contains(settingsTool)).toBe(true);
+    expect(toolsGroup.lastElementChild).toBe(settingsTool);
     expect(resonantTool.classList.contains("dashboard-tool-button")).toBe(true);
     expect(deltaVTool.classList.contains("dashboard-tool-button")).toBe(true);
     expect(resonantTool.querySelector(".panel-rail-label")?.textContent).toBe("Resonant Orbit Planner");
     expect(deltaVTool.querySelector(".panel-rail-label")?.textContent).toBe("Delta-V Planner");
+    expect(settingsTool.querySelector(".panel-rail-icon-settings")).toBeTruthy();
+    expect(settingsTool.querySelector(".panel-rail-label")?.textContent).toBe("Settings");
     expect(firstView.container.querySelector("#conn")).toBeNull();
     expect(firstView.container.querySelector("svg.spark")).toBeNull();
     expect(firstView.container.querySelector(".attitude-strip")).toBeTruthy();

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -70,6 +70,8 @@ beforeEach(() => {
   vi.stubGlobal("WebSocket", FakeWebSocket);
   liveTelemetryStore.disconnect();
   localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.style.removeProperty("color-scheme");
 });
 
 afterEach(() => {
@@ -156,12 +158,15 @@ describe("Dashboard lifecycle", () => {
     expect(screen.getByRole("button", { name: "Preferences" }).getAttribute("aria-current")).toBe("page");
     fireEvent.click(screen.getByRole("button", { name: "EARTH TIME" }));
     expect(localStorage.getItem("wmc-time-system-v1")).toBe("earth");
+    fireEvent.click(screen.getByRole("radio", { name: /Daylight Console/ }));
+    expect(localStorage.getItem("wmc-theme-v1")).toBe('"daylight-console"');
+    expect(document.documentElement.dataset.theme).toBe("daylight-console");
 
     fireEvent.click(screen.getByRole("button", { name: "Features & Mods" }));
     expect(drawer.querySelectorAll(".settings-feature-toggle")).toHaveLength(10);
     expect(screen.getAllByText("AVAILABLE").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "About" }));
-    expect(screen.getByText("Mission Control Dark (read-only)", { exact: true })).toBeTruthy();
+    expect(screen.getByText("Daylight Console", { exact: true })).toBeTruthy();
     expect(screen.getByText("Development", { exact: true })).toBeTruthy();
 
     fireEvent.keyDown(document, { key: "Escape" });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,6 +77,7 @@ function FixtureDashboard({ mode, notesOpen, onCloseNotes, onSetNotesOpen }: { m
   return (
     <DashboardSurface
       datalink={(open, onClose) => <DatalinkDrawer connectionStatus="fixture" endpoint="deterministic fixtures" onClose={onClose} open={open} sceneMode={mode} />}
+      effectiveEndpoint="deterministic fixtures"
       footerLabel="Development"
       identity={identity}
       linkText={`FIXTURE · ${mode}`}
@@ -85,6 +86,7 @@ function FixtureDashboard({ mode, notesOpen, onCloseNotes, onSetNotesOpen }: { m
       notesSnapshot={snapshot}
       onCloseNotes={onCloseNotes}
       onSetNotesOpen={onSetNotesOpen}
+      settingsSnapshot={snapshot}
     >
       {mode === "flight"
         ? <FixtureFlightDashboard snapshot={snapshot} />

--- a/frontend/src/appShell.tsx
+++ b/frontend/src/appShell.tsx
@@ -172,6 +172,8 @@ export function DashboardSurface({
     scienceAlarmSettings,
     section: settingsSection,
     selectSection,
+    themeId,
+    updateTheme,
     updateScienceAlarmSettings,
   } = useSettings();
   const dashboardSettingsSnapshot = settingsSnapshot ?? notesSnapshot;
@@ -217,6 +219,7 @@ export function DashboardSurface({
         onScienceAlarmSettingsChange={updateScienceAlarmSettings}
         onSectionChange={selectSection}
         onSetTimeSystem={setTimeSystem}
+        onSetTheme={updateTheme}
         open={settingsOpen}
         scienceAlarmProviders={dashboardSettingsSnapshot["sci.alarmProviders"]}
         scienceAlarmSettings={scienceAlarmSettings}
@@ -226,6 +229,7 @@ export function DashboardSurface({
           effectiveEndpoint,
           persistenceStatus: plannerPersistence.status,
         }}
+        themeId={themeId}
         timeSystem={timeSystem}
       />
       <NotesContinuityPreview commandEnabled={notesCommandEnabled} onClose={onCloseNotes} onSendCommand={onSendNotesCommand} open={notesOpen} snapshot={notesSnapshot} />

--- a/frontend/src/appShell.tsx
+++ b/frontend/src/appShell.tsx
@@ -20,6 +20,7 @@ import {
   HideablePanelSlot,
   PanelRestoreRail,
   PanelVisibilityProvider,
+  usePanelVisibility,
   type DashboardPanelId,
 } from "./components/PanelVisibility";
 import { PinnedNotePanel } from "./components/PinnedNotePanel";
@@ -33,6 +34,7 @@ import { PinnedResonantOrbitPanel } from "./resonantOrbit/PinnedResonantOrbitPan
 import { ResonantOrbitProvider, useResonantOrbitState } from "./resonantOrbit/state";
 import { ResonantOrbitTool } from "./resonantOrbit/ResonantOrbitTool";
 import { usePlannerPersistenceStatus } from "./sharedPlannerPersistence";
+import { SettingsDrawer, SettingsProvider, useSettings } from "./settings";
 import { liveTelemetryStore } from "./telemetry/store";
 import {
   ascensionSnapshotsEqual,
@@ -49,12 +51,13 @@ import {
   overviewSnapshotsEqual,
   pinnedNoteSnapshotsEqual,
   scienceSnapshotsEqual,
+  settingsSnapshotsEqual,
   stagingSnapshotsEqual,
   targetSnapshotsEqual,
 } from "./telemetry/subscriptions";
 import type { SceneMode, TelemetryCommand, TelemetrySnapshot } from "./telemetry/types";
 import { shallowEqual, useLiveDiagnostics, useLiveTelemetrySelector } from "./telemetry/useLiveTelemetry";
-import { TimeSystemProvider } from "./timeSystem";
+import { TimeSystemProvider, useTimeSystem } from "./timeSystem";
 
 export const DEFAULT_LIVE_ENDPOINT = "ws://127.0.0.1:8090";
 
@@ -100,9 +103,11 @@ function PlannerPersistenceIndicator() {
 export function DashboardProviders({ children }: PropsWithChildren) {
   return (
     <TimeSystemProvider>
-      <ResonantOrbitProvider>
-        <DeltaVDraftProvider>{children}</DeltaVDraftProvider>
-      </ResonantOrbitProvider>
+      <SettingsProvider>
+        <ResonantOrbitProvider>
+          <DeltaVDraftProvider>{children}</DeltaVDraftProvider>
+        </ResonantOrbitProvider>
+      </SettingsProvider>
     </TimeSystemProvider>
   );
 }
@@ -118,6 +123,7 @@ export function DashboardAppFrame({ children, notesOpen }: PropsWithChildren<{ n
 interface DashboardSurfaceProps {
   children?: ReactNode;
   datalink(open: boolean, onClose: () => void): ReactNode;
+  effectiveEndpoint?: string;
   footerLabel: "Development" | "Production";
   identity?: string;
   linkText: string;
@@ -130,12 +136,14 @@ interface DashboardSurfaceProps {
   onCloseNotes(): void;
   onSetNotesOpen(open: boolean): void;
   onSendNotesCommand?(command: TelemetryCommand): boolean;
+  settingsSnapshot?: TelemetrySnapshot;
   waitingMessage?: string;
 }
 
 export function DashboardSurface({
   children,
   datalink,
+  effectiveEndpoint,
   footerLabel,
   identity,
   linkText,
@@ -148,11 +156,25 @@ export function DashboardSurface({
   onCloseNotes,
   onSetNotesOpen,
   onSendNotesCommand = () => false,
+  settingsSnapshot,
   waitingMessage = "Waiting for the first valid Mission Control telemetry frame.",
 }: DashboardSurfaceProps) {
   const showHeader = liveWaiting;
   const [datalinkOpen, setDatalinkOpen] = useState(false);
   const { closeDeltaVDrawer, closeDrawer } = useResonantOrbitState();
+  const { hiddenPanels, restoreAllHiddenPanels } = usePanelVisibility();
+  const { system: timeSystem, setSystem: setTimeSystem } = useTimeSystem();
+  const plannerPersistence = usePlannerPersistenceStatus();
+  const {
+    closeSettings,
+    open: settingsOpen,
+    openSettings,
+    scienceAlarmSettings,
+    section: settingsSection,
+    selectSection,
+    updateScienceAlarmSettings,
+  } = useSettings();
+  const dashboardSettingsSnapshot = settingsSnapshot ?? notesSnapshot;
   const closeDatalink = useCallback(() => setDatalinkOpen(false), []);
   const closeOtherTools = useCallback(() => {
     onCloseNotes();
@@ -161,22 +183,61 @@ export function DashboardSurface({
   }, [closeDeltaVDrawer, closeDrawer, onCloseNotes]);
   const toggleDatalink = useCallback(() => {
     setDatalinkOpen((current) => {
-      if (!current) closeOtherTools();
+      if (!current) {
+        closeOtherTools();
+        closeSettings();
+      }
       return !current;
     });
-  }, [closeOtherTools]);
+  }, [closeOtherTools, closeSettings]);
+  const toggleSettings = useCallback(() => {
+    if (settingsOpen) {
+      closeSettings();
+      return;
+    }
+    closeOtherTools();
+    closeDatalink();
+    openSettings(settingsSection);
+  }, [closeDatalink, closeOtherTools, closeSettings, openSettings, settingsOpen, settingsSection]);
+
+  useEffect(() => {
+    if (!settingsOpen) return;
+    closeOtherTools();
+    closeDatalink();
+  }, [closeDatalink, closeOtherTools, settingsOpen]);
 
   return (
     <section className={`dashboard-surface ${mode === "flight" ? "flight-mode" : mode === "editor" ? "editor-mode" : "inactive-mode"}`}>
+      <SettingsDrawer
+        buildLabel={footerLabel}
+        effectiveEndpoint={effectiveEndpoint}
+        hiddenPanelCount={hiddenPanels.size}
+        onClose={closeSettings}
+        onRestoreHiddenPanels={restoreAllHiddenPanels}
+        onScienceAlarmSettingsChange={updateScienceAlarmSettings}
+        onSectionChange={selectSection}
+        onSetTimeSystem={setTimeSystem}
+        open={settingsOpen}
+        scienceAlarmProviders={dashboardSettingsSnapshot["sci.alarmProviders"]}
+        scienceAlarmSettings={scienceAlarmSettings}
+        section={settingsSection}
+        telemetry={{
+          capabilities: dashboardSettingsSnapshot["dashboard.capabilities"],
+          effectiveEndpoint,
+          persistenceStatus: plannerPersistence.status,
+        }}
+        timeSystem={timeSystem}
+      />
       <NotesContinuityPreview commandEnabled={notesCommandEnabled} onClose={onCloseNotes} onSendCommand={onSendNotesCommand} open={notesOpen} snapshot={notesSnapshot} />
       {datalink(datalinkOpen, closeDatalink)}
       <DashboardRail
         datalinkButton={<DatalinkRailButton onToggle={toggleDatalink} open={datalinkOpen} />}
-        notesButton={<NotesRailButton onOpen={closeDatalink} open={notesOpen} setOpen={onSetNotesOpen} />}
+        notesButton={<NotesRailButton onOpen={() => { closeDatalink(); closeSettings(); }} open={notesOpen} setOpen={onSetNotesOpen} />}
+        settingsButton={<SettingsRailButton onToggle={toggleSettings} open={settingsOpen} />}
         tools={(
           <>
-            <ResonantOrbitTool mode={mode} onOpen={() => { onCloseNotes(); closeDatalink(); }} snapshot={notesSnapshot} />
-            <DeltaVTool mode={mode} onOpen={() => { onCloseNotes(); closeDatalink(); }} snapshot={notesSnapshot} />
+            <ResonantOrbitTool mode={mode} onOpen={() => { onCloseNotes(); closeDatalink(); closeSettings(); }} snapshot={notesSnapshot} />
+            <DeltaVTool mode={mode} onOpen={() => { onCloseNotes(); closeDatalink(); closeSettings(); }} snapshot={notesSnapshot} />
           </>
         )}
       />
@@ -375,6 +436,7 @@ export function LiveDashboard({
   const annunciator = useFlightAnnunciator({ ...annunciatorInput, watchdog: true });
   const headerSnapshot = useLiveTelemetrySelector((state) => state.snapshot, headerSnapshotsEqual);
   const notesSnapshot = useLiveTelemetrySelector((state) => state.snapshot, notesSnapshotsEqual);
+  const settingsSnapshot = useLiveTelemetrySelector((state) => state.snapshot, settingsSnapshotsEqual);
   const mode = headerSnapshot?.["context.mode"] ?? "inactive";
   const waiting = headerSnapshot === null;
   const identity = mode === "flight" ? String(headerSnapshot?.["v.name"] ?? "Active vessel") : mode === "editor" ? String(headerSnapshot?.["editor.craftName"] ?? "Untitled craft") : undefined;
@@ -428,6 +490,7 @@ export function LiveDashboard({
           sceneMode={mode}
         />
       )}
+      effectiveEndpoint={connectionEndpoint}
       footerLabel={footerLabel}
       identity={identity}
       linkText={linkText}
@@ -440,6 +503,7 @@ export function LiveDashboard({
       onCloseNotes={onCloseNotes}
       onSetNotesOpen={onSetNotesOpen}
       onSendNotesCommand={(command) => liveTelemetryStore.send(command)}
+      settingsSnapshot={settingsSnapshot ?? emptyTelemetry}
       waitingMessage={waitingMessage}
     >
       {mode === "flight"
@@ -489,6 +553,23 @@ function NotesRailButton({ onOpen, open, setOpen }: { onOpen(): void; open: bool
     >
       <span aria-hidden="true" className="panel-rail-label">Notes</span>
       <PanelRailIcon name="notes" />
+    </button>
+  );
+}
+
+function SettingsRailButton({ onToggle, open }: { onToggle(): void; open: boolean }) {
+  return (
+    <button
+      aria-controls="settings-drawer"
+      aria-expanded={open}
+      aria-label="Settings"
+      className="settings-rail-tab dashboard-tool-button panel-rail-button"
+      onClick={onToggle}
+      title="Open Settings"
+      type="button"
+    >
+      <span aria-hidden="true" className="panel-rail-label">Settings</span>
+      <PanelRailIcon name="settings" />
     </button>
   );
 }

--- a/frontend/src/components/PanelRailIcon.tsx
+++ b/frontend/src/components/PanelRailIcon.tsx
@@ -7,6 +7,7 @@ export type PanelRailIconName =
   | "elec"
   | "sci"
   | "stage"
+  | "settings"
   | "target"
   | "notes"
   | "flightNote"
@@ -68,6 +69,12 @@ export function PanelRailIcon({ name }: { name: PanelRailIconName }) {
       <path className="rail-icon-fill" d="m10.5 22 2.6-5h5.8l2.6 5Z" />
       <circle className="rail-icon-detail" cx="15" cy="22" r="1" />
       <circle className="rail-icon-detail" cx="18.5" cy="19" r=".8" />
+    </svg>
+  );
+  if (name === "settings") return (
+    <svg {...common}>
+      <path d="M13.3 3h5.4l.8 3 2.1 1.2 3-.8 2.7 4.7-2.2 2.2v2.4l2.2 2.2-2.7 4.7-3-.8-2.1 1.2-.8 3h-5.4l-.8-3-2.1-1.2-3 .8-2.7-4.7 2.2-2.2v-2.4l-2.2-2.2 2.7-4.7 3 .8 2.1-1.2.8-3Z" />
+      <circle className="rail-icon-detail" cx="16" cy="14.5" r="4" />
     </svg>
   );
   if (name === "stage") return (

--- a/frontend/src/components/PanelVisibility.test.tsx
+++ b/frontend/src/components/PanelVisibility.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PanelVisibilityProvider, usePanelVisibility } from "./PanelVisibility";
+
+function Harness() {
+  const { autoCollapsePanel, hiddenPanels, restoreAllHiddenPanels } = usePanelVisibility();
+  return <>
+    <output data-testid="hidden-count">{hiddenPanels.size}</output>
+    <button onClick={() => autoCollapsePanel("sci")} type="button">Auto collapse science</button>
+    <button onClick={restoreAllHiddenPanels} type="button">Restore all</button>
+  </>;
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(cleanup);
+
+describe("PanelVisibilityProvider bulk restore", () => {
+  it("clears preference and transient hidden panels without resetting unrelated settings", () => {
+    localStorage.setItem("wmc-hidden-panels-v1", JSON.stringify(["editorDeltaVPlan"]));
+    localStorage.setItem("wmc-science-alarm-defaults-v1", "keep-alarm-settings");
+    localStorage.setItem("wmc-theme-v1", "keep-theme");
+    localStorage.setItem("wmc-resonant-library-v2", "keep-plans");
+
+    render(<PanelVisibilityProvider><Harness /></PanelVisibilityProvider>);
+    expect(screen.getByTestId("hidden-count").textContent).toBe("1");
+    fireEvent.click(screen.getByRole("button", { name: "Auto collapse science" }));
+    expect(screen.getByTestId("hidden-count").textContent).toBe("2");
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore all" }));
+    expect(screen.getByTestId("hidden-count").textContent).toBe("0");
+    expect(JSON.parse(localStorage.getItem("wmc-hidden-panels-v1") ?? "null")).toEqual([]);
+    expect(localStorage.getItem("wmc-science-alarm-defaults-v1")).toBe("keep-alarm-settings");
+    expect(localStorage.getItem("wmc-theme-v1")).toBe("keep-theme");
+    expect(localStorage.getItem("wmc-resonant-library-v2")).toBe("keep-plans");
+  });
+});

--- a/frontend/src/components/PanelVisibility.tsx
+++ b/frontend/src/components/PanelVisibility.tsx
@@ -75,6 +75,7 @@ interface PanelVisibilityValue {
   clearAutoCollapse(id: DashboardPanelId): void;
   hidePanel(id: DashboardPanelId): void;
   registerAvailablePanels(sourceId: string, panels: ReadonlySet<DashboardPanelId>): () => void;
+  restoreAllHiddenPanels(): void;
   restorePanel(id: DashboardPanelId): void;
 }
 
@@ -87,6 +88,7 @@ const fallbackVisibility: PanelVisibilityValue = {
   clearAutoCollapse() {},
   hidePanel() {},
   registerAvailablePanels() { return () => {}; },
+  restoreAllHiddenPanels() {},
   restorePanel() {},
 };
 const PanelVisibilityContext = createContext<PanelVisibilityValue>(fallbackVisibility);
@@ -202,6 +204,16 @@ export function PanelVisibilityProvider({
     setLastRestore((current) => ({ id, sequence: (current?.sequence ?? 0) + 1 }));
   }, [persist]);
 
+  const restoreAllHiddenPanels = useCallback(() => {
+    const firstHidden = panelOrder.find((id) => hiddenPanels.has(id));
+    setPreferenceHiddenPanels(new Set<DashboardPanelId>());
+    setAutoHiddenPanels(new Set<DashboardPanelId>());
+    persist(new Set<DashboardPanelId>());
+    if (firstHidden) {
+      setLastRestore((current) => ({ id: firstHidden, sequence: (current?.sequence ?? 0) + 1 }));
+    }
+  }, [hiddenPanels, persist]);
+
   const value = useMemo<PanelVisibilityValue>(() => ({
     availablePanels,
     centralizedRail,
@@ -211,6 +223,7 @@ export function PanelVisibilityProvider({
     clearAutoCollapse,
     hidePanel,
     registerAvailablePanels,
+    restoreAllHiddenPanels,
     restorePanel,
   }), [
     autoCollapsePanel,
@@ -221,6 +234,7 @@ export function PanelVisibilityProvider({
     hidePanel,
     lastRestore,
     registerAvailablePanels,
+    restoreAllHiddenPanels,
     restorePanel,
   ]);
 
@@ -275,10 +289,12 @@ export function PanelRestoreRail({ available }: { available: ReadonlySet<Dashboa
 export function DashboardRail({
   datalinkButton,
   notesButton,
+  settingsButton,
   tools,
 }: {
   datalinkButton: ReactNode;
   notesButton: ReactNode;
+  settingsButton: ReactNode;
   tools: ReactNode;
 }) {
   const { availablePanels, hiddenPanels, restorePanel } = usePanelVisibility();
@@ -304,6 +320,7 @@ export function DashboardRail({
         ))}
         {notesButton}
         {tools}
+        {settingsButton}
       </div>
     </nav>
   );

--- a/frontend/src/components/SciencePanel.test.tsx
+++ b/frontend/src/components/SciencePanel.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { flightTelemetryFixture } from "../telemetry/fixtures";
 import type { ScienceLabTelemetry, TelemetryCommand, TelemetrySnapshot } from "../telemetry/types";
+import { SettingsProvider, useSettings } from "../settings";
 import { SciencePanel } from "./SciencePanel";
 import { PanelVisibilityProvider } from "./PanelVisibility";
 
@@ -14,7 +15,12 @@ afterEach(() => {
 beforeEach(() => localStorage.clear());
 
 function renderPanel(snapshot: TelemetrySnapshot) {
-  return render(<PanelVisibilityProvider><SciencePanel snapshot={snapshot} /></PanelVisibilityProvider>);
+  return render(<SettingsProvider><PanelVisibilityProvider><SciencePanel snapshot={snapshot} /></PanelVisibilityProvider></SettingsProvider>);
+}
+
+function SettingsStateProbe() {
+  const settings = useSettings();
+  return <output data-testid="settings-state">{settings.open ? settings.section : "closed"}</output>;
 }
 
 describe("SciencePanel", () => {
@@ -100,13 +106,13 @@ describe("SciencePanel", () => {
     });
     expect(screen.getByText(/service update required/)).toBeTruthy();
 
-    rerender(<PanelVisibilityProvider><SciencePanel snapshot={{
+    rerender(<SettingsProvider><PanelVisibilityProvider><SciencePanel snapshot={{
       "context.mode": "flight",
       "sci.krpc.total": 0,
       "sci.krpc.count": 0,
       "sci.krpc.labTelemetryAvailable": true,
       "sci.krpc.labs": [],
-    }} /></PanelVisibilityProvider>);
+    }} /></PanelVisibilityProvider></SettingsProvider>);
     expect(screen.queryByText("No research labs aboard", { exact: true })).toBeNull();
     expect(screen.queryByLabelText("Science laboratories")).toBeNull();
     expect(screen.getByText("Recoverable", { exact: true })).toBeTruthy();
@@ -134,25 +140,18 @@ describe("SciencePanel", () => {
     expect(screen.getByText("Goo canister · 4 data", { exact: true })).toBeTruthy();
   });
 
-  it("persists alarm defaults and sends one manual alarm command", () => {
-    const onSendCommand = vi.fn((_command: TelemetryCommand) => true);
-    const { rerender } = render(<PanelVisibilityProvider><SciencePanel commandEnabled onSendCommand={onSendCommand} snapshot={flightTelemetryFixture} /></PanelVisibilityProvider>);
-
-    fireEvent.click(screen.getByRole("button", { name: "Science alarm settings" }));
-    const dialog = screen.getByRole("dialog", { name: "Alarm defaults" });
-    expect(within(dialog).getByRole("button", { name: "AUTO" }).getAttribute("aria-pressed")).toBe("true");
-    expect(within(dialog).getByRole("button", { name: "1 HOUR" }).getAttribute("aria-pressed")).toBe("true");
-    expect(within(dialog).getByRole("button", { name: "KILL WARP" }).getAttribute("aria-pressed")).toBe("true");
-    fireEvent.click(within(dialog).getByRole("button", { name: "STOCK" }));
-    fireEvent.click(within(dialog).getByRole("button", { name: "30 MIN" }));
-    fireEvent.click(within(dialog).getByRole("button", { name: "PAUSE GAME" }));
-    fireEvent.click(within(dialog).getByRole("button", { name: "SAVE DEFAULTS" }));
-
-    expect(JSON.parse(localStorage.getItem("wmc-science-alarm-defaults-v1") ?? "null")).toEqual({
+  it("uses shared alarm defaults, deep-links Settings, and sends one manual alarm command", () => {
+    localStorage.setItem("wmc-science-alarm-defaults-v1", JSON.stringify({
       provider: "stock",
       leadSeconds: 1800,
       kacAction: "pause_game",
-    });
+    }));
+    const onSendCommand = vi.fn((_command: TelemetryCommand) => true);
+    const { rerender } = render(<SettingsProvider><PanelVisibilityProvider><SciencePanel commandEnabled onSendCommand={onSendCommand} snapshot={flightTelemetryFixture} /></PanelVisibilityProvider><SettingsStateProbe /></SettingsProvider>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Science alarm settings" }));
+    expect(screen.getByTestId("settings-state").textContent).toBe("science-alarms");
+    expect(screen.queryByRole("dialog", { name: "Alarm defaults" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "SET ALARM" }));
     expect(onSendCommand).toHaveBeenCalledTimes(1);
     expect(onSendCommand.mock.calls[0][0]).toMatchObject({
@@ -165,7 +164,7 @@ describe("SciencePanel", () => {
     const sentCommand = onSendCommand.mock.calls[0][0];
     if (sentCommand.type !== "science.alarm.create") throw new Error("Expected a science alarm command.");
     const requestId = sentCommand.requestId;
-    rerender(<PanelVisibilityProvider><SciencePanel
+    rerender(<SettingsProvider><PanelVisibilityProvider><SciencePanel
       alarmResult={{
         type: "science.alarm.create.result",
         requestId,
@@ -179,8 +178,8 @@ describe("SciencePanel", () => {
       commandEnabled
       onSendCommand={onSendCommand}
       snapshot={flightTelemetryFixture}
-    /></PanelVisibilityProvider>);
-    expect(screen.getByRole("status").textContent).toContain("Stock alarm set");
+    /></PanelVisibilityProvider><SettingsStateProbe /></SettingsProvider>);
+    expect(screen.getByText("Stock alarm set 30 minutes before estimated capacity.", { exact: true })).toBeTruthy();
   });
 
   it("disables alarm creation when the lab has no finite ETA", () => {

--- a/frontend/src/components/SciencePanel.tsx
+++ b/frontend/src/components/SciencePanel.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { useDialogFocus } from "../deltaV/useDialogFocus";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { formatScienceColumn, formatScienceInline, isFiniteNumber } from "../formatting/numbers";
+import { useScienceAlarmSettings, useSettings } from "../settings";
 import type {
-  ScienceAlarmAction,
   ScienceAlarmProvider,
   ScienceAlarmProviderPreference,
   ScienceAlarmResult,
@@ -15,44 +14,7 @@ import type {
 import { Panel } from "./Panel";
 import { selectScience, type ScienceLabViewModel } from "./scienceModel";
 
-const SCIENCE_ALARM_SETTINGS_KEY = "wmc-science-alarm-defaults-v1";
-type ScienceAlarmLead = 1800 | 3600;
 type SciencePanelCommand = Extract<TelemetryCommand, { type: "science.alarm.create" | "science.lab.research" | "science.lab.transmit" }>;
-
-interface ScienceAlarmDefaults {
-  provider: ScienceAlarmProviderPreference;
-  leadSeconds: ScienceAlarmLead;
-  kacAction: ScienceAlarmAction;
-}
-
-const defaultScienceAlarmSettings: ScienceAlarmDefaults = {
-  provider: "auto",
-  leadSeconds: 3600,
-  kacAction: "kill_warp",
-};
-
-const scienceAlarmActions: Array<{ label: string; value: ScienceAlarmAction }> = [
-  { label: "KILL WARP", value: "kill_warp" },
-  { label: "PAUSE GAME", value: "pause_game" },
-  { label: "MESSAGE ONLY", value: "message_only" },
-  { label: "DO NOTHING", value: "do_nothing" },
-];
-
-function readScienceAlarmSettings(): ScienceAlarmDefaults {
-  if (typeof localStorage === "undefined") return defaultScienceAlarmSettings;
-  try {
-    const parsed = JSON.parse(localStorage.getItem(SCIENCE_ALARM_SETTINGS_KEY) ?? "null") as Partial<ScienceAlarmDefaults> | null;
-    return {
-      provider: parsed?.provider === "kac" || parsed?.provider === "stock" ? parsed.provider : "auto",
-      leadSeconds: parsed?.leadSeconds === 1800 ? 1800 : 3600,
-      kacAction: scienceAlarmActions.some(({ value }) => value === parsed?.kacAction)
-        ? parsed!.kacAction as ScienceAlarmAction
-        : "kill_warp",
-    };
-  } catch {
-    return defaultScienceAlarmSettings;
-  }
-}
 
 function resolvedAlarmProvider(
   preference: ScienceAlarmProviderPreference,
@@ -157,11 +119,8 @@ export function SciencePanel({
   transmitResult?: ScienceLabTransmitResult;
 }) {
   const model = selectScience(snapshot);
-  const [alarmSettings, setAlarmSettings] = useState(readScienceAlarmSettings);
-  const [draftProvider, setDraftProvider] = useState<ScienceAlarmProviderPreference>(alarmSettings.provider);
-  const [draftLeadSeconds, setDraftLeadSeconds] = useState<ScienceAlarmLead>(alarmSettings.leadSeconds);
-  const [draftKacAction, setDraftKacAction] = useState<ScienceAlarmAction>(alarmSettings.kacAction);
-  const [settingsOpen, setSettingsOpen] = useState(false);
+  const { scienceAlarmSettings: alarmSettings } = useScienceAlarmSettings();
+  const { openSettings } = useSettings();
   const [experimentDetailOpen, setExperimentDetailOpen] = useState(false);
   const [scienceSlotHeight, setScienceSlotHeight] = useState<number>();
   const [pending, setPending] = useState<{ labId: string; requestId: string } | null>(null);
@@ -170,8 +129,6 @@ export function SciencePanel({
   const [feedback, setFeedback] = useState<{ labId: string; message: string; status: "accepted" | "error" } | null>(null);
   const providers = snapshot["sci.alarmProviders"] ?? { kac: false, stock: false };
   const selectedProvider = resolvedAlarmProvider(alarmSettings.provider, providers);
-  const closeSettings = useCallback(() => setSettingsOpen(false), []);
-  const settingsDialogRef = useDialogFocus<HTMLElement>(settingsOpen, closeSettings);
   const experimentButtonRef = useRef<HTMLButtonElement>(null);
   const experimentBackRef = useRef<HTMLButtonElement>(null);
   const scienceBaselineRef = useRef<HTMLDivElement>(null);
@@ -243,24 +200,6 @@ export function SciencePanel({
     const timer = globalThis.setTimeout(() => setFeedback(null), 10_000);
     return () => globalThis.clearTimeout(timer);
   }, [feedback]);
-
-  const openSettings = () => {
-    setDraftProvider(alarmSettings.provider);
-    setDraftLeadSeconds(alarmSettings.leadSeconds);
-    setDraftKacAction(alarmSettings.kacAction);
-    setSettingsOpen(true);
-  };
-
-  const saveSettings = () => {
-    const next = { provider: draftProvider, leadSeconds: draftLeadSeconds, kacAction: draftKacAction };
-    setAlarmSettings(next);
-    try {
-      localStorage.setItem(SCIENCE_ALARM_SETTINGS_KEY, JSON.stringify(next));
-    } catch {
-      // The in-memory choice still applies when browser storage is unavailable.
-    }
-    setSettingsOpen(false);
-  };
 
   const createAlarm = (lab: ScienceLabViewModel) => {
     if (!commandEnabled || !selectedProvider || !["finite", "depleted"].includes(lab.etaKind) || !isFiniteNumber(lab.etaSeconds) || pending) return;
@@ -412,7 +351,7 @@ export function SciencePanel({
                     title={!alarmEligible ? "A finite completion estimate is required" : !selectedProvider ? "No selected alarm provider is available" : "Create a one-shot science capacity alarm"}
                     type="button"
                   >{waiting ? "SETTING…" : "SET ALARM"}</button>
-                  <button aria-haspopup="dialog" aria-label="Science alarm settings" className="sci-alarm-settings" onClick={openSettings} title="Science alarm defaults" type="button">
+                  <button aria-haspopup="dialog" aria-label="Science alarm settings" className="sci-alarm-settings" onClick={() => openSettings("science-alarms")} title="Science alarm defaults" type="button">
                     <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24"><path d="M9.7 2h4.6l.6 2.1 1.5.9 2.1-.5 2.3 4-1.5 1.6v1.8l1.5 1.6-2.3 4-2.1-.5-1.5.9-.6 2.1H9.7l-.6-2.1-1.5-.9-2.1.5-2.3-4 1.5-1.6V9.1L3.2 7.5l2.3-4 2.1.5 1.5-.9L9.7 2Zm2.3 6.6a3.4 3.4 0 1 0 0 6.8 3.4 3.4 0 0 0 0-6.8Z" /></svg>
                   </button>
                 </div>
@@ -451,26 +390,6 @@ export function SciencePanel({
         </section>}
       </div>}
 
-      {settingsOpen && <div className="delta-v-modal-backdrop sci-alarm-modal-backdrop" onMouseDown={(event) => { if (event.target === event.currentTarget) closeSettings(); }}>
-        <section aria-labelledby="science-alarm-settings-title" aria-modal="true" className="sci-alarm-modal" onMouseDown={(event) => event.stopPropagation()} ref={settingsDialogRef} role="dialog" tabIndex={-1}>
-          <header><div><span>SCIENCE ALARMS</span><h3 id="science-alarm-settings-title">Alarm defaults</h3></div><button aria-label="Close science alarm settings" onClick={closeSettings} type="button">×</button></header>
-          <div className="sci-alarm-modal-body">
-            <fieldset><legend>Provider</legend><div className="sci-alarm-options">
-              {(["auto", "kac", "stock"] as const).map((provider) => <button aria-pressed={draftProvider === provider} disabled={provider !== "auto" && !providers[provider]} key={provider} onClick={() => setDraftProvider(provider)} type="button">{provider.toUpperCase()}</button>)}
-            </div></fieldset>
-            <small>{draftProvider === "auto" ? "KAC is preferred when available; Stock is the fallback." : `${draftProvider.toUpperCase()} will be used when available.`}</small>
-            <fieldset><legend>Lead time</legend><div className="sci-alarm-options lead">
-              <button aria-pressed={draftLeadSeconds === 1800} onClick={() => setDraftLeadSeconds(1800)} type="button">30 MIN</button>
-              <button aria-pressed={draftLeadSeconds === 3600} onClick={() => setDraftLeadSeconds(3600)} type="button">1 HOUR</button>
-            </div></fieldset>
-            <fieldset><legend>KAC alarm action</legend><div className="sci-alarm-options action">
-              {scienceAlarmActions.map(({ label, value }) => <button aria-pressed={draftKacAction === value} key={value} onClick={() => setDraftKacAction(value)} type="button">{label}</button>)}
-            </div></fieldset>
-            <small>Alarms are created once from the current estimate and are not rescheduled automatically. Stock alarms always stop time warp.</small>
-          </div>
-          <footer><button onClick={closeSettings} type="button">CANCEL</button><button onClick={saveSettings} type="button">SAVE DEFAULTS</button></footer>
-        </section>
-      </div>}
     </Panel>
   );
 }

--- a/frontend/src/deltaV/DeltaVPlanner.test.tsx
+++ b/frontend/src/deltaV/DeltaVPlanner.test.tsx
@@ -104,6 +104,14 @@ describe("delta-v planner drawer", () => {
     expect(nextStop.selectedOptions[0]?.textContent).toBe("Choose next body…");
     expect((screen.getByRole("button", { name: /Add next stop/ }) as HTMLButtonElement).disabled).toBe(true);
     fireEvent.change(nextStop, { target: { value: "Duna" } });
+    const simplePlanning = screen.getByRole("radio", { name: "Simple" });
+    const advancedPlanning = screen.getByRole("radio", { name: "Advanced" });
+    expect(simplePlanning.closest(".delta-v-summary")).toBeTruthy();
+    expect(simplePlanning.closest(".delta-v-controls")).toBeNull();
+    fireEvent.click(advancedPlanning);
+    expect(screen.getByText("Per-leg porkchops")).toBeTruthy();
+    fireEvent.click(simplePlanning);
+    expect(screen.getByText("Ideal dates")).toBeTruthy();
     expect(screen.queryByRole("spinbutton", { name: "Planned altitude" })).toBeNull();
     fireEvent.click(screen.getAllByRole("radio", { name: "Parking orbit" })[0]);
     expect(screen.getByRole("spinbutton", { name: "Planned altitude" })).toBeTruthy();
@@ -558,16 +566,16 @@ describe("delta-v planner drawer", () => {
 
     expect((screen.getByRole("radio", { name: "Simple" }) as HTMLInputElement).checked).toBe(true);
     expect(screen.queryByRole("button", { name: "PORKCHOP" })).toBeNull();
-    expect(screen.getByText("Simple: ideal dates")).toBeTruthy();
-    expect(screen.queryByText("Advanced: per-leg porkchops")).toBeNull();
+    expect(screen.getByText("Ideal dates")).toBeTruthy();
+    expect(screen.queryByText("Per-leg porkchops")).toBeNull();
     fireEvent.click(screen.getByRole("radio", { name: "Parking orbit" }));
     expect(screen.getByRole("spinbutton", { name: "Planned altitude" })).toBeTruthy();
     expect(screen.getByText(/ATMO Ends at 50.0/)).toBeTruthy();
     fireEvent.click(screen.getByRole("radio", { name: "Advanced" }));
     expect(screen.getByRole("button", { name: "PORKCHOP" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Calculate ideal windows" })).toBeNull();
-    expect(screen.getByText("Advanced: per-leg porkchops")).toBeTruthy();
-    expect(screen.queryByText("Simple: ideal dates")).toBeNull();
+    expect(screen.getByText("Per-leg porkchops")).toBeTruthy();
+    expect(screen.queryByText("Ideal dates")).toBeNull();
     expect(screen.getByText("Planning margin")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Close delta-v planner" }));

--- a/frontend/src/deltaV/DeltaVPlanner.tsx
+++ b/frontend/src/deltaV/DeltaVPlanner.tsx
@@ -853,12 +853,15 @@ export function DeltaVPlanner({ mode, onCloseSavedPlans, resetRevision, saveTarg
     ? `${plan.origin.name} round trip`
     : plan ? `${plan.origin.name} → ${plan.destination.name}` : "";
   const saveControls = plan ? <div className="delta-v-save-bar">
-    <label><span>Plan name:</span><input aria-label="Delta-v plan name" placeholder={suggestedPlanName} value={planName} onChange={(event) => { setPlanName(event.target.value); setSaveError(false); setSavedNotice(""); }} /></label>
+    <div className="delta-v-save-heading">
+      <span>PLAN NAME</span>
+      {savedNotice && <small className={`delta-v-save-feedback${saveError ? " error" : ""}`} role={saveError ? "alert" : "status"}>{savedNotice}</small>}
+    </div>
+    <label><span className="sr-only">Plan name</span><input aria-label="Delta-v plan name" placeholder={suggestedPlanName} value={planName} onChange={(event) => { setPlanName(event.target.value); setSaveError(false); setSavedNotice(""); }} /></label>
     <div className="delta-v-save-actions">
       <button disabled={advancedPlanIncomplete} onClick={() => saveCurrentPlan(false)} type="button">{activeSavedPlanId ? "Update plan" : "Save plan"}</button>
       {activeSavedPlanId && <button className="secondary" disabled={advancedPlanIncomplete} onClick={() => saveCurrentPlan(true)} type="button">Save as new</button>}
     </div>
-    {savedNotice && <small className={`delta-v-save-feedback${saveError ? " error" : ""}`} role={saveError ? "alert" : "status"}>{savedNotice}</small>}
   </div> : null;
   const renderSavedPlan = (record: SavedDeltaVPlanRecord) => {
     const isPinned = pinned?.id === record.id;

--- a/frontend/src/deltaV/DeltaVPlanner.tsx
+++ b/frontend/src/deltaV/DeltaVPlanner.tsx
@@ -897,15 +897,9 @@ export function DeltaVPlanner({ mode, onCloseSavedPlans, resetRevision, saveTarg
           {nextStop.endpoint === "orbit" && <ParkingAltitudeInput body={nextStopBody} label="Planned altitude" onChange={(parkingAltitude) => setNextStop((current) => ({ ...current, parkingAltitude }))} unit={unit} value={nextStop.parkingAltitude} />}
         </> : <div className="delta-v-empty-stop"><span>ARRIVAL PROFILE</span><strong>Choose a body to configure the next stop.</strong></div>}
       </div>}
-      <div className="delta-v-mission-row one-way">
-        <fieldset><legend className="delta-v-field-heading"><span>Transfer planning</span></legend><div className="resonant-segments delta-v-transfer-mode">
-          <label><input checked={transferMode === "simple"} name="transfer-planning-mode" type="radio" onChange={() => selectTransferMode("simple")} /><span>Simple</span></label>
-          <label><input checked={transferMode === "advanced"} name="transfer-planning-mode" type="radio" onChange={() => selectTransferMode("advanced")} /><span>Advanced</span></label>
-        </div></fieldset>
-        <div className="delta-v-add-stop-row">
-          <button disabled={startLocked && !nextStopBody} onClick={startLocked ? addStop : lockStart} title={editingStopId ? "Update this route stop" : startLocked ? "Add this stop and keep the builder ready for the next leg" : "Lock the mission start and configure the first destination"} type="button">{editingStopId ? "Update stop" : "+ Add next stop"}</button>
-          {editingStopId && <button className="secondary" onClick={cancelStopEdit} type="button">Cancel edit</button>}
-        </div>
+      <div className="delta-v-add-stop-row">
+        <button disabled={startLocked && !nextStopBody} onClick={startLocked ? addStop : lockStart} title={editingStopId ? "Update this route stop" : startLocked ? "Add this stop and keep the builder ready for the next leg" : "Lock the mission start and configure the first destination"} type="button">{editingStopId ? "Update stop" : "+ Add next stop"}</button>
+        {editingStopId && <button className="secondary" onClick={cancelStopEdit} type="button">Cancel edit</button>}
       </div>
       </section>}
     </div>
@@ -934,7 +928,14 @@ export function DeltaVPlanner({ mode, onCloseSavedPlans, resetRevision, saveTarg
     {calculation.error && <div className="resonant-error delta-v-error" role="alert">{calculation.error}</div>}
     {plan && <div className="delta-v-output">
       <section className="delta-v-summary">
-        <header><div><span>PLANNING BUDGET</span><h3>{routeHeading}</h3></div><div className="delta-v-summary-mode"><small>{transferMode === "simple" ? "Simple: ideal dates" : "Advanced: per-leg porkchops"}</small><strong>{transferMode.toUpperCase()} + {marginPercent}%</strong></div></header>
+        <header>
+          <div><span>PLANNING BUDGET</span><h3>{routeHeading}</h3></div>
+          <fieldset className="delta-v-summary-transfer-mode"><legend className="sr-only">Transfer planning</legend><div className="resonant-segments delta-v-transfer-mode">
+            <label><input checked={transferMode === "simple"} name="transfer-planning-mode" type="radio" onChange={() => selectTransferMode("simple")} /><span>Simple</span></label>
+            <label><input checked={transferMode === "advanced"} name="transfer-planning-mode" type="radio" onChange={() => selectTransferMode("advanced")} /><span>Advanced</span></label>
+          </div></fieldset>
+          <div className="delta-v-summary-mode"><small>{transferMode === "simple" ? "Ideal dates" : "Per-leg porkchops"}</small><strong>{marginPercent}% MARGIN</strong></div>
+        </header>
         <div className="delta-v-total"><span>Total mission budget</span><strong className={advancedPlanIncomplete ? "delta-v-incomplete-bumper" : undefined}>{advancedPlanIncomplete ? "INCOMPLETE" : formatDeltaV(plan.totalDeltaV)}</strong><small>{planningStops.length} mission stop{planningStops.length === 1 ? "" : "s"} · {surfaceStopCount} surface stop{surfaceStopCount === 1 ? "" : "s"} · {plan.legs.length} modeled legs</small></div>
         <div className="delta-v-stat-grid">
           <article><span>Nominal route</span><strong className={advancedPlanIncomplete ? "delta-v-incomplete-bumper" : undefined}>{advancedPlanIncomplete ? "INCOMPLETE" : formatDeltaV(plan.nominalDeltaV)}</strong><small>Before planning margin</small></article>

--- a/frontend/src/deltaV/DeltaVTool.tsx
+++ b/frontend/src/deltaV/DeltaVTool.tsx
@@ -38,14 +38,17 @@ function DeltaVDrawer({ mode, snapshot }: { mode: SceneMode; snapshot?: Telemetr
     <div aria-hidden="true" className="resonant-drawer-backdrop" onMouseDown={closeDeltaVDrawer} />
     <aside aria-label="Delta-v planner" aria-modal="true" className="resonant-drawer delta-v-drawer" id="delta-v-drawer" ref={drawerDialogRef} role="dialog" tabIndex={-1}>
       <header>
-        <div><span>MISSION PLANNING · DELTA-V</span><h2>Delta-V Mission Planner</h2><p>Build an idealized mission budget from the live KSP body catalog without changing the active craft.</p></div>
+        <div><h2>Delta-V Mission Planner</h2><p>Build an idealized mission budget from the live KSP body catalog without changing the active craft.</p></div>
         <div className="delta-v-header-controls">
           <div className="delta-v-save-slot" ref={setSaveTarget} />
-          <div className="delta-v-header-actions">
-            <button aria-haspopup="dialog" aria-label="Load saved plans" className="delta-v-saved-plans-button" onClick={() => setSavedPlansOpen(true)} title="Load saved plans" type="button"><span>SAVED PLANS</span><strong>{currentSavePlanCount}</strong></button>
-            <button aria-haspopup="dialog" aria-label="Reset current plan" className="delta-v-reset-button" disabled={!draftHasContent} onClick={() => setResetConfirmationOpen(true)} title={draftHasContent ? "Clear the current draft and start a new plan" : "The current draft is already empty"} type="button">RESET</button>
-            <button aria-label="Model assumptions and limits" className="delta-v-assumptions-button" onClick={() => setAssumptionsOpen(true)} title="Model assumptions and limits" type="button">?</button>
-            <button aria-label="Close delta-v planner" onClick={closeDeltaVDrawer} type="button">×</button>
+          <div aria-label="Plan tools" className="delta-v-header-actions" role="group">
+            <span className="delta-v-header-actions-heading">PLAN TOOLS</span>
+            <div className="delta-v-header-action-buttons">
+              <button aria-haspopup="dialog" aria-label="Load saved plans" className="delta-v-saved-plans-button" onClick={() => setSavedPlansOpen(true)} title="Load saved plans" type="button"><span>SAVED PLANS</span><strong>{currentSavePlanCount}</strong></button>
+              <button aria-haspopup="dialog" aria-label="Reset current plan" className="delta-v-reset-button" disabled={!draftHasContent} onClick={() => setResetConfirmationOpen(true)} title={draftHasContent ? "Clear the current draft and start a new plan" : "The current draft is already empty"} type="button">RESET</button>
+              <button aria-label="Model assumptions and limits" className="delta-v-assumptions-button" onClick={() => setAssumptionsOpen(true)} title="Model assumptions and limits" type="button">MODEL</button>
+              <button aria-label="Close delta-v planner" onClick={closeDeltaVDrawer} type="button">×</button>
+            </div>
           </div>
         </div>
       </header>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { bootstrapTheme } from "./theme";
 import "./styles.css";
 import "./resonantOrbit/resonantOrbit.css";
+
+bootstrapTheme();
 
 const root = document.getElementById("root");
 

--- a/frontend/src/resonantOrbit/resonantOrbit.css
+++ b/frontend/src/resonantOrbit/resonantOrbit.css
@@ -1,7 +1,7 @@
-.resonant-rail-tab { border-color: var(--amber-accent); color: var(--amber); background: #211a12; }
-.resonant-rail-tab:hover, .resonant-rail-tab[aria-expanded="true"] { border-color: var(--amber-dim); color: #ffd498; background: #2b2115; }
-.delta-v-rail-tab { border-color: var(--amber-accent); color: var(--amber); background: #211a12; }
-.delta-v-rail-tab:hover, .delta-v-rail-tab[aria-expanded="true"] { border-color: var(--amber-dim); color: #ffd498; background: #2b2115; }
+.resonant-rail-tab { border-color: var(--amber-accent); color: var(--amber); background: var(--rail-face); }
+.resonant-rail-tab:hover, .resonant-rail-tab[aria-expanded="true"] { border-color: var(--amber-dim); color: var(--rail-text-hover); background: var(--rail-face-hover); }
+.delta-v-rail-tab { border-color: var(--amber-accent); color: var(--amber); background: var(--rail-face); }
+.delta-v-rail-tab:hover, .delta-v-rail-tab[aria-expanded="true"] { border-color: var(--amber-dim); color: var(--rail-text-hover); background: var(--rail-face-hover); }
 .delta-v-rail-icon { display: flex; width: 29px; height: 28px; align-items: center; justify-content: center; flex: 0 0 29px; flex-direction: column; line-height: 1; text-transform: none; }
 .delta-v-rail-icon b { font: 700 12px var(--mono); letter-spacing: -.08em; }
 .delta-v-rail-icon small { margin-top: 3px; color: var(--amber-dim); font: 700 8px var(--mono); letter-spacing: .12em; }
@@ -25,7 +25,7 @@
 .resonant-drawer-body { min-height: 0; overflow: auto; }
 .resonant-drawer > footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 11px 18px; border-top: 1px solid var(--surface-seam); color: var(--slate); background: var(--surface-rail); box-shadow: var(--surface-depth-engraved); font-size: 9px; }
 .resonant-drawer > footer button { min-height: 36px; padding: 8px 14px; border: 1px solid var(--cyan); color: var(--cyan); background: rgba(78,201,224,.08); cursor: pointer; font-weight: 700; }
-.resonant-drawer > footer button:hover { color: #061014; background: var(--cyan); }
+.resonant-drawer > footer button:hover { color: var(--on-accent); background: var(--cyan); }
 .resonant-drawer > footer button.pinned { border-color: var(--green); color: var(--green); background: rgba(126,231,135,.08); }
 .resonant-drawer > footer button:disabled { opacity: .4; cursor: not-allowed; }
 .resonant-drawer > footer.resonant-attribution { justify-content: flex-start; flex-wrap: wrap; }
@@ -73,7 +73,7 @@
 .resonant-library-list article > div:first-child strong { color: var(--text-primary); font-size: 10px; }
 .resonant-library-list article > div:first-child span { margin-top: 4px; color: var(--slate); font-size: 9px; text-transform: uppercase; }
 .resonant-library-actions { display: flex; gap: 5px; }
-.resonant-library-actions button { min-height: 29px; padding: 5px 8px; border: 1px solid var(--rule-bright); color: var(--cyan); background: #0c141e; cursor: pointer; font: 10px var(--mono); text-transform: uppercase; }
+.resonant-library-actions button { min-height: 29px; padding: 5px 8px; border: 1px solid var(--rule-bright); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 10px var(--mono); text-transform: uppercase; }
 .resonant-library-actions button:hover, .resonant-library-actions button.active { border-color: var(--cyan); background: rgba(78,201,224,.1); }
 .resonant-library-actions button.active { border-color: var(--green); color: var(--green); }
 .resonant-library-actions button.delete { color: var(--slate); }
@@ -86,7 +86,7 @@
 .resonant-advanced .resonant-check { display: flex; align-items: center; align-self: end; min-height: 36px; flex-direction: row; }
 .resonant-check input { width: 16px; min-height: 16px; accent-color: var(--cyan); }
 
-.resonant-error { margin: 12px 16px; padding: 11px; border: 1px solid var(--warn); color: #ffc2bb; background: rgba(255,107,91,.08); font-size: 10px; }
+.resonant-error { margin: 12px 16px; padding: 11px; border: 1px solid var(--warn); color: var(--error-text); background: var(--destructive-surface); font-size: 10px; }
 .resonant-plot { position: relative; min-height: 330px; overflow: hidden; border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: radial-gradient(circle at center,rgba(78,201,224,.05),transparent 48%),linear-gradient(rgba(78,201,224,.025) 1px,transparent 1px),linear-gradient(90deg,rgba(78,201,224,.025) 1px,transparent 1px),#050a0f; background-size: auto,24px 24px,24px 24px,auto; }
 .resonant-plot canvas { display: block; width: 100%; height: 330px; }
 .resonant-plot-legend { position: absolute; left: 14px; bottom: 12px; display: flex; gap: 15px; color: var(--slate); font-size: 9px; }
@@ -117,9 +117,9 @@
 .resonant-result-grid article.delta > strong { color: var(--amber); }
 .resonant-result-grid article > small { display: block; margin-top: 6px; color: var(--slate); font-size: 9px; }
 .resonant-warnings { display: grid; gap: 5px; margin-top: 10px; }
-.resonant-warnings > div { padding: 7px 9px; border-left: 2px solid var(--cyan); color: #9eb9c2; background: rgba(78,201,224,.05); font-size: 9px; }
-.resonant-warnings > .warning { border-color: var(--amber); color: #d8c4a7; background: rgba(255,180,84,.06); }
-.resonant-warnings > .danger { border-color: var(--warn); color: #e4b1ac; background: rgba(255,107,91,.06); }
+.resonant-warnings > div { padding: 7px 9px; border-left: 2px solid var(--cyan); color: var(--slate); background: var(--row-hover-wash); font-size: 9px; }
+.resonant-warnings > .warning { border-color: var(--amber); color: var(--amber); background: var(--note-cover); }
+.resonant-warnings > .danger { border-color: var(--warn); color: var(--error-text); background: var(--destructive-surface); }
 
 .delta-v-drawer-body { display: block; overflow: hidden; }
 .delta-v-planner { display: flex; height: 100%; min-height: 0; flex-direction: column; overflow: hidden; }
@@ -133,7 +133,7 @@
 .delta-v-configuration-toggle > strong { display: inline-flex; flex: 0 0 auto; align-items: center; gap: 7px; color: var(--slate); font-size: 10px; letter-spacing: .08em; }
 .delta-v-configuration-toggle i { color: var(--cyan); font-style: normal; font-size: 10px; }
 .delta-v-configuration-toggle:hover, .delta-v-configuration-toggle:focus-visible { background: rgba(78,201,224,.07); }
-.delta-v-configuration-toggle:hover > strong, .delta-v-configuration-toggle:focus-visible > strong { color: #c9dce7; }
+.delta-v-configuration-toggle:hover > strong, .delta-v-configuration-toggle:focus-visible > strong { color: var(--text-primary); }
 .delta-v-live-badge { display: inline-block; margin-left: 7px; padding: 2px 4px; border: 1px solid rgba(78,201,224,.45); color: var(--cyan); font: 9px var(--mono); letter-spacing: .08em; vertical-align: 2px; }
 .delta-v-live-badge.modeled { border-color: rgba(231,168,82,.45); color: var(--amber); }
 .delta-v-controls { display: grid; grid-template-columns: minmax(0,1fr); gap: 7px; padding: 9px 16px 11px; }
@@ -159,29 +159,29 @@
 .delta-v-controls small.delta-v-input-error { color: var(--error-text); }
 .delta-v-parking-altitude > small { overflow: visible; text-overflow: clip; white-space: normal; }
 .delta-v-stop-builder.editing { padding: 6px; border: 1px solid rgba(255,180,84,.45); background: rgba(255,180,84,.035); }
-.delta-v-empty-stop { display: grid; min-height: 58px; grid-column: 2 / -1; align-content: center; gap: 5px; padding: 7px 10px; border: 1px dashed #294657; background: #070d13; }
+.delta-v-empty-stop { display: grid; min-height: 58px; grid-column: 2 / -1; align-content: center; gap: 5px; padding: 7px 10px; border: 1px dashed var(--accent-border); background: var(--surface-well); }
 .delta-v-empty-stop span { color: var(--slate); font-size: 9px; letter-spacing: .08em; }
 .delta-v-empty-stop strong { color: var(--slate-muted-text); font-size: 9px; font-weight: 400; }
 .delta-v-add-stop-row { display: flex; min-height: 44px; margin-top: 16px; align-self: start; align-items: center; justify-self: end; gap: 6px; }
 .delta-v-add-stop-row button { min-height: 30px; padding: 5px 10px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 10px var(--mono); letter-spacing: .04em; text-transform: uppercase; }
-.delta-v-add-stop-row button:hover, .delta-v-add-stop-row button:focus-visible { border-color: var(--cyan); background: #102633; }
-.delta-v-add-stop-row button.secondary { border-color: var(--rule-bright); color: var(--slate); background: #0c141e; }
+.delta-v-add-stop-row button:hover, .delta-v-add-stop-row button:focus-visible { border-color: var(--cyan); background: var(--control-pressed); }
+.delta-v-add-stop-row button.secondary { border-color: var(--rule-bright); color: var(--slate); background: var(--control-surface); }
 .delta-v-add-stop-row button:disabled { opacity: .4; cursor: not-allowed; }
 .delta-v-add-stop-row button, .delta-v-plan-library-actions button, .delta-v-save-bar button, .delta-v-route-window-actions button, .delta-v-porkchop-button, .delta-v-add-step button, .delta-v-stay-control button, .delta-v-reset-button, .delta-v-saved-plans-button, .delta-v-assumptions-button { border-radius: var(--surface-radius-face); background: var(--surface-raised-face); box-shadow: var(--surface-depth-control); }
 .delta-v-plan-library-actions button.delete, .delta-v-route-stop-actions button:last-child, .delta-v-custom-actions button { box-shadow: var(--surface-depth-control); }
 .delta-v-endpoint-segments input:disabled + span { opacity: .35; cursor: not-allowed; }
-.delta-v-plan-library-empty { padding: 7px 9px; border: 1px dashed #294657; color: var(--slate-muted-text); font-size: 9px; }
+.delta-v-plan-library-empty { padding: 7px 9px; border: 1px dashed var(--accent-border); color: var(--slate-muted-text); font-size: 9px; }
 .delta-v-plan-library-list { display: grid; gap: 4px; }
-.delta-v-plan-library-list article { display: grid; grid-template-columns: minmax(150px,1fr) auto; align-items: center; gap: 8px; padding: 6px 7px; border: 1px solid var(--rule); background: #091119; }
+.delta-v-plan-library-list article { display: grid; grid-template-columns: minmax(150px,1fr) auto; align-items: center; gap: 8px; padding: 6px 7px; border: 1px solid var(--rule); background: var(--surface-well); }
 .delta-v-plan-library-list article.pinned { box-shadow: inset 2px 0 var(--green); background: rgba(126,231,135,.04); }
-.delta-v-plan-library-list article.loaded { border-color: #3a697d; background: rgba(78,201,224,.055); }
+.delta-v-plan-library-list article.loaded { border-color: var(--accent-border-hover); background: var(--row-hover-wash); }
 .delta-v-plan-library-list article > div:first-child { display: grid; min-width: 0; gap: 2px; }
 .delta-v-plan-library-list article strong { overflow: hidden; color: var(--text-primary); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-plan-library-list article span { overflow: hidden; color: var(--slate); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-plan-library-actions { display: flex; gap: 4px; }
 .delta-v-plan-library-actions button { min-height: 29px; padding: 4px 7px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 10px var(--mono); }
 .delta-v-plan-library-actions button.active { border-color: rgba(126,231,135,.45); color: var(--green); }
-.delta-v-plan-library-actions button.delete { border-color: #573b43; color: var(--error-text); background: #120b0f; }
+.delta-v-plan-library-actions button.delete { border-color: var(--destructive-border); color: var(--error-text); background: var(--destructive-surface); }
 .delta-v-plan-library-actions button:disabled { opacity: .65; cursor: default; }
 .delta-v-error { margin-bottom: 0; }
 .delta-v-output { display: grid; min-height: min(360px,100%); flex: 1; grid-template-columns: minmax(0,1fr); grid-template-rows: auto minmax(0,1fr); grid-template-areas: "summary" "route"; gap: 8px; padding: 9px 16px 11px; overflow: hidden; }
@@ -202,7 +202,7 @@
 .delta-v-save-actions button { flex: 1 1 auto; }
 .delta-v-save-bar small { grid-column: 1 / -1; align-self: center; color: var(--green); font-size: 9px; }
 .delta-v-save-bar small.error { color: var(--error-text); }
-.delta-v-total { grid-area: budget-total; padding: 12px 15px; border: 1px solid var(--amber-accent); border-left: 3px solid var(--amber); background: linear-gradient(100deg,rgba(255,180,84,.09),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-total { grid-area: budget-total; padding: 12px 15px; border: 1px solid var(--amber-accent); border-left: 3px solid var(--amber); background: linear-gradient(100deg,var(--note-cover),var(--panel-translucent)); box-shadow: var(--surface-depth-control); }
 .delta-v-total > span, .delta-v-stat-grid span { display: block; color: var(--slate); font-size: 9px; letter-spacing: .07em; text-transform: uppercase; }
 .delta-v-total > strong { display: block; margin-top: 6px; color: var(--amber); font-size: clamp(24px,3vw,34px); letter-spacing: -.035em; }
 .delta-v-total > small, .delta-v-stat-grid small { display: block; margin-top: 5px; color: var(--slate-muted-text); font-size: 9px; }
@@ -222,14 +222,14 @@
 .delta-v-route-window-actions { display: flex; min-width: 0; align-items: center; justify-content: flex-end; gap: 7px; }
 .delta-v-route-window-actions > span { color: var(--amber); font-size: 10px; letter-spacing: .03em; text-align: right; white-space: nowrap; }
 .delta-v-route-window-actions button { min-height: 29px; padding: 5px 9px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 10px var(--mono); letter-spacing: .04em; white-space: nowrap; }
-.delta-v-route-window-actions button:hover:not(:disabled), .delta-v-route-window-actions button:focus-visible { border-color: var(--cyan); background: #102633; }
+.delta-v-route-window-actions button:hover:not(:disabled), .delta-v-route-window-actions button:focus-visible { border-color: var(--cyan); background: var(--control-pressed); }
 .delta-v-route-window-actions button:disabled { opacity: .4; cursor: not-allowed; }
 .delta-v-route-window-error { margin: 0; padding: 6px 13px; border-bottom: 1px solid rgba(201,104,91,.35); color: var(--error-text); background: rgba(201,104,91,.07); font-size: 10px; }
 .delta-v-route-list { min-height: 0; flex: 1; overflow-x: hidden; overflow-y: auto; }
 .delta-v-leg { display: grid; grid-template-columns: 38px minmax(0,1fr) auto; align-items: center; gap: 11px; min-height: 66px; padding: 9px 13px 9px 8px; border-bottom: 1px solid var(--rule); }
 .delta-v-leg:last-child { border-bottom: 0; }
 .delta-v-leg-marker { position: relative; display: grid; align-self: stretch; place-items: center; }
-.delta-v-leg-marker span { position: relative; z-index: 1; display: grid; width: 31px; height: 31px; place-items: center; border: 1px solid var(--accent-border); border-radius: 50%; color: var(--cyan); background: #09131b; font-size: 9px; }
+.delta-v-leg-marker span { position: relative; z-index: 1; display: grid; width: 31px; height: 31px; place-items: center; border: 1px solid var(--accent-border); border-radius: 50%; color: var(--cyan); background: var(--control-surface); font-size: 9px; }
 .delta-v-leg-marker i { position: absolute; top: -10px; bottom: -10px; left: 50%; border-left: 1px dotted var(--accent-border); }
 .delta-v-route-list > .delta-v-leg:first-child .delta-v-leg-marker i { top: 37px; }
 .delta-v-leg > div:nth-child(2) { min-width: 0; }
@@ -237,7 +237,7 @@
 .delta-v-leg > div:nth-child(2) strong { color: var(--text-primary); font-size: 12px; }
 .delta-v-leg > div:nth-child(2) small { margin-top: 4px; color: var(--slate); font-size: 10px; }
 .delta-v-leg-options { display: flex; flex-wrap: wrap; gap: 4px 9px; margin-top: 6px; }
-.delta-v-leg-options label { display: inline-flex; align-items: center; gap: 5px; min-width: 0; color: #9eb9c2; font-size: 10px; line-height: 1.25; cursor: pointer; }
+.delta-v-leg-options label { display: inline-flex; align-items: center; gap: 5px; min-width: 0; color: var(--slate); font-size: 10px; line-height: 1.25; cursor: pointer; }
 .delta-v-leg-options input { width: 12px; height: 12px; margin: 0; flex: 0 0 auto; accent-color: var(--cyan); }
 .delta-v-landing-options { align-items: end; }
 .delta-v-leg-options .delta-v-inline-reserve { display: grid; grid-template-columns: minmax(115px,auto) 125px; align-items: center; gap: 7px; cursor: default; }
@@ -262,38 +262,38 @@
 .delta-v-leg-advisories { display: flex; flex-wrap: wrap; align-items: center; gap: 4px 6px; margin-top: 4px; }
 .delta-v-leg-advisories > .delta-v-craft-note,
 .delta-v-leg-advisories > .delta-v-thermal-note { display: flex; width: fit-content; max-width: 100%; margin: 0; padding: 4px 8px; line-height: 1.3; letter-spacing: .03em; white-space: normal; }
-.delta-v-leg-advisories > .delta-v-craft-note { border: 1px solid rgba(78,201,224,.4); color: #b8e7ef; background: rgba(78,201,224,.07); }
+.delta-v-leg-advisories > .delta-v-craft-note { border: 1px solid var(--accent-border); color: var(--cyan); background: var(--row-hover-wash); }
 .delta-v-leg-advisories > .delta-v-thermal-note { border: 1px solid rgba(255,180,84,.42); color: var(--amber); background: rgba(255,180,84,.07); }
-.delta-v-leg-advisories > .delta-v-thermal-note.not-detected { border-color: rgba(255,107,91,.48); color: #ff9b8f; background: rgba(255,107,91,.08); }
+.delta-v-leg-advisories > .delta-v-thermal-note.not-detected { border-color: var(--destructive-border); color: var(--error-text); background: var(--destructive-surface); }
 .delta-v-leg-heading { display: flex; align-items: center; gap: 8px; }
 .delta-v-porkchop-button { min-height: 26px; flex: 0 0 auto; padding: 3px 6px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 10px var(--mono); letter-spacing: .05em; }
-.delta-v-porkchop-button:hover, .delta-v-porkchop-button:focus-visible { border-color: var(--cyan); background: #102633; }
-.delta-v-leg-timeline { color: #9fcbd4 !important; }
+.delta-v-porkchop-button:hover, .delta-v-porkchop-button:focus-visible { border-color: var(--cyan); background: var(--control-pressed); }
+.delta-v-leg-timeline { color: var(--cyan) !important; }
 .delta-v-leg-timeline.conflict { color: var(--error-text) !important; }
 .delta-v-leg.ascent .delta-v-leg-side > b, .delta-v-leg.deorbit .delta-v-leg-side > b, .delta-v-leg.landing .delta-v-leg-side > b { color: var(--amber); }
 .delta-v-leg.transfer .delta-v-leg-side > b { color: var(--slate); }
 .delta-v-leg.custom { background: rgba(255,180,84,.035); box-shadow: inset 2px 0 rgba(255,180,84,.55); }
-.delta-v-custom-label input { width: 100%; min-height: 31px; padding: 5px 8px; border: 1px solid var(--rule-bright); outline: 0; color: #f2d3a2; background: var(--surface-well); box-shadow: var(--surface-depth-deep); box-sizing: border-box; font: 10px var(--mono); }
+.delta-v-custom-label input { width: 100%; min-height: 31px; padding: 5px 8px; border: 1px solid var(--rule-bright); outline: 0; color: var(--text-value); background: var(--surface-well); box-shadow: var(--surface-depth-deep); box-sizing: border-box; font: 10px var(--mono); }
 .delta-v-custom-label input:focus, .delta-v-custom-actions input:focus { border-color: var(--amber); }
 .delta-v-custom-actions { display: grid; grid-template-columns: 140px 28px; align-items: center; gap: 6px; }
 .delta-v-custom-actions .resonant-input-unit input { width: 100%; min-height: 31px; padding: 5px 48px 5px 8px; border: 1px solid var(--rule-bright); outline: 0; color: var(--amber); background: var(--surface-well); box-shadow: var(--surface-depth-deep); box-sizing: border-box; font: 10px var(--mono); }
 .delta-v-custom-actions .resonant-input-unit > span { top: 9px; right: 29px; font-size: 9px; }
-.delta-v-custom-actions button { width: 28px; height: 28px; border: 1px solid #6c3e3e; color: #e59898; background: #1c1010; cursor: pointer; font-size: 15px; }
+.delta-v-custom-actions button { width: 28px; height: 28px; border: 1px solid var(--destructive-border); color: var(--error-text); background: var(--destructive-surface); cursor: pointer; font-size: 15px; }
 .delta-v-add-step { position: relative; z-index: 3; height: 0; }
 .delta-v-add-step::before { position: absolute; z-index: 1; top: -16px; bottom: -16px; left: 27px; border-left: 1px dotted var(--accent-border); content: ""; }
-.delta-v-add-step button { position: absolute; z-index: 2; top: -11px; left: 16px; display: grid; width: 22px; min-width: 22px !important; height: 22px; min-height: 22px !important; padding: 0 0 1px; place-items: center; border: 1px solid #49677a; border-radius: 50%; color: var(--cyan); background: #0c1821; cursor: pointer; font: 15px/1 var(--mono); }
-.delta-v-add-step button:hover, .delta-v-add-step button:focus-visible { border-color: var(--cyan); color: #d8f8ff; background: #153143; }
+.delta-v-add-step button { position: absolute; z-index: 2; top: -11px; left: 16px; display: grid; width: 22px; min-width: 22px !important; height: 22px; min-height: 22px !important; padding: 0 0 1px; place-items: center; border: 1px solid var(--accent-border); border-radius: 50%; color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 15px/1 var(--mono); }
+.delta-v-add-step button:hover, .delta-v-add-step button:focus-visible { border-color: var(--cyan); color: var(--text-primary); background: var(--control-pressed); }
 
 .delta-v-stay-control { display: grid; width: 100%; max-width: 420px; grid-template-columns: minmax(150px,auto) auto; align-items: center; gap: 8px; padding: 5px 7px; border: 1px solid rgba(78,201,224,.35); background: rgba(78,201,224,.045); }
-.delta-v-stay-control > span { color: #b9cbd7; font-size: 10px; font-weight: 700; }
+.delta-v-stay-control > span { color: var(--text-value); font-size: 10px; font-weight: 700; }
 .delta-v-stay-control > div { display: flex; align-items: center; gap: 4px; }
 .delta-v-stay-control button { display: grid; width: 27px; height: 27px; padding: 0; place-items: center; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 13px var(--mono); }
 .delta-v-stay-control button:disabled { opacity: .35; cursor: default; }
 .delta-v-stay-control label { display: flex; align-items: center; gap: 5px; color: var(--slate); font-size: 10px; }
-.delta-v-stay-control input { width: 54px; min-height: 27px; padding: 3px 5px; border: 1px solid #294657; color: var(--text-primary); background: var(--surface-well); box-shadow: var(--surface-depth-deep); font: 10px var(--mono); text-align: right; }
+.delta-v-stay-control input { width: 54px; min-height: 27px; padding: 3px 5px; border: 1px solid var(--accent-border); color: var(--text-primary); background: var(--surface-well); box-shadow: var(--surface-depth-deep); font: 10px var(--mono); text-align: right; }
 .delta-v-calculated-stay { display: grid; width: 100%; max-width: 420px; min-height: 48px; align-content: center; gap: 3px; padding: 7px 10px; border: 1px solid rgba(255,180,84,.38); background: rgba(255,180,84,.045); }
 .delta-v-calculated-stay > span { color: var(--amber); font-size: 10px; font-weight: 700; letter-spacing: .06em; }
-.delta-v-calculated-stay > strong { color: #e3edf2; font-size: 13px; font-variant-numeric: tabular-nums; }
+.delta-v-calculated-stay > strong { color: var(--text-primary); font-size: 13px; font-variant-numeric: tabular-nums; }
 .delta-v-calculated-stay > small { overflow: hidden; color: var(--slate); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-timeline-conflict { margin: 0; padding: 7px 13px; border-bottom: 1px solid rgba(201,104,91,.35); color: var(--error-text); background: rgba(201,104,91,.07); font-size: 10px; }
 
@@ -302,9 +302,9 @@
 .porkchop-modal > header { display: flex; flex: 0 0 auto; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 15px; border-bottom: 1px solid var(--rule); background: linear-gradient(90deg,rgba(78,201,224,.09),transparent); }
 .porkchop-modal > header div { display: grid; gap: 3px; }
 .porkchop-modal > header span { color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .14em; }
-.porkchop-modal > header h3 { margin: 0; color: #e1eaf0; font-size: 14px; }
-.porkchop-modal > header button { width: 29px; height: 29px; border: 1px solid var(--accent-border); color: var(--slate); background: #0a141c; cursor: pointer; font: 18px var(--mono); }
-.porkchop-constraint { margin: 0; padding: 8px 15px; border-bottom: 1px solid var(--rule); color: #b9cbd7; background: rgba(255,180,84,.055); font-size: 9px; }
+.porkchop-modal > header h3 { margin: 0; color: var(--text-primary); font-size: 14px; }
+.porkchop-modal > header button { width: 29px; height: 29px; border: 1px solid var(--accent-border); color: var(--slate); background: var(--control-surface); cursor: pointer; font: 18px var(--mono); }
+.porkchop-constraint { margin: 0; padding: 8px 15px; border-bottom: 1px solid var(--rule); color: var(--text-value); background: var(--note-cover); font-size: 9px; }
 .porkchop-empty { display: grid; min-height: 300px; padding: 30px; place-content: center; justify-items: center; gap: 9px; text-align: center; }
 .porkchop-empty strong { color: var(--text-primary); font-size: 13px; }
 .porkchop-empty small { max-width: 460px; color: var(--slate); font-size: 9px; }
@@ -316,7 +316,7 @@
 .porkchop-canvas { width: 100%; height: 100%; min-height: 240px; border: 1px solid #263f4f; background: #0a141c; cursor: crosshair; }
 .porkchop-legend { display: flex; align-items: center; gap: 7px; padding: 4px 16px 8px 34px; color: var(--slate); font: 9px var(--mono); }
 .porkchop-legend i { width: min(240px,30vw); height: 7px; background: linear-gradient(90deg,rgb(50,202,178),rgb(78,201,224),rgb(111,142,192),rgb(181,116,124),rgb(226,157,82)); }
-.porkchop-legend b { margin-left: 8px; color: #c7d6df; font-weight: 400; }
+.porkchop-legend b { margin-left: 8px; color: var(--text-value); font-weight: 400; }
 .porkchop-readouts { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); border-block: 1px solid var(--rule); background: rgba(78,201,224,.025); }
 .porkchop-hover-readout, .porkchop-ideal-readout { display: flex; min-width: 0; flex-wrap: wrap; align-items: center; gap: 6px 14px; padding: 7px 16px; color: var(--slate); font-size: 9px; }
 .porkchop-hover-readout { border-right: 1px solid var(--rule); }
@@ -341,7 +341,7 @@
 .porkchop-range-filter { grid-template-columns: repeat(2,minmax(0,1fr)); }
 .porkchop-range-filter > span { grid-column: 1 / -1; }
 .porkchop-range-filter label { display: grid; min-width: 0; gap: 2px; }
-.porkchop-range-filter label b { min-width: 0; overflow: hidden; color: #c7d6df; font: 9px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.porkchop-range-filter label b { min-width: 0; overflow: hidden; color: var(--text-value); font: 9px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
 .porkchop-range-filter input { width: 100%; min-height: 16px; accent-color: var(--cyan); cursor: pointer; }
 .porkchop-evaluation { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); margin: 10px 16px 0; border: 1px solid var(--rule); }
 .porkchop-evaluation > div { display: grid; gap: 4px; padding: 9px; border-right: 1px solid var(--rule); }
@@ -350,7 +350,7 @@
 .porkchop-evaluation strong { color: var(--text-primary); font-size: 10px; }
 .porkchop-error { margin: 8px 16px 0; color: var(--error-text); font-size: 10px; }
 .porkchop-modal > footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; }
-.porkchop-modal > footer button:last-child { border-color: var(--cyan); color: #071015; background: var(--cyan); }
+.porkchop-modal > footer button:last-child { border-color: var(--cyan); color: var(--on-accent); background: var(--cyan); }
 .porkchop-modal button:disabled { opacity: .42; cursor: not-allowed; }
 
 @media (max-width: 640px) {

--- a/frontend/src/resonantOrbit/resonantOrbit.css
+++ b/frontend/src/resonantOrbit/resonantOrbit.css
@@ -173,7 +173,7 @@
 .delta-v-plan-library-empty { padding: 7px 9px; border: 1px dashed var(--accent-border); color: var(--slate-muted-text); font-size: 9px; }
 .delta-v-plan-library-list { display: grid; gap: 4px; }
 .delta-v-plan-library-list article { display: grid; grid-template-columns: minmax(150px,1fr) auto; align-items: center; gap: 8px; padding: 6px 7px; border: 1px solid var(--rule); background: var(--surface-well); }
-.delta-v-plan-library-list article.pinned { box-shadow: inset 2px 0 var(--green); background: rgba(126,231,135,.04); }
+.delta-v-plan-library-list article.pinned { box-shadow: inset 2px 0 var(--green); background: color-mix(in srgb,var(--green) 6%,var(--surface-well)); }
 .delta-v-plan-library-list article.loaded { border-color: var(--accent-border-hover); background: var(--row-hover-wash); }
 .delta-v-plan-library-list article > div:first-child { display: grid; min-width: 0; gap: 2px; }
 .delta-v-plan-library-list article strong { overflow: hidden; color: var(--text-primary); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
@@ -481,33 +481,33 @@
   }
 }
 .delta-v-modal-backdrop { position: absolute; z-index: 20; inset: 0; display: grid; padding: 20px; place-items: center; background: rgba(0,0,0,.72); }
-.delta-v-modal { width: min(620px,92%); max-height: min(640px,88vh); border: 1px solid var(--rule-bright); color: var(--text-primary); background: #081018; box-shadow: 0 20px 65px rgba(0,0,0,.7); }
-.delta-v-modal > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; padding: 14px 16px; border-bottom: 1px solid var(--rule); }
+.delta-v-modal { width: min(620px,92%); max-height: min(640px,88vh); border: 1px solid var(--rule-bright); color: var(--text-primary); background: var(--surface-bezel); box-shadow: var(--surface-depth-plate); }
+.delta-v-modal > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; padding: 14px 16px; border-bottom: 1px solid var(--rule); background: var(--surface-rail); box-shadow: var(--surface-depth-engraved); }
 .delta-v-modal > header span { color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .12em; }
 .delta-v-modal h3 { margin: 4px 0 0; color: var(--amber); font-size: 15px; text-transform: uppercase; }
 .delta-v-modal > header button { display: grid; width: 24px; min-width: 24px; height: 24px; padding: 0; place-items: center; border: 0; color: var(--text-primary); background: transparent; cursor: pointer; font-size: 21px; }
-.delta-v-modal ul { display: grid; max-height: 470px; gap: 10px; margin: 0; padding: 16px 22px 18px 34px; overflow: auto; color: #a9bfca; font-size: 10px; line-height: 1.5; }
+.delta-v-modal ul { display: grid; max-height: 470px; gap: 10px; margin: 0; padding: 16px 22px 18px 34px; overflow: auto; color: var(--state-body-text); font-size: 10px; line-height: 1.5; }
 .delta-v-reset-modal { width: min(520px,92%); }
-.delta-v-reset-modal > p { margin: 0; padding: 18px 16px; color: #a9bfca; font-size: 10px; line-height: 1.55; }
-.delta-v-reset-actions { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--rule); background: #080e15; }
-.delta-v-reset-actions button { min-height: 32px; padding: 7px 11px; border: 1px solid var(--accent-border); color: var(--cyan); background: rgba(78,201,224,.05); cursor: pointer; font: 10px var(--mono); letter-spacing: .05em; }
-.delta-v-reset-actions button:hover, .delta-v-reset-actions button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.11); }
-.delta-v-reset-actions button:last-child { border-color: var(--amber-accent); color: var(--amber); background: rgba(255,180,84,.08); }
-.delta-v-reset-actions button:last-child:hover, .delta-v-reset-actions button:last-child:focus-visible { border-color: var(--amber); background: rgba(255,180,84,.16); }
+.delta-v-reset-modal > p { margin: 0; padding: 18px 16px; color: var(--state-body-text); font-size: 10px; line-height: 1.55; }
+.delta-v-reset-actions { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--rule); background: var(--surface-rail); }
+.delta-v-reset-actions button { min-height: 32px; padding: 7px 11px; border: 1px solid var(--accent-border); color: var(--cyan); background: color-mix(in srgb,var(--cyan) 7%,var(--control-surface)); cursor: pointer; font: 10px var(--mono); letter-spacing: .05em; }
+.delta-v-reset-actions button:hover, .delta-v-reset-actions button:focus-visible { border-color: var(--cyan); background: color-mix(in srgb,var(--cyan) 14%,var(--control-surface-hover)); }
+.delta-v-reset-actions button:last-child { border-color: var(--amber-accent); color: var(--amber); background: color-mix(in srgb,var(--amber) 9%,var(--control-surface)); }
+.delta-v-reset-actions button:last-child:hover, .delta-v-reset-actions button:last-child:focus-visible { border-color: var(--amber); background: color-mix(in srgb,var(--amber) 17%,var(--control-surface-hover)); }
 .delta-v-plan-library-modal { display: flex; width: min(720px,92%); min-height: 180px; flex-direction: column; overflow: hidden; }
 .delta-v-plan-library-header-actions { display: flex; flex: 0 0 auto; flex-direction: row-reverse; align-items: center; gap: 8px; }
 .delta-v-plan-library-header-actions label { position: relative; display: inline-flex; cursor: pointer; }
 .delta-v-plan-library-header-actions label input { position: absolute; width: 1px; height: 1px; opacity: 0; }
 .delta-v-plan-library-header-actions label span { display: inline-flex; min-height: 26px; align-items: center; padding: 3px 7px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); font-size: 10px; letter-spacing: .05em; }
-.delta-v-plan-library-header-actions label input:checked + span { border-color: rgba(126,231,135,.48); color: var(--green); background: rgba(126,231,135,.07); }
+.delta-v-plan-library-header-actions label input:checked + span { border-color: color-mix(in srgb,var(--green) 48%,transparent); color: var(--green); background: color-mix(in srgb,var(--green) 8%,var(--control-surface)); }
 .delta-v-plan-library-header-actions label:focus-within span { outline: 1px solid var(--cyan); outline-offset: 2px; }
-.delta-v-plan-library-modal > p { margin: 0; padding: 10px 16px; border-bottom: 1px solid var(--rule); color: var(--slate); font-size: 9px; }
+.delta-v-plan-library-modal > p { margin: 0; padding: 10px 16px; border-bottom: 1px solid var(--rule); color: var(--slate); background: var(--surface-plate); font-size: 9px; }
 .delta-v-plan-library-modal > .delta-v-plan-library-empty { display: grid; justify-items: center; gap: 10px; margin: 16px; padding: 28px 16px; text-align: center; }
 .delta-v-plan-library-empty button { min-height: 30px; padding: 5px 9px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 10px var(--mono); }
-.delta-v-plan-library-modal > .delta-v-plan-library-list { min-height: 0; margin: 0; padding: 10px 12px 12px; overflow: auto; }
+.delta-v-plan-library-modal > .delta-v-plan-library-list { min-height: 0; margin: 0; padding: 10px 12px 12px; overflow: auto; background: var(--surface-bezel); }
 .delta-v-plan-library-group { display: grid; gap: 4px; }
 .delta-v-plan-library-group + .delta-v-plan-library-group { margin-top: 8px; }
-.delta-v-plan-library-group-heading { display: flex; align-items: stretch; border-block: 1px solid var(--rule); background: rgba(255,180,84,.045); }
+.delta-v-plan-library-group-heading { display: flex; align-items: stretch; border-block: 1px solid var(--rule); background: color-mix(in srgb,var(--amber) 6%,var(--surface-plate)); }
 .delta-v-plan-library-group-heading h4 { min-width: 0; margin: 0; padding: 5px 7px; color: var(--amber); font-size: 10px; letter-spacing: .07em; text-transform: uppercase; }
 .delta-v-plan-library-group-heading button { margin-left: auto; padding: 4px 8px; border: 0; border-left: 1px solid var(--accent-border); color: var(--cyan); background: var(--control-surface); cursor: pointer; font: 10px var(--mono); }
 .resonant-drawer > footer.delta-v-footer { color: var(--slate); }
@@ -1962,4 +1962,174 @@
 @media (max-width: 760px) {
   .resonant-drawer.delta-v-drawer > header { padding: 10px 12px; }
   .resonant-drawer.delta-v-drawer > header p { display: none; }
+}
+
+/* Delta-V plan management is a small form and a separate utility group, not one fused toolbar. */
+.delta-v-save-heading,
+.delta-v-header-actions-heading {
+  min-width: 0;
+  color: var(--slate);
+  font: 700 9px/1.2 var(--mono);
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+.delta-v-save-heading {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.delta-v-save-heading > span,
+.delta-v-header-actions-heading { color: var(--cyan); }
+.delta-v-save-heading > span { flex: 0 0 auto; white-space: nowrap; }
+.delta-v-save-heading .delta-v-save-feedback {
+  min-width: 0;
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  color: var(--green);
+  background: transparent;
+  box-shadow: none;
+  font: 700 9px/1.2 var(--mono);
+  letter-spacing: .02em;
+  text-align: right;
+  text-overflow: ellipsis;
+  text-transform: none;
+  white-space: nowrap;
+}
+.delta-v-save-heading .delta-v-save-feedback.error { color: var(--error-text); }
+.delta-v-header-action-buttons {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.resonant-drawer > header .delta-v-header-action-buttons > button:last-child {
+  display: grid;
+  width: 34px;
+  min-width: 34px;
+  height: 34px;
+  padding: 0;
+  place-items: center;
+}
+
+@media (min-width: 761px) {
+  .resonant-drawer.delta-v-drawer > header {
+    grid-template-columns: minmax(220px,.4fr) minmax(650px,1.6fr);
+    align-items: center;
+    gap: 16px;
+    padding: 7px 12px;
+  }
+  .delta-v-header-controls {
+    display: grid;
+    width: 100%;
+    min-width: 0;
+    grid-template-columns: minmax(0,1fr) max-content;
+    align-items: end;
+    gap: 12px;
+  }
+  .delta-v-save-slot,
+  .delta-v-save-slot .delta-v-save-bar {
+    display: grid;
+    width: 100%;
+    min-width: 0;
+  }
+  .delta-v-save-slot .delta-v-save-bar {
+    grid-template-columns: minmax(190px,1fr) auto;
+    grid-template-rows: 11px 34px;
+    align-items: stretch;
+    gap: 3px 7px;
+  }
+  .delta-v-save-slot .delta-v-save-bar label {
+    display: block;
+    min-width: 0;
+    grid-column: 1;
+    grid-row: 2;
+  }
+  .delta-v-save-slot .delta-v-save-bar label > span { display: none; }
+  .delta-v-save-slot .delta-v-save-bar input,
+  .delta-v-save-slot .delta-v-save-actions button,
+  .delta-v-header-action-buttons > button {
+    box-sizing: border-box;
+    height: 34px;
+    min-height: 34px !important;
+  }
+  .delta-v-save-slot .delta-v-save-bar input {
+    border-radius: var(--surface-radius-face);
+  }
+  .delta-v-save-slot .delta-v-save-actions {
+    display: flex;
+    min-width: 0;
+    grid-column: 2;
+    grid-row: 2;
+    align-items: stretch;
+    gap: 6px;
+  }
+  .delta-v-save-slot .delta-v-save-actions button,
+  .delta-v-save-slot .delta-v-save-actions button:last-child {
+    border: 1px solid var(--accent-border);
+    border-radius: var(--surface-radius-face);
+  }
+  .delta-v-save-slot .delta-v-save-actions button:first-child {
+    border-color: var(--cyan);
+    color: var(--on-accent);
+    background: var(--cyan);
+  }
+  .resonant-drawer > header .delta-v-save-slot .delta-v-save-actions button:first-child:hover:not(:disabled),
+  .resonant-drawer > header .delta-v-save-slot .delta-v-save-actions button:first-child:focus-visible {
+    border-color: var(--cyan);
+    color: var(--on-accent);
+    background: var(--cyan);
+  }
+  .delta-v-save-slot .delta-v-save-actions button.secondary {
+    color: var(--text-value);
+    background: var(--surface-raised-face);
+  }
+  .delta-v-save-heading { grid-row: 1; }
+  .delta-v-header-actions {
+    display: grid;
+    min-width: 0;
+    grid-template-rows: 11px 34px;
+    align-items: stretch;
+    gap: 3px;
+    padding-left: 12px;
+    border-left: 1px solid var(--surface-seam);
+  }
+  .delta-v-header-actions-heading { grid-row: 1; }
+  .delta-v-header-action-buttons { grid-row: 2; }
+  .resonant-drawer > header .delta-v-assumptions-button {
+    display: block;
+    width: auto;
+    min-width: 0;
+    padding-inline: 8px;
+    font-size: 10px;
+  }
+}
+
+@media (min-width: 761px) and (max-width: 979px) {
+  .resonant-drawer.delta-v-drawer > header { grid-template-columns: minmax(0,1fr); }
+  .resonant-drawer.delta-v-drawer > header > div:first-child { display: none; }
+}
+
+@media (max-width: 760px) {
+  .resonant-drawer.delta-v-drawer > header { display: grid; grid-template-columns: minmax(0,1fr); }
+  .delta-v-header-controls { display: grid; width: 100%; gap: 10px; }
+  .delta-v-save-slot .delta-v-save-bar {
+    display: grid;
+    grid-template-columns: minmax(0,1fr);
+    gap: 5px;
+  }
+  .delta-v-save-heading,
+  .delta-v-save-slot .delta-v-save-bar label,
+  .delta-v-save-slot .delta-v-save-actions { grid-column: 1; }
+  .delta-v-save-slot .delta-v-save-actions { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 7px; }
+  .delta-v-save-slot .delta-v-save-actions button:only-child { grid-column: 1 / -1; }
+  .delta-v-header-actions { display: grid; gap: 5px; padding-top: 9px; border-top: 1px solid var(--surface-seam); }
+  .delta-v-header-action-buttons { display: grid; grid-template-columns: minmax(0,1fr) auto auto 44px; gap: 7px; }
+  .resonant-drawer > header .delta-v-header-action-buttons > button:last-child { width: 44px; min-width: 44px; height: 44px; }
+  .resonant-drawer > header .delta-v-assumptions-button { min-width: 62px; }
 }

--- a/frontend/src/resonantOrbit/resonantOrbit.css
+++ b/frontend/src/resonantOrbit/resonantOrbit.css
@@ -186,9 +186,12 @@
 .delta-v-error { margin-bottom: 0; }
 .delta-v-output { display: grid; min-height: min(360px,100%); flex: 1; grid-template-columns: minmax(0,1fr); grid-template-rows: auto minmax(0,1fr); grid-template-areas: "summary" "route"; gap: 8px; padding: 9px 16px 11px; overflow: hidden; }
 .delta-v-summary { display: grid; grid-area: summary; grid-template-columns: minmax(270px,.65fr) minmax(0,1.35fr); grid-template-areas: "budget-head budget-head" "budget-total budget-stats"; gap: 6px; min-width: 0; }
-.delta-v-summary > header { display: flex; grid-area: budget-head; align-items: center; justify-content: space-between; gap: 10px; }
+.delta-v-summary > header { display: grid; grid-area: budget-head; grid-template-columns: minmax(180px,1fr) minmax(220px,300px) auto; align-items: end; gap: 10px; }
 .delta-v-summary > header span, .delta-v-route > header span { color: var(--cyan); font-size: 9px; font-weight: 700; letter-spacing: .12em; }
 .delta-v-summary > header h3 { margin: 3px 0 0; color: var(--text-primary); font-size: 14px; }
+.delta-v-summary-transfer-mode { min-width: 0; margin: 0; padding: 0; border: 0; }
+.delta-v-summary-transfer-mode > legend { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
+.delta-v-summary-transfer-mode .delta-v-transfer-mode label span { min-height: 30px; }
 .delta-v-summary-mode { display: flex; min-width: 0; align-items: center; justify-content: flex-end; gap: 8px; }
 .delta-v-summary-mode > small { overflow: hidden; color: var(--slate-muted-text); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-summary-mode > strong { flex: 0 0 auto; padding: 5px 7px; border: 1px solid rgba(126,231,135,.35); color: var(--green); font-size: 9px; letter-spacing: .06em; }
@@ -1848,7 +1851,7 @@
   .delta-v-planner:has(> .delta-v-output) > .delta-v-configuration:not(.collapsed) { max-height: calc(100% - 300px); }
   .delta-v-configuration-toggle { min-height: 36px; padding: 5px 16px; }
   .delta-v-configuration-toggle > span { display: flex; align-items: baseline; gap: 8px; }
-  .delta-v-controls { display: grid; grid-template-columns: minmax(130px,.85fr) minmax(175px,1.05fr) minmax(150px,.9fr) minmax(190px,1.1fr) auto; align-items: start; gap: 10px; padding: 8px 16px 10px; }
+  .delta-v-controls { display: grid; grid-template-columns: minmax(150px,.9fr) minmax(190px,1.1fr) minmax(170px,1fr) auto; align-items: start; gap: 10px; padding: 8px 16px 10px; }
   .delta-v-location-row, .delta-v-mission-row, .delta-v-mission-row.one-way { display: contents; }
   .delta-v-controls label { gap: 4px; }
   .delta-v-controls label > span, .delta-v-controls legend { height: 14px; line-height: 14px; }
@@ -1864,9 +1867,10 @@
 
   .delta-v-output { gap: 6px; padding: 7px 16px 8px; }
   .delta-v-summary { grid-template-columns: minmax(240px,.72fr) minmax(0,1.28fr); gap: 5px; }
-  .delta-v-summary > header { min-height: 20px; }
+  .delta-v-summary > header { min-height: 30px; }
   .delta-v-summary > header > div { display: flex; min-width: 0; align-items: baseline; gap: 8px; }
   .delta-v-summary > header h3 { margin: 0; overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+  .delta-v-summary-transfer-mode .delta-v-transfer-mode label span { min-height: 30px; }
   .delta-v-summary-mode > strong { padding: 3px 6px; }
   .delta-v-total { display: grid; align-content: center; grid-template-columns: auto 1fr; column-gap: 8px; padding: 8px 10px; }
   .delta-v-total > span { grid-column: 1; }
@@ -1938,6 +1942,9 @@
   .delta-v-location-row > :last-child, .delta-v-mission-row > :last-child { grid-column: 1 / -1; }
   .delta-v-output { min-height: 0; grid-template-rows: minmax(96px,.7fr) minmax(200px,1.3fr); }
   .delta-v-summary { min-height: 0; grid-template-columns: minmax(0,1fr); grid-template-areas: "budget-head" "budget-total" "budget-stats"; align-content: start; overflow-y: auto; overscroll-behavior: contain; scrollbar-gutter: stable; }
+  .delta-v-summary > header { grid-template-columns: minmax(0,1fr) auto; align-items: end; }
+  .delta-v-summary-transfer-mode { grid-column: 1 / -1; grid-row: 2; }
+  .delta-v-summary-mode { grid-column: 2; grid-row: 1; }
   .delta-v-stat-grid { grid-template-columns: repeat(2,minmax(0,1fr)); }
   .delta-v-margin-card { grid-template-columns: minmax(0,1fr); grid-template-rows: auto auto auto; row-gap: 5px; }
   .delta-v-margin-controls { width: 100%; min-width: 0; grid-column: 1; grid-row: 3; grid-template-columns: repeat(3,minmax(0,1fr)); grid-template-rows: repeat(2,44px); }

--- a/frontend/src/resonantOrbit/resonantOrbit.css
+++ b/frontend/src/resonantOrbit/resonantOrbit.css
@@ -518,7 +518,7 @@
 .resonant-unpin { padding: 3px 6px; border: 1px solid var(--surface-amber-face-edge); border-radius: var(--surface-radius-face); color: var(--surface-amber-face-text); background: var(--surface-amber-face); box-shadow: var(--surface-depth-control); cursor: pointer; font-size: 10px; text-transform: uppercase; }
 .resonant-edit-plan { padding: 3px 7px; border: 1px solid var(--surface-cyan-face-edge); border-radius: var(--surface-radius-face); color: var(--cyan); background: var(--surface-cyan-face); box-shadow: var(--surface-depth-control); cursor: pointer; font-size: 10px; text-transform: uppercase; }
 .resonant-editor-plan { display: grid; grid-template-columns: minmax(174px,.85fr) minmax(0,1.55fr); gap: 7px; }
-.resonant-editor-constellation, .resonant-editor-plan-details { min-width: 0; border: 1px solid var(--rule); background: #090f17; }
+.resonant-editor-constellation, .resonant-editor-plan-details { min-width: 0; border: 1px solid var(--rule); background: var(--plan-panel-ground); }
 .resonant-editor-constellation { position: relative; min-height: 164px; padding: 4px; }
 .resonant-editor-orbit-graphic { display: block; width: 100%; height: 100%; min-height: 154px; overflow: visible; }
 .resonant-editor-orbit-grid { fill: none; stroke: rgba(78,201,224,.08); stroke-width: 1; }
@@ -546,7 +546,7 @@
 .resonant-editor-plan-status i { width: 6px; height: 6px; flex: 0 0 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px rgba(126,231,135,.35); }
 .resonant-editor-plan-status.warning { color: var(--amber); }
 .resonant-editor-plan-status.warning i { background: var(--amber); box-shadow: 0 0 6px rgba(255,180,84,.35); }
-.resonant-editor-plan-status.danger { color: #ff9b90; }
+.resonant-editor-plan-status.danger { color: var(--state-red-text); }
 .resonant-editor-plan-status.danger i { background: #ff6b5b; box-shadow: 0 0 6px rgba(255,107,91,.35); }
 .resonant-flight-summary { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 5px; }
 .resonant-flight-summary > div { min-width: 0; padding: 8px; border: 1px solid var(--surface-plate-edge); border-radius: var(--surface-radius-face); background: var(--surface-well); box-shadow: var(--surface-depth-recessed); }
@@ -554,10 +554,10 @@
 .resonant-flight-summary strong { display: block; color: var(--cyan); font-size: 10px; overflow-wrap: anywhere; }
 .resonant-orbit-target-heading { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .resonant-orbit-target-state { min-width: 0; margin-top: 4px; }
-.resonant-orbit-target-status { display: block; box-sizing: border-box; width: 84px; min-width: 0; padding: 2px 7px; border: 1px solid var(--rule-bright); color: var(--slate); background: #0c141e; font-size: 9px; font-weight: 700; letter-spacing: .04em; line-height: 1.2; text-align: center; white-space: nowrap; }
-.resonant-orbit-target-status.low, .resonant-orbit-target-status.high { border-color: rgba(255,107,91,.55); color: #ff9b90; background: rgba(255,107,91,.1); }
+.resonant-orbit-target-status { display: block; box-sizing: border-box; width: 84px; min-width: 0; padding: 2px 7px; border: 1px solid var(--rule-bright); color: var(--slate); background: var(--plan-target-face); font-size: 9px; font-weight: 700; letter-spacing: .04em; line-height: 1.2; text-align: center; white-space: nowrap; }
+.resonant-orbit-target-status.low, .resonant-orbit-target-status.high { border-color: var(--state-border-red); color: var(--state-red-text); background: color-mix(in srgb,var(--danger) 10%,transparent); }
 .resonant-orbit-target-status.in-range { border-color: rgba(126,231,135,.5); color: var(--green); background: rgba(126,231,135,.09); }
-.resonant-flight-guidance { display: grid; grid-template-columns: 30px 1fr; gap: 8px; margin-top: 8px; padding: 9px; border-left: 2px solid var(--amber); background: linear-gradient(100deg,rgba(255,180,84,.09),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.resonant-flight-guidance { display: grid; grid-template-columns: 30px 1fr; gap: 8px; margin-top: 8px; padding: 9px; border-left: 2px solid var(--amber); background: var(--state-wash-amber); box-shadow: var(--state-wash-depth); }
 .resonant-flight-guidance > span { color: var(--amber); font-size: 16px; }
 .resonant-flight-guidance strong { color: var(--text-primary); font-size: 10px; text-transform: uppercase; }
 .resonant-flight-guidance p { margin: 4px 0 0; color: var(--slate); font-size: 9px; line-height: 1.45; }
@@ -578,19 +578,19 @@
 .delta-v-pinned-identity { display: flex; min-width: 0; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 7px; }
 .delta-v-pinned-identity strong { overflow: hidden; color: var(--text-primary); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-pinned-identity span { flex: 0 1 auto; color: var(--slate); font-size: 9px; text-align: right; }
-.delta-v-pinned-identity.editor { min-height: 29px; margin-bottom: 7px; padding: 6px 8px; border: 1px solid var(--rule); background: #090f17; }
+.delta-v-pinned-identity.editor { min-height: 29px; margin-bottom: 7px; padding: 6px 8px; border: 1px solid var(--rule); background: var(--plan-panel-ground); }
 .delta-v-pinned-identity.editor strong { color: var(--amber); font-size: 12px; letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-pinned-identity.editor span { flex: 0 0 auto; color: var(--green); font-size: 9px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
 .delta-v-pinned-scope { margin: -2px 0 7px; color: var(--cyan); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; }
 .delta-v-pinned-scope.legacy { color: var(--amber); }
-.delta-v-pinned-scope-warning { margin: 0 0 7px; padding: 6px 8px; border: 1px solid rgba(255,180,84,.45); color: #f0c987; background: rgba(255,180,84,.06); font-size: 10px; line-height: 1.4; }
+.delta-v-pinned-scope-warning { margin: 0 0 7px; padding: 6px 8px; border: 1px solid var(--state-border-amber); color: var(--state-amber-text); background: var(--state-wash-amber); box-shadow: var(--state-wash-depth); font-size: 10px; line-height: 1.4; }
 .delta-v-pinned-overview { display: grid; grid-template-columns: minmax(0,1.65fr) minmax(138px,.9fr); gap: 7px; }
 .delta-v-pinned-facts { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 5px; }
 .delta-v-pinned-facts > div { min-width: 0; padding: 6px 7px; border: 1px solid var(--surface-plate-edge); border-radius: var(--surface-radius-face); background: var(--surface-well); box-shadow: var(--surface-depth-recessed); }
 .delta-v-pinned-facts span, .delta-v-pinned-window span { display: block; margin-bottom: 3px; color: var(--slate); font-size: 9px; letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-pinned-facts strong { display: block; color: var(--cyan); font-size: 10px; overflow-wrap: anywhere; }
 .delta-v-editor-briefing { display: grid; grid-template-columns: minmax(0,.98fr) minmax(0,1.02fr); gap: 7px; }
-.delta-v-editor-budget, .delta-v-editor-coverage { min-width: 0; min-height: 99px; border: 1px solid var(--rule); background: #090f17; }
+.delta-v-editor-budget, .delta-v-editor-coverage { min-width: 0; min-height: 99px; border: 1px solid var(--rule); background: var(--plan-panel-ground); }
 .delta-v-editor-budget > header, .delta-v-editor-coverage > header { display: flex; min-height: 32px; padding: 6px 8px; align-items: baseline; justify-content: space-between; gap: 8px; border-bottom: 1px solid var(--rule); }
 .delta-v-editor-budget > header span, .delta-v-editor-coverage > header span { overflow: hidden; color: var(--slate); font-size: 9px; letter-spacing: .06em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .delta-v-editor-budget > header strong { color: var(--amber); font-size: 15px; white-space: nowrap; }
@@ -607,35 +607,35 @@
 .delta-v-editor-coverage > div strong { overflow: hidden; color: var(--cyan); font-size: 14px; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-editor-coverage > div span { flex: 0 0 auto; color: var(--slate); font-size: 9px; letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-editor-coverage > footer { min-height: 26px; margin-top: auto; padding: 6px 8px; border-top: 1px solid var(--rule); color: var(--cyan); font-size: 10px; letter-spacing: .04em; text-transform: uppercase; }
-.delta-v-editor-coverage.surplus { border-color: rgba(126,231,135,.38); background: linear-gradient(100deg,rgba(126,231,135,.09),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-editor-coverage.surplus { border-color: var(--state-border-green); background: var(--state-wash-green); box-shadow: var(--state-wash-depth); }
 .delta-v-editor-coverage.surplus > header strong, .delta-v-editor-coverage.surplus > footer { color: var(--green); }
-.delta-v-editor-coverage.tight { border-color: rgba(255,180,84,.48); background: linear-gradient(100deg,rgba(255,180,84,.1),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-editor-coverage.tight { border-color: var(--state-border-amber); background: var(--state-wash-amber); box-shadow: var(--state-wash-depth); }
 .delta-v-editor-coverage.tight > header strong, .delta-v-editor-coverage.tight > footer { color: var(--amber); }
-.delta-v-editor-coverage.shortfall { border-color: rgba(255,107,91,.58); background: linear-gradient(100deg,rgba(255,107,91,.11),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
-.delta-v-editor-coverage.shortfall > header strong, .delta-v-editor-coverage.shortfall > footer { color: #ff9b8f; }
-.delta-v-editor-coverage.unavailable { border-color: rgba(255,180,84,.38); }
+.delta-v-editor-coverage.shortfall { border-color: var(--state-border-red); background: var(--state-wash-red); box-shadow: var(--state-wash-depth); }
+.delta-v-editor-coverage.shortfall > header strong, .delta-v-editor-coverage.shortfall > footer { color: var(--state-red-text); }
+.delta-v-editor-coverage.unavailable { border-color: var(--state-border-amber); }
 .delta-v-editor-coverage.unavailable > header strong, .delta-v-editor-coverage.unavailable > footer { color: var(--amber); }
 .delta-v-pinned-progress { display: flex; min-width: 0; margin-top: 7px; padding: 6px 8px; align-items: center; justify-content: space-between; gap: 8px; border: 1px solid var(--surface-plate-edge); border-radius: var(--surface-radius-face); background: var(--surface-well); box-shadow: var(--surface-depth-recessed); }
 .delta-v-pinned-progress > span { color: var(--slate); font-size: 9px; letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-pinned-progress strong { color: var(--text-primary); font-size: 10px; white-space: nowrap; }
 .delta-v-pinned-progress button { min-width: 58px; padding: 5px 7px; border: 1px solid var(--surface-seam); border-radius: var(--surface-radius-face); color: var(--slate); background: var(--surface-raised-face); box-shadow: var(--surface-depth-control); cursor: pointer; font: 10px var(--mono); text-transform: uppercase; }
-.delta-v-pinned-comparison { display: flex; min-width: 0; flex-direction: column; padding: 7px 8px; border: 1px solid var(--rule-bright); background: linear-gradient(100deg,rgba(78,201,224,.08),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-pinned-comparison { display: flex; min-width: 0; flex-direction: column; padding: 7px 8px; border: 1px solid var(--rule-bright); background: var(--state-wash-cyan); box-shadow: var(--state-wash-depth); }
 .delta-v-pinned-comparison header { display: flex; justify-content: space-between; gap: 8px; color: var(--slate); font-size: 9px; letter-spacing: .06em; }
 .delta-v-pinned-comparison header strong { color: var(--cyan); }
-.delta-v-pinned-comparison p { margin: 7px 0; color: #b9cad5; font-size: 12px; line-height: 1.35; }
+.delta-v-pinned-comparison p { margin: 7px 0; color: var(--state-body-text); font-size: 12px; line-height: 1.35; }
 .delta-v-pinned-comparison p span { display: block; margin-top: 4px; color: var(--slate); }
-.delta-v-pinned-comparison.surplus { border-color: rgba(126,231,135,.38); background: linear-gradient(100deg,rgba(126,231,135,.09),rgba(15,21,31,.78)); }
+.delta-v-pinned-comparison.surplus { border-color: var(--state-border-green); background: var(--state-wash-green); }
 .delta-v-pinned-comparison.surplus header strong, .delta-v-pinned-overview.surplus .delta-v-pinned-facts > div:last-child strong { color: var(--green); }
-.delta-v-pinned-comparison.tight { border-color: rgba(255,180,84,.48); background: linear-gradient(100deg,rgba(255,180,84,.1),rgba(15,21,31,.78)); }
+.delta-v-pinned-comparison.tight { border-color: var(--state-border-amber); background: var(--state-wash-amber); }
 .delta-v-pinned-comparison.tight header strong, .delta-v-pinned-overview.tight .delta-v-pinned-facts > div:last-child strong { color: var(--amber); }
-.delta-v-pinned-comparison.shortfall { border-color: rgba(255,107,91,.58); background: linear-gradient(100deg,rgba(255,107,91,.11),rgba(15,21,31,.78)); }
-.delta-v-pinned-comparison.shortfall header strong, .delta-v-pinned-overview.shortfall .delta-v-pinned-facts > div:last-child strong { color: #ff9b8f; }
-.delta-v-pinned-comparison.unavailable { border-color: rgba(255,180,84,.35); }
+.delta-v-pinned-comparison.shortfall { border-color: var(--state-border-red); background: var(--state-wash-red); }
+.delta-v-pinned-comparison.shortfall header strong, .delta-v-pinned-overview.shortfall .delta-v-pinned-facts > div:last-child strong { color: var(--state-red-text); }
+.delta-v-pinned-comparison.unavailable { border-color: var(--state-border-amber); }
 .delta-v-pinned-comparison.unavailable header strong { color: var(--amber); }
-.delta-v-pinned-window { margin-top: 7px; padding: 8px; border-left: 2px solid var(--cyan); background: linear-gradient(100deg,rgba(78,201,224,.085),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-pinned-window { margin-top: 7px; padding: 8px; border-left: 2px solid var(--cyan); background: var(--state-wash-cyan); box-shadow: var(--state-wash-depth); }
 .delta-v-pinned-window strong { color: var(--text-primary); font-size: 10px; }
 .delta-v-pinned-window small { display: block; margin-top: 4px; color: var(--slate); font-size: 9px; }
-.delta-v-launch-target { margin-top: 7px; padding: 8px; border: 1px solid rgba(78,201,224,.34); border-left: 2px solid var(--cyan); background: linear-gradient(100deg,rgba(78,201,224,.085),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-launch-target { margin-top: 7px; padding: 8px; border: 1px solid var(--state-border-cyan); border-left: 2px solid var(--cyan); background: var(--state-wash-cyan); box-shadow: var(--state-wash-depth); }
 .delta-v-launch-target > header { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--slate); font-size: 9px; letter-spacing: .06em; }
 .delta-v-launch-target > header strong { color: var(--cyan); font-size: 9px; }
 .delta-v-launch-target-grid { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 5px; margin-top: 7px; }
@@ -644,26 +644,26 @@
 .delta-v-launch-target-grid span { margin-bottom: 3px; color: var(--slate); font-size: 9px; letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-launch-target-grid b { color: var(--text-primary); font-size: 10px; }
 .delta-v-launch-target-grid small { margin-top: 3px; color: var(--slate); font-size: 9px; }
-.delta-v-progress-suggestion { display: flex; margin-top: 7px; padding: 9px; align-items: center; justify-content: space-between; gap: 10px; border: 1px solid rgba(255,180,84,.48); border-left: 3px solid var(--amber); background: linear-gradient(100deg,rgba(255,180,84,.11),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-progress-suggestion { display: flex; margin-top: 7px; padding: 9px; align-items: center; justify-content: space-between; gap: 10px; border: 1px solid var(--state-border-amber); border-left: 3px solid var(--amber); background: var(--state-wash-amber); box-shadow: var(--state-wash-depth); }
 .delta-v-progress-suggestion > div { min-width: 0; }
 .delta-v-progress-suggestion strong, .delta-v-progress-suggestion span { display: block; }
 .delta-v-progress-suggestion strong { color: var(--amber); font-size: 12px; }
-.delta-v-progress-suggestion span { margin-top: 3px; color: #c5ced9; font-size: 12px; line-height: 1.4; }
+.delta-v-progress-suggestion span { margin-top: 3px; color: var(--state-body-muted); font-size: 12px; line-height: 1.4; }
 .delta-v-progress-suggestion button { min-height: 44px; padding: 8px 12px; flex: 0 0 auto; border: 1px solid var(--surface-amber-face-edge); border-radius: var(--surface-radius-face); color: var(--surface-amber-face-text); background: var(--surface-amber-face); box-shadow: var(--surface-depth-control); cursor: pointer; font: 12px var(--mono); text-transform: uppercase; }
-.delta-v-transfer-readiness { margin-top: 7px; padding: 8px; border: 1px solid var(--rule-bright); border-left: 2px solid var(--cyan); background: linear-gradient(100deg,rgba(78,201,224,.085),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-transfer-readiness { margin-top: 7px; padding: 8px; border: 1px solid var(--rule-bright); border-left: 2px solid var(--cyan); background: var(--state-wash-cyan); box-shadow: var(--state-wash-depth); }
 .delta-v-transfer-readiness > header { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--slate); font-size: 9px; letter-spacing: .06em; }
 .delta-v-transfer-readiness > header strong { color: var(--cyan); font-size: 10px; }
 .delta-v-readiness-toggle { display: inline-flex; min-width: 0; padding: 2px 0 2px 5px; align-items: center; gap: 4px; border: 0; color: var(--slate); background: transparent; cursor: pointer; font: inherit; letter-spacing: inherit; }
 .delta-v-readiness-toggle > span { width: 8px; color: currentColor; text-align: center; }
 .delta-v-readiness-toggle:hover { color: var(--cyan); }
 .delta-v-readiness-toggle:focus-visible { color: var(--cyan); outline: 1px solid currentColor; outline-offset: 2px; }
-.delta-v-transfer-readiness.warning { border-color: rgba(255,180,84,.48); background: linear-gradient(100deg,rgba(255,180,84,.1),rgba(15,21,31,.78)); }
+.delta-v-transfer-readiness.warning { border-color: var(--state-border-amber); background: var(--state-wash-amber); }
 .delta-v-transfer-readiness.warning > header strong { color: var(--amber); }
-.delta-v-transfer-readiness.blocked { border-color: rgba(255,107,91,.5); background: linear-gradient(100deg,rgba(255,107,91,.11),rgba(15,21,31,.78)); }
-.delta-v-transfer-readiness.blocked > header strong { color: #ff9b8f; }
-.delta-v-transfer-readiness.created { border-color: rgba(126,231,135,.45); background: linear-gradient(100deg,rgba(126,231,135,.09),rgba(15,21,31,.78)); }
+.delta-v-transfer-readiness.blocked { border-color: var(--state-border-red); background: var(--state-wash-red); }
+.delta-v-transfer-readiness.blocked > header strong { color: var(--state-red-text); }
+.delta-v-transfer-readiness.created { border-color: var(--state-border-green); background: var(--state-wash-green); }
 .delta-v-transfer-readiness.created > header strong { color: var(--green); }
-.delta-v-transfer-readiness.executed { border-color: rgba(255,180,84,.48); background: linear-gradient(100deg,rgba(255,180,84,.1),rgba(15,21,31,.78)); }
+.delta-v-transfer-readiness.executed { border-color: var(--state-border-amber); background: var(--state-wash-amber); }
 .delta-v-transfer-readiness.executed > header strong { color: var(--amber); }
 .delta-v-readiness-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 5px; margin-top: 7px; }
 .delta-v-readiness-grid > div { min-width: 0; padding: 6px 7px; border: 1px solid var(--surface-plate-edge); border-radius: var(--surface-radius-face); background: var(--surface-well); box-shadow: var(--surface-depth-recessed); }
@@ -676,33 +676,33 @@
 .delta-v-maneuver-preview strong { color: var(--cyan); font-size: 10px; }
 .delta-v-maneuver-preview small { margin-top: 3px; color: var(--slate); font-size: 9px; }
 .delta-v-readiness-issues { display: grid; gap: 3px; margin: 7px 0 0; padding: 0; list-style: none; }
-.delta-v-readiness-issues li { padding-left: 11px; color: #b9cad5; font-size: 10px; line-height: 1.4; }
+.delta-v-readiness-issues li { padding-left: 11px; color: var(--state-body-text); font-size: 10px; line-height: 1.4; }
 .delta-v-readiness-issues li::before { margin-left: -11px; margin-right: 5px; color: var(--amber); content: "\25b8"; }
-.delta-v-readiness-issues.blockers li::before { color: #ff9b8f; }
-.delta-v-maneuver-error { color: #ff9b8f !important; }
+.delta-v-readiness-issues.blockers li::before { color: var(--state-red-text); }
+.delta-v-maneuver-error { color: var(--state-red-text) !important; }
 .delta-v-maneuver-actions { display: flex; min-height: 28px; margin-top: 7px; }
-.delta-v-maneuver-actions button { flex: 1; min-height: 30px; padding: 5px 8px; border: 1px solid var(--accent-border); color: var(--cyan); background: #0a131d; cursor: pointer; font: 10px var(--mono); letter-spacing: .03em; text-transform: uppercase; }
+.delta-v-maneuver-actions button { flex: 1; min-height: 30px; padding: 5px 8px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--plan-control-face); cursor: pointer; font: 10px var(--mono); letter-spacing: .03em; text-transform: uppercase; }
 .delta-v-maneuver-actions button:hover:not(:disabled), .delta-v-maneuver-actions button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.08); }
 .delta-v-maneuver-actions button:disabled { opacity: .42; cursor: not-allowed; }
 .delta-v-maneuver-actions > span { padding: 6px 0; color: var(--green); font-size: 10px; line-height: 1.4; }
-.delta-v-pinned-route-toggle { display: flex; min-height: 30px; margin-top: 7px; padding: 4px 5px 4px 8px; align-items: center; justify-content: space-between; gap: 8px; border: 1px solid var(--rule); background: rgba(9,15,23,.65); }
+.delta-v-pinned-route-toggle { display: flex; min-height: 30px; margin-top: 7px; padding: 4px 5px 4px 8px; align-items: center; justify-content: space-between; gap: 8px; border: 1px solid var(--rule); background: var(--plan-route-wash); }
 .delta-v-pinned-route-toggle > span { color: var(--slate); font-size: 9px; letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-pinned-route-toggle > button { min-height: 28px; padding: 4px 8px; border: 1px solid var(--surface-cyan-face-edge); border-radius: var(--surface-radius-face); color: var(--cyan); background: var(--surface-cyan-face); box-shadow: var(--surface-depth-control); cursor: pointer; font: 10px var(--mono); letter-spacing: .03em; text-transform: uppercase; }
 .delta-v-pinned-route-toggle > button:hover, .delta-v-pinned-route-toggle > button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.08); }
-.delta-v-editor-route-heading { display: flex; min-height: 26px; margin-top: 7px; padding: 5px 7px; align-items: center; gap: 8px; border: 1px solid var(--rule); background: rgba(9,15,23,.65); }
+.delta-v-editor-route-heading { display: flex; min-height: 26px; margin-top: 7px; padding: 5px 7px; align-items: center; gap: 8px; border: 1px solid var(--rule); background: var(--plan-route-wash); }
 .delta-v-editor-route-heading > span { min-width: 0; overflow: hidden; color: var(--slate); font-size: 10px; letter-spacing: .05em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .delta-v-editor-route-heading > span b { color: var(--text-primary); font-weight: 600; }
 .delta-v-editor-route-heading > strong { margin-left: auto; color: var(--cyan); font-size: 11px; white-space: nowrap; }
-.delta-v-editor-route-heading > button { min-height: 24px; padding: 2px 6px; border: 1px solid var(--accent-border); color: var(--cyan); background: #0a131d; cursor: pointer; font: 10px var(--mono); text-transform: uppercase; }
+.delta-v-editor-route-heading > button { min-height: 24px; padding: 2px 6px; border: 1px solid var(--accent-border); color: var(--cyan); background: var(--plan-control-face); cursor: pointer; font: 10px var(--mono); text-transform: uppercase; }
 .delta-v-pinned-route { display: grid; gap: 3px; margin-top: 7px; }
-.delta-v-pinned-route > div { display: grid; min-width: 0; gap: 6px; padding: 5px 6px; align-items: center; border: 1px solid var(--surface-plate-edge); border-radius: var(--surface-radius-face); background: linear-gradient(180deg,#101823 0%,#0b1118 100%); box-shadow: var(--surface-depth-control); }
+.delta-v-pinned-route > div { display: grid; min-width: 0; gap: 6px; padding: 5px 6px; align-items: center; border: 1px solid var(--surface-plate-edge); border-radius: var(--surface-radius-face); background: var(--plan-step-face); box-shadow: var(--surface-depth-control); }
 .delta-v-pinned-route.flight > div { grid-template-columns: 28px 21px minmax(0,1fr) auto; }
 .delta-v-pinned-route.editor > div { grid-template-columns: 21px minmax(0,1fr) auto; }
-.delta-v-pinned-route.editor { gap: 0; margin-top: 3px; border: 1px solid var(--rule); background: rgba(9,15,23,.8); }
+.delta-v-pinned-route.editor { gap: 0; margin-top: 3px; border: 1px solid var(--rule); background: var(--plan-route-wash-strong); }
 .delta-v-pinned-route.editor.expanded { max-height: 204px; overflow-y: auto; overscroll-behavior: contain; scrollbar-gutter: stable; }
 .delta-v-pinned-route.editor > div { min-height: 31px; padding: 5px 7px; grid-template-columns: 25px minmax(0,1fr) auto; border: 0; border-bottom: 1px solid var(--rule); border-radius: 0; background: transparent; box-shadow: none; }
 .delta-v-pinned-route.editor > div:last-child { border-bottom: 0; }
-.delta-v-pinned-route.editor .delta-v-pinned-step-number { position: relative; z-index: 0; display: grid; width: 19px; height: 19px; place-items: center; border: 1px solid var(--accent-border); border-radius: 50%; color: var(--cyan); background: #0a131d; }
+.delta-v-pinned-route.editor .delta-v-pinned-step-number { position: relative; z-index: 0; display: grid; width: 19px; height: 19px; place-items: center; border: 1px solid var(--accent-border); border-radius: 50%; color: var(--cyan); background: var(--plan-control-face); }
 .delta-v-pinned-route.editor > div:not(:last-child) .delta-v-pinned-step-number::after { position: absolute; top: 18px; left: 8px; z-index: -1; width: 1px; height: 13px; background: var(--accent-border); content: ""; }
 .delta-v-pinned-route.editor .delta-v-pinned-step-copy > strong { font-size: 11px; }
 .delta-v-pinned-route.editor > div > b { font-size: 11px; }
@@ -719,18 +719,18 @@
 .delta-v-pinned-step-copy > small span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-pinned-step-copy > small b { flex: 0 0 auto; color: var(--amber); font-size: 9px; }
 .delta-v-pinned-route > div > b { color: var(--cyan); font-size: 10px; white-space: nowrap; }
-.delta-v-pinned-route > .delta-v-pinned-complete { display: flex; padding: 12px; align-items: center; justify-content: space-between; border-color: rgba(126,231,135,.35); background: linear-gradient(100deg,rgba(126,231,135,.09),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); }
+.delta-v-pinned-route > .delta-v-pinned-complete { display: flex; padding: 12px; align-items: center; justify-content: space-between; border-color: var(--state-border-green); background: var(--state-wash-green); box-shadow: var(--state-wash-depth); }
 .delta-v-pinned-complete strong { color: var(--green); font-size: 10px; text-transform: uppercase; }
 .delta-v-pinned-complete span { color: var(--slate); font-size: 9px; }
 .delta-v-pinned-completed { margin-top: 6px; border: 1px solid var(--rule); background: rgba(9,15,23,.55); }
 .delta-v-pinned-completed summary { padding: 6px 8px; color: var(--slate); cursor: pointer; font-size: 10px; letter-spacing: .04em; text-transform: uppercase; }
 .delta-v-pinned-completed > div { display: grid; gap: 3px; padding: 0 5px 5px; }
-.delta-v-pinned-completed button { display: flex; min-height: 30px; align-items: center; justify-content: space-between; gap: 8px; padding: 5px 7px; border: 1px solid var(--surface-seam); border-radius: var(--surface-radius-face); color: #b9cad5; background: var(--surface-raised-face); box-shadow: var(--surface-depth-control); cursor: pointer; font: 10px var(--mono); text-align: left; }
+.delta-v-pinned-completed button { display: flex; min-height: 30px; align-items: center; justify-content: space-between; gap: 8px; padding: 5px 7px; border: 1px solid var(--surface-seam); border-radius: var(--surface-radius-face); color: var(--state-body-text); background: var(--surface-raised-face); box-shadow: var(--surface-depth-control); cursor: pointer; font: 10px var(--mono); text-align: left; }
 .delta-v-pinned-completed button span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .delta-v-pinned-completed button b { flex: 0 0 auto; color: var(--cyan); font-size: 10px; text-transform: uppercase; }
-.delta-v-pinned-thermal { margin-top: 7px; padding: 7px 8px; border: 1px solid rgba(255,180,84,.42); color: var(--amber); background: linear-gradient(100deg,rgba(255,180,84,.1),rgba(15,21,31,.78)); box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5); font-size: 9px; line-height: 1.35; }
-.delta-v-pinned-thermal.not-detected { border-color: rgba(255,107,91,.48); color: #ff9b8f; background: linear-gradient(100deg,rgba(255,107,91,.11),rgba(15,21,31,.78)); }
-.delta-v-pinned-thermal.detected { border-color: rgba(126,231,135,.35); color: var(--green); background: linear-gradient(100deg,rgba(126,231,135,.09),rgba(15,21,31,.78)); }
+.delta-v-pinned-thermal { margin-top: 7px; padding: 7px 8px; border: 1px solid var(--state-border-amber); color: var(--amber); background: var(--state-wash-amber); box-shadow: var(--state-wash-depth); font-size: 9px; line-height: 1.35; }
+.delta-v-pinned-thermal.not-detected { border-color: var(--state-border-red); color: var(--state-red-text); background: var(--state-wash-red); }
+.delta-v-pinned-thermal.detected { border-color: var(--state-border-green); color: var(--green); background: var(--state-wash-green); }
 
 @media (orientation: landscape) and (min-width: 980px) and (max-height: 950px) {
   .resonant-drawer { width: min(1180px,96vw); }

--- a/frontend/src/settings/SettingsDrawer.test.tsx
+++ b/frontend/src/settings/SettingsDrawer.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SCIENCE_ALARM_SETTINGS } from "./state";
+import { SettingsDrawer, type SettingsDrawerProps } from "./SettingsDrawer";
+
+afterEach(cleanup);
+
+function props(overrides: Partial<SettingsDrawerProps> = {}): SettingsDrawerProps {
+  return {
+    hiddenPanelCount: 2,
+    onClose: vi.fn(),
+    onRestoreHiddenPanels: vi.fn(),
+    onScienceAlarmSettingsChange: vi.fn(),
+    onSectionChange: vi.fn(),
+    onSetTimeSystem: vi.fn(),
+    open: true,
+    scienceAlarmProviders: { kac: true, stock: true },
+    scienceAlarmSettings: DEFAULT_SCIENCE_ALARM_SETTINGS,
+    section: "preferences",
+    telemetry: {
+      effectiveEndpoint: "ws://127.0.0.1:8090",
+      capabilities: { schemaVersion: 1, features: {} as never },
+      persistenceStatus: "shared",
+    },
+    timeSystem: "kerbin",
+    ...overrides,
+  };
+}
+
+describe("SettingsDrawer", () => {
+  it("renders immediate preferences and the safe restore action", () => {
+    const onSetTimeSystem = vi.fn();
+    const view = render(<SettingsDrawer {...props({ onSetTimeSystem })} />);
+    const dialog = screen.getByRole("dialog", { name: "Mission Control Settings" });
+    expect(within(dialog).getByText("2 panels hidden.")).toBeTruthy();
+    fireEvent.click(within(dialog).getByRole("button", { name: "EARTH TIME" }));
+    expect(onSetTimeSystem).toHaveBeenCalledWith("earth");
+    expect(view.container.querySelector("#settings-drawer")).toBeTruthy();
+  });
+
+  it("keeps feature labels and order fixed and expands one evidence row at a time", () => {
+    const onSectionChange = vi.fn();
+    const view = render(<SettingsDrawer {...props({ onSectionChange, section: "features-mods" })} />);
+    const dialog = screen.getByRole("dialog", { name: "Mission Control Settings" });
+    const rows = [...dialog.querySelectorAll<HTMLElement>(".settings-feature-toggle")];
+    expect(rows.map((row) => row.firstElementChild?.textContent)).toEqual([
+      "Notes", "Science telemetry", "Science alarms", "Communications", "Stage analysis", "Live transfer calculations", "Heat monitoring", "Heat controls", "Editor electricity", "Damage monitoring",
+    ]);
+    fireEvent.click(rows[0]);
+    expect(screen.getByText("Saved notes continuity across scenes")).toBeTruthy();
+    fireEvent.click(rows[1]);
+    expect(screen.queryByText("Saved notes continuity across scenes")).toBeNull();
+    expect(screen.getByText("Science lab and experiment telemetry")).toBeTruthy();
+    expect(view.container.textContent).toContain("ws://127.0.0.1:8090");
+  });
+
+  it("uses unknown for invalid feature statuses and only publishes approved wiki links", () => {
+    render(<SettingsDrawer {...props({ section: "features-mods", telemetry: { capabilities: { schemaVersion: 1, features: { notes: { status: "not-a-status", reason: "not-a-reason", evidence: [] } } as never } } })} />);
+    expect(screen.getAllByText("UNKNOWN").length).toBeGreaterThan(0);
+
+    const onSectionChange = vi.fn();
+    cleanup();
+    render(<SettingsDrawer {...props({ onSectionChange, section: "help" })} />);
+    expect(screen.queryByText(/Settings-and-Integrations/)).toBeNull();
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBe(12);
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Getting-Started",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Installation-Options",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Launcher-and-Service-Maintenance",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Mission-Control-Overview",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Flight-Dashboard",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/VAB-and-SPH",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Mission-Planning",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Notes-and-Panel-Customization",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Mods-and-Compatibility",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Network-and-Safety",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/Troubleshooting",
+      "https://github.com/SacredWoobie/woobies-mission-control/wiki/ESP32-Controlpad",
+    ]);
+    links.forEach((link) => {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toContain("noreferrer");
+    });
+  });
+
+  it("reports the current palette without exposing a theme chooser", () => {
+    render(<SettingsDrawer {...props({ section: "about" })} />);
+    const dialog = screen.getByRole("dialog", { name: "Mission Control Settings" });
+    expect(within(dialog).getByText("Mission Control Dark (read-only)")).toBeTruthy();
+    expect(within(dialog).queryByRole("combobox")).toBeNull();
+    expect(within(dialog).queryByRole("button", { name: /theme|palette/i })).toBeNull();
+  });
+
+  it("deep-links science alarms while retaining the Preferences navigator", () => {
+    const onScienceAlarmSettingsChange = vi.fn();
+    render(<SettingsDrawer {...props({ onScienceAlarmSettingsChange, section: "science-alarms" })} />);
+    const dialog = screen.getByRole("dialog", { name: "Mission Control Settings" });
+    expect(within(dialog).getByRole("button", { name: "Preferences" }).getAttribute("aria-current")).toBe("page");
+    fireEvent.click(within(dialog).getByRole("button", { name: "STOCK" }));
+    expect(onScienceAlarmSettingsChange).toHaveBeenCalledWith({ provider: "stock" });
+  });
+});

--- a/frontend/src/settings/SettingsDrawer.test.tsx
+++ b/frontend/src/settings/SettingsDrawer.test.tsx
@@ -86,6 +86,32 @@ describe("SettingsDrawer", () => {
     });
   });
 
+  it("distinguishes installed and not-detected markers from runtime availability", () => {
+    render(<SettingsDrawer {...props({
+      section: "features-mods",
+      telemetry: {
+        capabilities: {
+          schemaVersion: 1,
+          features: {
+            notes: {
+              status: "unknown",
+              reason: "not_observed",
+              evidence: [{ id: "notes", status: "detected", source: "root_scan" }],
+            },
+            science_telemetry: {
+              status: "unknown",
+              reason: "dependency_missing",
+              evidence: [{ id: "wcs", status: "missing", source: "root_scan" }],
+            },
+          } as never,
+        },
+      },
+    })} />);
+    expect(screen.getByRole("button", { name: /Notes.*INSTALLED · NOT OBSERVED HERE/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Science telemetry.*NOT DETECTED/ })).toBeTruthy();
+    expect(screen.queryByText("STOCK FALLBACK ACTIVE")).toBeNull();
+  });
+
   it("reports the current palette without exposing a theme chooser", () => {
     render(<SettingsDrawer {...props({ section: "about" })} />);
     const dialog = screen.getByRole("dialog", { name: "Mission Control Settings" });

--- a/frontend/src/settings/SettingsDrawer.test.tsx
+++ b/frontend/src/settings/SettingsDrawer.test.tsx
@@ -56,9 +56,9 @@ describe("SettingsDrawer", () => {
     expect(view.container.textContent).toContain("ws://127.0.0.1:8090");
   });
 
-  it("uses unknown for invalid feature statuses and only publishes approved wiki links", () => {
+  it("uses detection unavailable for invalid capability data and only publishes approved wiki links", () => {
     render(<SettingsDrawer {...props({ section: "features-mods", telemetry: { capabilities: { schemaVersion: 1, features: { notes: { status: "not-a-status", reason: "not-a-reason", evidence: [] } } as never } } })} />);
-    expect(screen.getAllByText("UNKNOWN").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("DETECTION UNAVAILABLE").length).toBeGreaterThan(0);
 
     const onSectionChange = vi.fn();
     cleanup();
@@ -86,7 +86,7 @@ describe("SettingsDrawer", () => {
     });
   });
 
-  it("distinguishes installed and not-detected markers from runtime availability", () => {
+  it("reports dashboard-wide installation capability without scene-dependent status", () => {
     render(<SettingsDrawer {...props({
       section: "features-mods",
       telemetry: {
@@ -99,17 +99,42 @@ describe("SettingsDrawer", () => {
               evidence: [{ id: "notes", status: "detected", source: "root_scan" }],
             },
             science_telemetry: {
+              status: "fallback",
+              reason: "fallback_active",
+              evidence: [
+                { id: "stock_science", status: "active", source: "runtime" },
+                { id: "wcs", status: "detected", source: "root_scan" },
+              ],
+            },
+            communications: {
+              status: "available",
+              reason: "ready",
+              evidence: [
+                { id: "remote_tech", status: "active", source: "runtime" },
+                { id: "remote_tech", status: "missing", source: "root_scan" },
+              ],
+            },
+            stage_analysis: {
               status: "unknown",
               reason: "dependency_missing",
-              evidence: [{ id: "wcs", status: "missing", source: "root_scan" }],
+              evidence: [
+                { id: "stage_stats", status: "missing", source: "root_scan" },
+                { id: "mechjeb", status: "missing", source: "root_scan" },
+              ],
             },
           } as never,
         },
       },
     })} />);
-    expect(screen.getByRole("button", { name: /Notes.*INSTALLED · NOT OBSERVED HERE/ })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Science telemetry.*NOT DETECTED/ })).toBeTruthy();
-    expect(screen.queryByText("STOCK FALLBACK ACTIVE")).toBeNull();
+    expect(screen.getByRole("button", { name: /Notes.*AVAILABLE/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Science telemetry.*AVAILABLE/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Communications.*AVAILABLE · STOCK/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Stage analysis.*UNAVAILABLE/ })).toBeTruthy();
+    expect(screen.queryByText(/NOT OBSERVED|STOCK FALLBACK ACTIVE|NOT DETECTED/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Science telemetry.*AVAILABLE/ }));
+    expect(screen.queryByText("Runtime")).toBeNull();
+    expect(screen.getByText(/Woobies Control Stats service.*DETECTED.*Installation scan/)).toBeTruthy();
   });
 
   it("reports the current palette without exposing a theme chooser", () => {

--- a/frontend/src/settings/SettingsDrawer.test.tsx
+++ b/frontend/src/settings/SettingsDrawer.test.tsx
@@ -15,6 +15,7 @@ function props(overrides: Partial<SettingsDrawerProps> = {}): SettingsDrawerProp
     onScienceAlarmSettingsChange: vi.fn(),
     onSectionChange: vi.fn(),
     onSetTimeSystem: vi.fn(),
+    onSetTheme: vi.fn(),
     open: true,
     scienceAlarmProviders: { kac: true, stock: true },
     scienceAlarmSettings: DEFAULT_SCIENCE_ALARM_SETTINGS,
@@ -24,6 +25,7 @@ function props(overrides: Partial<SettingsDrawerProps> = {}): SettingsDrawerProp
       capabilities: { schemaVersion: 1, features: {} as never },
       persistenceStatus: "shared",
     },
+    themeId: "mission-control-dark",
     timeSystem: "kerbin",
     ...overrides,
   };
@@ -137,12 +139,23 @@ describe("SettingsDrawer", () => {
     expect(screen.getByText(/Woobies Control Stats service.*DETECTED.*Installation scan/)).toBeTruthy();
   });
 
-  it("reports the current palette without exposing a theme chooser", () => {
-    render(<SettingsDrawer {...props({ section: "about" })} />);
+  it("offers all four themes and reports the current selection in About", () => {
+    const onSetTheme = vi.fn();
+    const view = render(<SettingsDrawer {...props({ onSetTheme })} />);
     const dialog = screen.getByRole("dialog", { name: "Mission Control Settings" });
-    expect(within(dialog).getByText("Mission Control Dark (read-only)")).toBeTruthy();
-    expect(within(dialog).queryByRole("combobox")).toBeNull();
-    expect(within(dialog).queryByRole("button", { name: /theme|palette/i })).toBeNull();
+    const themes = within(dialog).getAllByRole("radio");
+    expect(themes.map((theme) => theme.textContent)).toEqual([
+      expect.stringContaining("Mission Control Dark"),
+      expect.stringContaining("Daylight Console"),
+      expect.stringContaining("Warm CRT"),
+      expect.stringContaining("Green Phosphor"),
+    ]);
+    expect(themes[0].getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(within(dialog).getByRole("radio", { name: /Daylight Console/ }));
+    expect(onSetTheme).toHaveBeenCalledWith("daylight-console");
+
+    view.rerender(<SettingsDrawer {...props({ onSetTheme, section: "about", themeId: "daylight-console" })} />);
+    expect(within(screen.getByRole("dialog", { name: "Mission Control Settings" })).getByText("Daylight Console")).toBeTruthy();
   });
 
   it("deep-links science alarms while retaining the Preferences navigator", () => {

--- a/frontend/src/settings/SettingsDrawer.tsx
+++ b/frontend/src/settings/SettingsDrawer.tsx
@@ -2,7 +2,10 @@ import { useState } from "react";
 import { PRODUCT_NAME, PRODUCT_VERSION } from "../buildIdentity";
 import { useDialogFocus } from "../deltaV/useDialogFocus";
 import {
-  CURRENT_THEME_METADATA,
+  DEFAULT_THEME_ID,
+  THEME_METADATA,
+  THEME_OPTIONS,
+  type ThemeId,
 } from "../theme";
 import type { TimeSystem } from "../timeSystem";
 import type {
@@ -58,8 +61,8 @@ export interface SettingsDrawerProps {
   onScienceAlarmSettingsChange(next: Partial<ScienceAlarmDefaults>): void;
   onSectionChange(section: SettingsSection): void;
   onSetTimeSystem?(system: TimeSystem): void;
+  onSetTheme?(themeId: ThemeId): void;
   open: boolean;
-  paletteLabel?: string;
   productName?: string;
   productVersion?: string;
   releaseUrl?: string;
@@ -68,6 +71,7 @@ export interface SettingsDrawerProps {
   scienceAlarmSettings: ScienceAlarmDefaults;
   section: SettingsSection;
   telemetry?: SettingsTelemetryInfo;
+  themeId?: ThemeId;
   timeSystem?: TimeSystem;
   wikiBaseUrl?: string;
 }
@@ -163,13 +167,35 @@ function PreferencesSection({
   onRestoreHiddenPanels,
   onScienceAlarmSettingsChange,
   onSetTimeSystem,
+  onSetTheme,
   scienceAlarmProviders,
   scienceAlarmSettings,
   scienceOnly = false,
+  themeId,
   timeSystem,
-}: Pick<SettingsDrawerProps, "hiddenPanelCount" | "onRestoreHiddenPanels" | "onScienceAlarmSettingsChange" | "onSetTimeSystem" | "scienceAlarmProviders" | "scienceAlarmSettings" | "timeSystem"> & { heading?: string; scienceOnly?: boolean }) {
+}: Pick<SettingsDrawerProps, "hiddenPanelCount" | "onRestoreHiddenPanels" | "onScienceAlarmSettingsChange" | "onSetTimeSystem" | "onSetTheme" | "scienceAlarmProviders" | "scienceAlarmSettings" | "themeId" | "timeSystem"> & { heading?: string; scienceOnly?: boolean }) {
   return <section aria-labelledby="settings-preferences-heading" className="settings-section">
     <h3 id="settings-preferences-heading">{heading}</h3>
+    {!scienceOnly && <fieldset className="settings-fieldset">
+      <legend>Appearance</legend>
+      <div aria-label="Dashboard theme" className="settings-theme-grid" role="radiogroup">
+        {THEME_OPTIONS.map((theme) => <button
+          aria-checked={themeId === theme.id}
+          className="settings-theme-option"
+          key={theme.id}
+          onClick={() => onSetTheme?.(theme.id)}
+          role="radio"
+          type="button"
+        >
+          <span aria-hidden="true" className="settings-theme-swatches">
+            {theme.swatches.map((swatch) => <i key={swatch} style={{ background: swatch }} />)}
+          </span>
+          <strong>{theme.label}</strong>
+          <small>{theme.description}</small>
+        </button>)}
+      </div>
+      <small>Applies immediately and is stored in this browser. Typography and layout remain unchanged.</small>
+    </fieldset>}
     {!scienceOnly && <fieldset className="settings-fieldset">
       <legend>Time system</legend>
       <div className="settings-choice-row">
@@ -305,7 +331,7 @@ function AboutSection({
   issuesUrl,
   launcherBoundary,
   licenseUrl,
-  paletteLabel,
+  themeLabel,
   productName,
   productVersion,
   releaseUrl,
@@ -317,7 +343,7 @@ function AboutSection({
   issuesUrl: string;
   launcherBoundary: string;
   licenseUrl: string;
-  paletteLabel: string;
+  themeLabel: string;
   productName: string;
   productVersion: string;
   releaseUrl: string;
@@ -330,7 +356,7 @@ function AboutSection({
       <div><dt>Product</dt><dd>{productName}</dd></div>
       <div><dt>Release</dt><dd>v{productVersion}</dd></div>
       <div><dt>Build</dt><dd>{buildLabel}</dd></div>
-      <div><dt>Palette</dt><dd>{paletteLabel} (read-only)</dd></div>
+      <div><dt>Theme</dt><dd>{themeLabel}</dd></div>
       <div><dt>Loopback endpoint</dt><dd>{effectiveEndpoint || "Unknown"}</dd></div>
       <div><dt>Launcher boundary</dt><dd>{launcherBoundary}</dd></div>
     </dl>
@@ -356,8 +382,8 @@ export function SettingsDrawer({
   onScienceAlarmSettingsChange,
   onSectionChange,
   onSetTimeSystem,
+  onSetTheme,
   open,
-  paletteLabel = CURRENT_THEME_METADATA.label,
   productName = PRODUCT_NAME,
   productVersion = PRODUCT_VERSION,
   releaseUrl = RELEASE_URL,
@@ -366,6 +392,7 @@ export function SettingsDrawer({
   scienceAlarmSettings,
   section,
   telemetry,
+  themeId = DEFAULT_THEME_ID,
   timeSystem,
   wikiBaseUrl = DEFAULT_WIKI_BASE,
 }: SettingsDrawerProps) {
@@ -396,8 +423,10 @@ export function SettingsDrawer({
           onRestoreHiddenPanels={onRestoreHiddenPanels}
           onScienceAlarmSettingsChange={onScienceAlarmSettingsChange}
           onSetTimeSystem={onSetTimeSystem}
+          onSetTheme={onSetTheme}
           scienceAlarmProviders={scienceAlarmProviders}
           scienceAlarmSettings={scienceAlarmSettings}
+          themeId={themeId}
           timeSystem={timeSystem}
         />}
         {section === "science-alarms" && <PreferencesSection
@@ -406,9 +435,11 @@ export function SettingsDrawer({
           onRestoreHiddenPanels={onRestoreHiddenPanels}
           onScienceAlarmSettingsChange={onScienceAlarmSettingsChange}
           onSetTimeSystem={onSetTimeSystem}
+          onSetTheme={onSetTheme}
           scienceAlarmProviders={scienceAlarmProviders}
           scienceAlarmSettings={scienceAlarmSettings}
           scienceOnly
+          themeId={themeId}
           timeSystem={timeSystem}
         />}
         {section === "features-mods" && <FeaturesSection telemetry={effectiveTelemetry} />}
@@ -419,7 +450,7 @@ export function SettingsDrawer({
           issuesUrl={issuesUrl}
           launcherBoundary={launcherBoundary}
           licenseUrl={licenseUrl}
-          paletteLabel={paletteLabel}
+          themeLabel={THEME_METADATA[themeId].label}
           productName={productName}
           productVersion={productVersion}
           releaseUrl={releaseUrl}

--- a/frontend/src/settings/SettingsDrawer.tsx
+++ b/frontend/src/settings/SettingsDrawer.tsx
@@ -21,7 +21,7 @@ import {
 
 export type SettingsFeatureId = DashboardFeatureId;
 
-export type SettingsFeatureStatus = "available" | "fallback" | "unavailable" | "unknown";
+export type SettingsFeatureStatus = "available" | "installed" | "fallback" | "not-detected" | "unavailable" | "unknown";
 
 export const SETTINGS_FEATURES: readonly {
   id: SettingsFeatureId;
@@ -84,7 +84,9 @@ function wikiUrl(base: string, slug: string) {
 
 function statusLabel(status: SettingsFeatureStatus) {
   if (status === "available") return "AVAILABLE";
+  if (status === "installed") return "INSTALLED · NOT OBSERVED HERE";
   if (status === "fallback") return "STOCK FALLBACK ACTIVE";
+  if (status === "not-detected") return "NOT DETECTED";
   if (status === "unavailable") return "UNAVAILABLE";
   return "UNKNOWN";
 }
@@ -221,13 +223,13 @@ function FeaturesSection({ telemetry }: { telemetry?: SettingsTelemetryInfo }) {
   const [expanded, setExpanded] = useState<SettingsFeatureId | null>(null);
   return <section aria-labelledby="settings-features-heading" className="settings-section">
     <h3 id="settings-features-heading">Features &amp; Mods</h3>
-    <p className="settings-section-intro">Availability is reported by the current dashboard feed. Missing or invalid capability data is shown as UNKNOWN.</p>
+    <p className="settings-section-intro">AVAILABLE and STOCK FALLBACK ACTIVE require live runtime evidence. INSTALLED means the known dependencies were found but are not observable in this scene. NOT DETECTED means a fixed known marker was not found; UNKNOWN means the feed cannot classify it.</p>
     <div className="settings-feature-list">
       {SETTINGS_FEATURES.map((feature) => {
         const capability = validCapabilitySnapshot(telemetry?.capabilities)
           ? telemetry.capabilities.features[feature.id]
           : undefined;
-        const status: SettingsFeatureStatus = capability?.status === "available"
+        let status: SettingsFeatureStatus = capability?.status === "available"
           || capability?.status === "fallback"
           || capability?.status === "unavailable"
           ? capability.status
@@ -235,6 +237,12 @@ function FeaturesSection({ telemetry }: { telemetry?: SettingsTelemetryInfo }) {
         const evidence = capability && Array.isArray(capability.evidence)
           ? capability.evidence.filter((item): item is DashboardCapabilityEvidence => !!item && typeof item === "object" && (item.status === "active" || item.status === "detected" || item.status === "missing" || item.status === "unavailable" || item.status === "unknown") && (item.source === "runtime" || item.source === "root_scan") && typeof item.id === "string")
           : [];
+        const installationEvidence = evidence.filter((item) => item.source === "root_scan");
+        if (status === "unknown" && capability?.reason === "not_observed" && installationEvidence.length > 0 && installationEvidence.every((item) => item.status === "detected")) {
+          status = "installed";
+        } else if (status === "unknown" && capability?.reason === "dependency_missing" && installationEvidence.some((item) => item.status === "missing")) {
+          status = "not-detected";
+        }
         const open = expanded === feature.id;
         return <article className={`settings-feature settings-feature-${status}`} key={feature.id}>
           <button

--- a/frontend/src/settings/SettingsDrawer.tsx
+++ b/frontend/src/settings/SettingsDrawer.tsx
@@ -21,7 +21,7 @@ import {
 
 export type SettingsFeatureId = DashboardFeatureId;
 
-export type SettingsFeatureStatus = "available" | "installed" | "fallback" | "not-detected" | "unavailable" | "unknown";
+export type SettingsFeatureStatus = "available" | "stock" | "unavailable" | "unknown";
 
 export const SETTINGS_FEATURES: readonly {
   id: SettingsFeatureId;
@@ -84,12 +84,19 @@ function wikiUrl(base: string, slug: string) {
 
 function statusLabel(status: SettingsFeatureStatus) {
   if (status === "available") return "AVAILABLE";
-  if (status === "installed") return "INSTALLED · NOT OBSERVED HERE";
-  if (status === "fallback") return "STOCK FALLBACK ACTIVE";
-  if (status === "not-detected") return "NOT DETECTED";
+  if (status === "stock") return "AVAILABLE · STOCK";
   if (status === "unavailable") return "UNAVAILABLE";
-  return "UNKNOWN";
+  return "DETECTION UNAVAILABLE";
 }
+
+const STOCK_CAPABILITY_FEATURES = new Set<SettingsFeatureId>([
+  "science_telemetry",
+  "science_alarms",
+  "communications",
+  "heat_monitoring",
+  "editor_electricity",
+  "damage_monitoring",
+]);
 
 function validCapabilitySnapshot(snapshot: DashboardCapabilitiesSnapshot | null | undefined): snapshot is DashboardCapabilitiesSnapshot {
   return !!snapshot
@@ -223,26 +230,23 @@ function FeaturesSection({ telemetry }: { telemetry?: SettingsTelemetryInfo }) {
   const [expanded, setExpanded] = useState<SettingsFeatureId | null>(null);
   return <section aria-labelledby="settings-features-heading" className="settings-section">
     <h3 id="settings-features-heading">Features &amp; Mods</h3>
-    <p className="settings-section-intro">AVAILABLE and STOCK FALLBACK ACTIVE require live runtime evidence. INSTALLED means the known dependencies were found but are not observable in this scene. NOT DETECTED means a fixed known marker was not found; UNKNOWN means the feed cannot classify it.</p>
+    <p className="settings-section-intro">Dashboard-wide status is based on the configured KSP installation, not the current game scene. AVAILABLE means the required known integrations were detected. AVAILABLE · STOCK means the feature remains available through Mission Control&apos;s built-in stock path. DETECTION UNAVAILABLE means the installation could not be checked.</p>
     <div className="settings-feature-list">
       {SETTINGS_FEATURES.map((feature) => {
         const capability = validCapabilitySnapshot(telemetry?.capabilities)
           ? telemetry.capabilities.features[feature.id]
           : undefined;
-        let status: SettingsFeatureStatus = capability?.status === "available"
-          || capability?.status === "fallback"
-          || capability?.status === "unavailable"
-          ? capability.status
-          : "unknown";
-        const evidence = capability && Array.isArray(capability.evidence)
+        const installationEvidence = capability && Array.isArray(capability.evidence)
           ? capability.evidence.filter((item): item is DashboardCapabilityEvidence => !!item && typeof item === "object" && (item.status === "active" || item.status === "detected" || item.status === "missing" || item.status === "unavailable" || item.status === "unknown") && (item.source === "runtime" || item.source === "root_scan") && typeof item.id === "string")
+            .filter((item) => item.source === "root_scan")
           : [];
-        const installationEvidence = evidence.filter((item) => item.source === "root_scan");
-        if (status === "unknown" && capability?.reason === "not_observed" && installationEvidence.length > 0 && installationEvidence.every((item) => item.status === "detected")) {
-          status = "installed";
-        } else if (status === "unknown" && capability?.reason === "dependency_missing" && installationEvidence.some((item) => item.status === "missing")) {
-          status = "not-detected";
-        }
+        const detected = installationEvidence.length > 0 && installationEvidence.every((item) => item.status === "detected");
+        const missing = installationEvidence.some((item) => item.status === "missing");
+        const status: SettingsFeatureStatus = detected
+          ? "available"
+          : missing
+            ? STOCK_CAPABILITY_FEATURES.has(feature.id) ? "stock" : "unavailable"
+            : "unknown";
         const open = expanded === feature.id;
         return <article className={`settings-feature settings-feature-${status}`} key={feature.id}>
           <button
@@ -256,7 +260,7 @@ function FeaturesSection({ telemetry }: { telemetry?: SettingsTelemetryInfo }) {
           </button>
           {open && <div id={`settings-feature-evidence-${feature.id}`} className="settings-feature-evidence">
             <p>{feature.evidence}</p>
-            {evidence.length > 0 && <ul>{evidence.map((item, index) => <li key={`${item.source}-${item.id}-${index}`}>{evidenceLabel(item)} / {evidenceStatusLabel(item.status)} / {item.source === "runtime" ? "Runtime" : "Installation scan"}{evidenceVersion(item)}</li>)}</ul>}
+            {installationEvidence.length > 0 && <ul>{installationEvidence.map((item, index) => <li key={`${item.source}-${item.id}-${index}`}>{evidenceLabel(item)} / {evidenceStatusLabel(item.status)} / Installation scan{evidenceVersion(item)}</li>)}</ul>}
           </div>}
         </article>;
       })}

--- a/frontend/src/settings/SettingsDrawer.tsx
+++ b/frontend/src/settings/SettingsDrawer.tsx
@@ -1,0 +1,421 @@
+import { useState } from "react";
+import { PRODUCT_NAME, PRODUCT_VERSION } from "../buildIdentity";
+import { useDialogFocus } from "../deltaV/useDialogFocus";
+import {
+  CURRENT_THEME_METADATA,
+} from "../theme";
+import type { TimeSystem } from "../timeSystem";
+import type {
+  DashboardCapabilitiesSnapshot,
+  DashboardCapabilityEvidence,
+  DashboardFeatureId,
+  ScienceAlarmProvider,
+} from "../telemetry/types";
+import {
+  SCIENCE_ALARM_ACTIONS,
+  SCIENCE_ALARM_PROVIDERS,
+  SETTINGS_SECTIONS,
+  type ScienceAlarmDefaults,
+  type SettingsSection,
+} from "./state";
+
+export type SettingsFeatureId = DashboardFeatureId;
+
+export type SettingsFeatureStatus = "available" | "fallback" | "unavailable" | "unknown";
+
+export const SETTINGS_FEATURES: readonly {
+  id: SettingsFeatureId;
+  label: string;
+  evidence: string;
+}[] = [
+  { id: "notes", label: "Notes", evidence: "Saved notes continuity across scenes" },
+  { id: "science_telemetry", label: "Science telemetry", evidence: "Science lab and experiment telemetry" },
+  { id: "science_alarms", label: "Science alarms", evidence: "KAC and Stock alarm providers" },
+  { id: "communications", label: "Communications", evidence: "RemoteTech and stock communications" },
+  { id: "stage_analysis", label: "Stage analysis", evidence: "Flight and editor staging analysis" },
+  { id: "live_transfer_calculations", label: "Live transfer calculations", evidence: "MechJeb-backed transfer planning" },
+  { id: "heat_monitoring", label: "Heat monitoring", evidence: "System Heat and stock thermal telemetry" },
+  { id: "heat_controls", label: "Heat controls", evidence: "System Heat radiator-loop controls" },
+  { id: "editor_electricity", label: "Editor electricity", evidence: "Editor electrical analysis" },
+  { id: "damage_monitoring", label: "Damage monitoring", evidence: "Vessel damage and stock damage telemetry" },
+];
+
+export interface SettingsTelemetryInfo {
+  capabilities?: DashboardCapabilitiesSnapshot | null;
+  effectiveEndpoint?: string;
+  persistenceStatus?: "shared" | "syncing" | "error" | "local";
+}
+
+export interface SettingsDrawerProps {
+  buildLabel?: "Development" | "Production";
+  effectiveEndpoint?: string;
+  hiddenPanelCount?: number;
+  issuesUrl?: string;
+  launcherBoundary?: string;
+  licenseUrl?: string;
+  onClose(): void;
+  onRestoreHiddenPanels?(): void;
+  onScienceAlarmSettingsChange(next: Partial<ScienceAlarmDefaults>): void;
+  onSectionChange(section: SettingsSection): void;
+  onSetTimeSystem?(system: TimeSystem): void;
+  open: boolean;
+  paletteLabel?: string;
+  productName?: string;
+  productVersion?: string;
+  releaseUrl?: string;
+  repositoryUrl?: string;
+  scienceAlarmProviders?: Partial<Record<ScienceAlarmProvider, boolean>>;
+  scienceAlarmSettings: ScienceAlarmDefaults;
+  section: SettingsSection;
+  telemetry?: SettingsTelemetryInfo;
+  timeSystem?: TimeSystem;
+  wikiBaseUrl?: string;
+}
+
+const DEFAULT_WIKI_BASE = "https://github.com/SacredWoobie/woobies-mission-control/wiki";
+const REPOSITORY_URL = "https://github.com/SacredWoobie/woobies-mission-control";
+const RELEASE_URL = `${REPOSITORY_URL}/releases/tag/v${PRODUCT_VERSION}`;
+const ISSUES_URL = `${REPOSITORY_URL}/issues`;
+const LICENSE_URL = `${REPOSITORY_URL}/blob/main/LICENSE`;
+
+function wikiUrl(base: string, slug: string) {
+  return `${base.replace(/\/$/, "")}/${slug}`;
+}
+
+function statusLabel(status: SettingsFeatureStatus) {
+  if (status === "available") return "AVAILABLE";
+  if (status === "fallback") return "STOCK FALLBACK ACTIVE";
+  if (status === "unavailable") return "UNAVAILABLE";
+  return "UNKNOWN";
+}
+
+function validCapabilitySnapshot(snapshot: DashboardCapabilitiesSnapshot | null | undefined): snapshot is DashboardCapabilitiesSnapshot {
+  return !!snapshot
+    && snapshot.schemaVersion === 1
+    && !!snapshot.features
+    && typeof snapshot.features === "object";
+}
+
+const EVIDENCE_LABELS: Record<string, string> = {
+  notes: "Notes provider",
+  vessel_science: "Vessel Science provider",
+  stock_science: "Stock science provider",
+  kac: "Kerbal Alarm Clock provider",
+  stock: "Stock alarm provider",
+  remote_tech: "RemoteTech provider",
+  stock_commnet: "Stock CommNet provider",
+  stage_stats: "StageStats service",
+  woobies_mechjeb: "Woobies MechJeb bridge",
+  mechjeb: "MechJeb compatibility",
+  system_heat: "System Heat provider",
+  stock_thermal: "Stock thermal fallback",
+  dynamic_battery_storage: "Dynamic battery storage",
+  stock_electricity: "Stock electricity fallback",
+  vessel_damage: "Vessel damage provider",
+  stock_damage: "Stock damage provider",
+  wcs: "Woobies Control Stats service",
+  system_heat_service: "Woobies System Heat service",
+  system_heat_mod: "System Heat mod",
+  compatibility_target: "Supported MechJeb target",
+};
+
+function evidenceLabel(evidence: DashboardCapabilityEvidence) {
+  return EVIDENCE_LABELS[evidence.id] ?? "Known capability evidence";
+}
+
+function evidenceStatusLabel(status: DashboardCapabilityEvidence["status"]) {
+  if (status === "active") return "ACTIVE";
+  if (status === "detected") return "DETECTED";
+  if (status === "missing") return "MISSING";
+  if (status === "unavailable") return "UNAVAILABLE";
+  return "UNKNOWN";
+}
+
+function evidenceVersion(evidence: DashboardCapabilityEvidence) {
+  return typeof evidence.version === "string"
+    && /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/.test(evidence.version)
+    ? ` / v${evidence.version}`
+    : "";
+}
+
+function externalLink(href: string, children: string) {
+  return <a href={href} rel="noreferrer" target="_blank">{children}</a>;
+}
+
+function LinkList({ base, links }: { base: string; links: readonly { label: string; slug: string }[] }) {
+  return <ul className="settings-link-list">
+    {links.map(({ label, slug }) => <li key={slug}>{externalLink(wikiUrl(base, slug), label)}</li>)}
+  </ul>;
+}
+
+function PreferencesSection({
+  heading = "Preferences",
+  hiddenPanelCount,
+  onRestoreHiddenPanels,
+  onScienceAlarmSettingsChange,
+  onSetTimeSystem,
+  scienceAlarmProviders,
+  scienceAlarmSettings,
+  scienceOnly = false,
+  timeSystem,
+}: Pick<SettingsDrawerProps, "hiddenPanelCount" | "onRestoreHiddenPanels" | "onScienceAlarmSettingsChange" | "onSetTimeSystem" | "scienceAlarmProviders" | "scienceAlarmSettings" | "timeSystem"> & { heading?: string; scienceOnly?: boolean }) {
+  return <section aria-labelledby="settings-preferences-heading" className="settings-section">
+    <h3 id="settings-preferences-heading">{heading}</h3>
+    {!scienceOnly && <fieldset className="settings-fieldset">
+      <legend>Time system</legend>
+      <div className="settings-choice-row">
+        {(["kerbin", "earth"] as const).map((candidate) => <button
+          aria-pressed={timeSystem === candidate}
+          key={candidate}
+          onClick={() => onSetTimeSystem?.(candidate)}
+          type="button"
+        >{candidate === "kerbin" ? "KERBIN TIME" : "EARTH TIME"}</button>)}
+      </div>
+      <small>Applies immediately to dashboard clocks and planning dates.</small>
+    </fieldset>}
+
+    <fieldset className="settings-fieldset">
+      <legend>Science alarm defaults</legend>
+      <div className="settings-choice-row">
+        {SCIENCE_ALARM_PROVIDERS.map(({ label, value }) => {
+          const available = value === "auto" || scienceAlarmProviders?.[value as ScienceAlarmProvider] === true;
+          return <button
+            aria-pressed={scienceAlarmSettings.provider === value}
+            disabled={!available}
+            key={value}
+            onClick={() => onScienceAlarmSettingsChange({ provider: value })}
+            title={available ? undefined : "Provider availability is unknown or unavailable."}
+            type="button"
+          >{label}</button>;
+        })}
+      </div>
+      <div className="settings-choice-row">
+        {[1800, 3600].map((seconds) => <button
+          aria-pressed={scienceAlarmSettings.leadSeconds === seconds}
+          key={seconds}
+          onClick={() => onScienceAlarmSettingsChange({ leadSeconds: seconds as 1800 | 3600 })}
+          type="button"
+        >{seconds === 1800 ? "30 MIN" : "1 HOUR"}</button>)}
+      </div>
+      <div className="settings-choice-row settings-choice-row-wrap">
+        {SCIENCE_ALARM_ACTIONS.map(({ label, value }) => <button
+          aria-pressed={scienceAlarmSettings.kacAction === value}
+          key={value}
+          onClick={() => onScienceAlarmSettingsChange({ kacAction: value })}
+          type="button"
+        >{label}</button>)}
+      </div>
+      <small>Selections are stored in this browser and apply immediately to new alarms.</small>
+    </fieldset>
+
+    {!scienceOnly && <fieldset className="settings-fieldset">
+      <legend>Panel visibility</legend>
+      <p>{hiddenPanelCount ? `${hiddenPanelCount} panel${hiddenPanelCount === 1 ? "" : "s"} hidden.` : "No hidden panels."}</p>
+      <button disabled={!hiddenPanelCount || !onRestoreHiddenPanels} onClick={onRestoreHiddenPanels} type="button">RESTORE HIDDEN PANELS</button>
+      <small>This restores dashboard panels only; it does not change telemetry, plans, or KSP state.</small>
+    </fieldset>}
+  </section>;
+}
+
+function FeaturesSection({ telemetry }: { telemetry?: SettingsTelemetryInfo }) {
+  const [expanded, setExpanded] = useState<SettingsFeatureId | null>(null);
+  return <section aria-labelledby="settings-features-heading" className="settings-section">
+    <h3 id="settings-features-heading">Features &amp; Mods</h3>
+    <p className="settings-section-intro">Availability is reported by the current dashboard feed. Missing or invalid capability data is shown as UNKNOWN.</p>
+    <div className="settings-feature-list">
+      {SETTINGS_FEATURES.map((feature) => {
+        const capability = validCapabilitySnapshot(telemetry?.capabilities)
+          ? telemetry.capabilities.features[feature.id]
+          : undefined;
+        const status: SettingsFeatureStatus = capability?.status === "available"
+          || capability?.status === "fallback"
+          || capability?.status === "unavailable"
+          ? capability.status
+          : "unknown";
+        const evidence = capability && Array.isArray(capability.evidence)
+          ? capability.evidence.filter((item): item is DashboardCapabilityEvidence => !!item && typeof item === "object" && (item.status === "active" || item.status === "detected" || item.status === "missing" || item.status === "unavailable" || item.status === "unknown") && (item.source === "runtime" || item.source === "root_scan") && typeof item.id === "string")
+          : [];
+        const open = expanded === feature.id;
+        return <article className={`settings-feature settings-feature-${status}`} key={feature.id}>
+          <button
+            aria-controls={`settings-feature-evidence-${feature.id}`}
+            aria-expanded={open}
+            className="settings-feature-toggle"
+            onClick={() => setExpanded(open ? null : feature.id)}
+            type="button"
+          >
+            <span>{feature.label}</span><strong>{statusLabel(status)}</strong>
+          </button>
+          {open && <div id={`settings-feature-evidence-${feature.id}`} className="settings-feature-evidence">
+            <p>{feature.evidence}</p>
+            {evidence.length > 0 && <ul>{evidence.map((item, index) => <li key={`${item.source}-${item.id}-${index}`}>{evidenceLabel(item)} / {evidenceStatusLabel(item.status)} / {item.source === "runtime" ? "Runtime" : "Installation scan"}{evidenceVersion(item)}</li>)}</ul>}
+          </div>}
+        </article>;
+      })}
+    </div>
+    <dl className="settings-diagnostics">
+      <div><dt>Effective endpoint</dt><dd>{telemetry?.effectiveEndpoint || "Unknown"}</dd></div>
+      <div><dt>Plan persistence</dt><dd>{telemetry?.persistenceStatus === "shared" ? "Shared file" : telemetry?.persistenceStatus === "syncing" ? "Syncing" : telemetry?.persistenceStatus === "error" ? "Storage error" : telemetry?.persistenceStatus === "local" ? "Local until linked" : "Unknown"}</dd></div>
+    </dl>
+  </section>;
+}
+
+function HelpSection({ wikiBaseUrl }: { wikiBaseUrl: string }) {
+  return <section aria-labelledby="settings-help-heading" className="settings-section">
+    <h3 id="settings-help-heading">Help</h3>
+    <h4>Start &amp; setup</h4>
+    <LinkList base={wikiBaseUrl} links={[
+      { label: "Getting Started", slug: "Getting-Started" },
+      { label: "Installation Options", slug: "Installation-Options" },
+      { label: "Launcher and Service Maintenance", slug: "Launcher-and-Service-Maintenance" },
+    ]} />
+    <h4>Dashboard</h4>
+    <LinkList base={wikiBaseUrl} links={[
+      { label: "Mission Control Overview", slug: "Mission-Control-Overview" },
+      { label: "Flight Dashboard", slug: "Flight-Dashboard" },
+      { label: "VAB and SPH", slug: "VAB-and-SPH" },
+      { label: "Mission Planning", slug: "Mission-Planning" },
+      { label: "Notes and Panel Customization", slug: "Notes-and-Panel-Customization" },
+    ]} />
+    <h4>Support</h4>
+    <LinkList base={wikiBaseUrl} links={[
+      { label: "Mods and Compatibility", slug: "Mods-and-Compatibility" },
+      { label: "Network and Safety", slug: "Network-and-Safety" },
+      { label: "Troubleshooting", slug: "Troubleshooting" },
+      { label: "ESP32 Controlpad", slug: "ESP32-Controlpad" },
+    ]} />
+  </section>;
+}
+
+function AboutSection({
+  buildLabel,
+  effectiveEndpoint,
+  issuesUrl,
+  launcherBoundary,
+  licenseUrl,
+  paletteLabel,
+  productName,
+  productVersion,
+  releaseUrl,
+  repositoryUrl,
+  wikiBaseUrl,
+}: {
+  buildLabel: "Development" | "Production";
+  effectiveEndpoint?: string;
+  issuesUrl: string;
+  launcherBoundary: string;
+  licenseUrl: string;
+  paletteLabel: string;
+  productName: string;
+  productVersion: string;
+  releaseUrl: string;
+  repositoryUrl: string;
+  wikiBaseUrl: string;
+}) {
+  return <section aria-labelledby="settings-about-heading" className="settings-section">
+    <h3 id="settings-about-heading">About</h3>
+    <dl className="settings-about-list">
+      <div><dt>Product</dt><dd>{productName}</dd></div>
+      <div><dt>Release</dt><dd>v{productVersion}</dd></div>
+      <div><dt>Build</dt><dd>{buildLabel}</dd></div>
+      <div><dt>Palette</dt><dd>{paletteLabel} (read-only)</dd></div>
+      <div><dt>Loopback endpoint</dt><dd>{effectiveEndpoint || "Unknown"}</dd></div>
+      <div><dt>Launcher boundary</dt><dd>{launcherBoundary}</dd></div>
+    </dl>
+    <ul className="settings-link-list">
+      <li>{externalLink(repositoryUrl, "Repository")}</li>
+      <li>{externalLink(wikiBaseUrl, "Project wiki")}</li>
+      <li>{externalLink(releaseUrl, `v${productVersion} release`)}</li>
+      <li>{externalLink(issuesUrl, "Issues")}</li>
+      <li>{externalLink(licenseUrl, "License")}</li>
+    </ul>
+  </section>;
+}
+
+export function SettingsDrawer({
+  buildLabel = "Production",
+  effectiveEndpoint,
+  hiddenPanelCount = 0,
+  issuesUrl = ISSUES_URL,
+  launcherBoundary = "The launcher selects the KSP folder, installs or repairs services, checks updates, and starts or stops the feed. This browser owns dashboard-local preferences only.",
+  licenseUrl = LICENSE_URL,
+  onClose,
+  onRestoreHiddenPanels,
+  onScienceAlarmSettingsChange,
+  onSectionChange,
+  onSetTimeSystem,
+  open,
+  paletteLabel = CURRENT_THEME_METADATA.label,
+  productName = PRODUCT_NAME,
+  productVersion = PRODUCT_VERSION,
+  releaseUrl = RELEASE_URL,
+  repositoryUrl = REPOSITORY_URL,
+  scienceAlarmProviders,
+  scienceAlarmSettings,
+  section,
+  telemetry,
+  timeSystem,
+  wikiBaseUrl = DEFAULT_WIKI_BASE,
+}: SettingsDrawerProps) {
+  const dialogRef = useDialogFocus<HTMLElement>(open, onClose);
+  if (!open) return null;
+
+  const effectiveTelemetry = {
+    ...telemetry,
+    effectiveEndpoint: effectiveEndpoint ?? telemetry?.effectiveEndpoint,
+  };
+
+  return <>
+    <div aria-hidden="true" className="resonant-drawer-backdrop settings-drawer-backdrop" onMouseDown={onClose} />
+    <aside aria-label="Mission Control Settings" aria-modal="true" className="resonant-drawer settings-drawer" id="settings-drawer" ref={dialogRef} role="dialog" tabIndex={-1}>
+      <header>
+        <div><span>MISSION CONTROL / SETTINGS</span><h2>Settings</h2><p>Browser-local preferences and integration guidance.</p></div>
+        <button aria-label="Close Settings" onClick={onClose} type="button">{"\u00d7"}</button>
+      </header>
+      <div className="settings-drawer-body resonant-drawer-body">
+        <nav aria-label="Settings sections" className="settings-section-nav">
+          {SETTINGS_SECTIONS.map(({ id, label }) => {
+            const active = section === id || (section === "science-alarms" && id === "preferences");
+            return <button aria-current={active ? "page" : undefined} className={active ? "active" : undefined} key={id} onClick={() => onSectionChange(id)} type="button">{label}</button>;
+          })}
+        </nav>
+        {section === "preferences" && <PreferencesSection
+          hiddenPanelCount={hiddenPanelCount}
+          onRestoreHiddenPanels={onRestoreHiddenPanels}
+          onScienceAlarmSettingsChange={onScienceAlarmSettingsChange}
+          onSetTimeSystem={onSetTimeSystem}
+          scienceAlarmProviders={scienceAlarmProviders}
+          scienceAlarmSettings={scienceAlarmSettings}
+          timeSystem={timeSystem}
+        />}
+        {section === "science-alarms" && <PreferencesSection
+          heading="Science alarm defaults"
+          hiddenPanelCount={hiddenPanelCount}
+          onRestoreHiddenPanels={onRestoreHiddenPanels}
+          onScienceAlarmSettingsChange={onScienceAlarmSettingsChange}
+          onSetTimeSystem={onSetTimeSystem}
+          scienceAlarmProviders={scienceAlarmProviders}
+          scienceAlarmSettings={scienceAlarmSettings}
+          scienceOnly
+          timeSystem={timeSystem}
+        />}
+        {section === "features-mods" && <FeaturesSection telemetry={effectiveTelemetry} />}
+        {section === "help" && <HelpSection wikiBaseUrl={wikiBaseUrl} />}
+        {section === "about" && <AboutSection
+          buildLabel={buildLabel}
+          effectiveEndpoint={effectiveEndpoint ?? telemetry?.effectiveEndpoint}
+          issuesUrl={issuesUrl}
+          launcherBoundary={launcherBoundary}
+          licenseUrl={licenseUrl}
+          paletteLabel={paletteLabel}
+          productName={productName}
+          productVersion={productVersion}
+          releaseUrl={releaseUrl}
+          repositoryUrl={repositoryUrl}
+          wikiBaseUrl={wikiBaseUrl}
+        />}
+      </div>
+      <footer><span>Preferences apply in this browser. KSP and the launcher remain outside the browser settings boundary.</span></footer>
+    </aside>
+  </>;
+}

--- a/frontend/src/settings/index.ts
+++ b/frontend/src/settings/index.ts
@@ -1,0 +1,24 @@
+export {
+  DEFAULT_SCIENCE_ALARM_SETTINGS,
+  SCIENCE_ALARM_ACTIONS,
+  SCIENCE_ALARM_PROVIDERS,
+  SCIENCE_ALARM_SETTINGS_KEY,
+  SETTINGS_SECTIONS,
+  normalizeScienceAlarmSettings,
+  persistScienceAlarmSettings,
+  readScienceAlarmSettings,
+  SettingsProvider,
+  useScienceAlarmSettings,
+  useSettings,
+  type ScienceAlarmDefaults,
+  type ScienceAlarmLead,
+  type SettingsSection,
+} from "./state";
+export {
+  SETTINGS_FEATURES,
+  SettingsDrawer,
+  type SettingsDrawerProps,
+  type SettingsFeatureId,
+  type SettingsFeatureStatus,
+  type SettingsTelemetryInfo,
+} from "./SettingsDrawer";

--- a/frontend/src/settings/state.test.tsx
+++ b/frontend/src/settings/state.test.tsx
@@ -9,9 +9,14 @@ import {
   normalizeScienceAlarmSettings,
   useSettings,
 } from "./state";
+import { THEME_STORAGE_KEY } from "../theme";
 
 afterEach(cleanup);
-beforeEach(() => localStorage.clear());
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.style.removeProperty("color-scheme");
+});
 
 function Harness() {
   const settings = useSettings();
@@ -19,8 +24,10 @@ function Harness() {
     <output data-testid="open">{String(settings.open)}</output>
     <output data-testid="section">{settings.section}</output>
     <output data-testid="alarm">{JSON.stringify(settings.scienceAlarmSettings)}</output>
+    <output data-testid="theme">{settings.themeId}</output>
     <button onClick={() => settings.openSettings("science-alarms")} type="button">Open alarms</button>
     <button onClick={() => settings.updateScienceAlarmSettings({ provider: "stock", leadSeconds: 1800, kacAction: "pause_game" })} type="button">Set alarm</button>
+    <button onClick={() => settings.updateTheme("green-phosphor")} type="button">Set theme</button>
     <button onClick={settings.closeSettings} type="button">Close</button>
   </>;
 }
@@ -33,6 +40,17 @@ describe("settings state", () => {
       leadSeconds: 1800,
       kacAction: "message_only",
     });
+  });
+
+  it("loads and immediately persists a theme selection for every dashboard scene", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, '"warm-crt"');
+    render(<SettingsProvider><Harness /></SettingsProvider>);
+    expect(screen.getByTestId("theme").textContent).toBe("warm-crt");
+
+    fireEvent.click(screen.getByRole("button", { name: "Set theme" }));
+    expect(screen.getByTestId("theme").textContent).toBe("green-phosphor");
+    expect(document.documentElement.dataset.theme).toBe("green-phosphor");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('"green-phosphor"');
   });
 
   it("keeps the section session-local and persists alarm updates immediately", () => {

--- a/frontend/src/settings/state.test.tsx
+++ b/frontend/src/settings/state.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_SCIENCE_ALARM_SETTINGS,
+  SCIENCE_ALARM_SETTINGS_KEY,
+  SettingsProvider,
+  normalizeScienceAlarmSettings,
+  useSettings,
+} from "./state";
+
+afterEach(cleanup);
+beforeEach(() => localStorage.clear());
+
+function Harness() {
+  const settings = useSettings();
+  return <>
+    <output data-testid="open">{String(settings.open)}</output>
+    <output data-testid="section">{settings.section}</output>
+    <output data-testid="alarm">{JSON.stringify(settings.scienceAlarmSettings)}</output>
+    <button onClick={() => settings.openSettings("science-alarms")} type="button">Open alarms</button>
+    <button onClick={() => settings.updateScienceAlarmSettings({ provider: "stock", leadSeconds: 1800, kacAction: "pause_game" })} type="button">Set alarm</button>
+    <button onClick={settings.closeSettings} type="button">Close</button>
+  </>;
+}
+
+describe("settings state", () => {
+  it("normalizes malformed or partial science alarm storage to the exact defaults", () => {
+    expect(normalizeScienceAlarmSettings({ provider: "bogus", leadSeconds: 999, kacAction: "bogus" })).toEqual(DEFAULT_SCIENCE_ALARM_SETTINGS);
+    expect(normalizeScienceAlarmSettings({ provider: "stock", leadSeconds: 1800, kacAction: "message_only" })).toEqual({
+      provider: "stock",
+      leadSeconds: 1800,
+      kacAction: "message_only",
+    });
+  });
+
+  it("keeps the section session-local and persists alarm updates immediately", () => {
+    render(<SettingsProvider><Harness /></SettingsProvider>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open alarms" }));
+    expect(screen.getByTestId("open").textContent).toBe("true");
+    expect(screen.getByTestId("section").textContent).toBe("science-alarms");
+
+    fireEvent.click(screen.getByRole("button", { name: "Set alarm" }));
+    expect(JSON.parse(localStorage.getItem(SCIENCE_ALARM_SETTINGS_KEY) ?? "null")).toEqual({
+      provider: "stock",
+      leadSeconds: 1800,
+      kacAction: "pause_game",
+    });
+    expect(screen.getByTestId("alarm").textContent).toContain('"provider":"stock"');
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.getByTestId("open").textContent).toBe("false");
+    expect(screen.getByTestId("section").textContent).toBe("science-alarms");
+  });
+
+  it("falls back safely when local storage contains invalid JSON", () => {
+    localStorage.setItem(SCIENCE_ALARM_SETTINGS_KEY, "{not-json");
+    render(<SettingsProvider><Harness /></SettingsProvider>);
+    expect(screen.getByTestId("alarm").textContent).toBe(JSON.stringify(DEFAULT_SCIENCE_ALARM_SETTINGS));
+  });
+
+  it("does not throw when browser storage is unavailable", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => { throw new Error("denied"); });
+    render(<SettingsProvider><Harness /></SettingsProvider>);
+    fireEvent.click(screen.getByRole("button", { name: "Set alarm" }));
+    expect(screen.getByTestId("alarm").textContent).toContain('"provider":"stock"');
+    setItem.mockRestore();
+  });
+});

--- a/frontend/src/settings/state.tsx
+++ b/frontend/src/settings/state.tsx
@@ -10,6 +10,11 @@ import type {
   ScienceAlarmAction,
   ScienceAlarmProviderPreference,
 } from "../telemetry/types";
+import {
+  loadThemeId,
+  selectTheme,
+  type ThemeId,
+} from "../theme";
 
 export const SCIENCE_ALARM_SETTINGS_KEY = "wmc-science-alarm-defaults-v1";
 
@@ -84,9 +89,11 @@ interface SettingsContextValue {
   open: boolean;
   section: SettingsSection;
   scienceAlarmSettings: ScienceAlarmDefaults;
+  themeId: ThemeId;
   closeSettings(): void;
   openSettings(section?: SettingsSection): void;
   selectSection(section: SettingsSection): void;
+  updateTheme(themeId: ThemeId): void;
   updateScienceAlarmSettings(next: Partial<ScienceAlarmDefaults> | ScienceAlarmDefaults): void;
 }
 
@@ -94,9 +101,11 @@ const fallbackSettings: SettingsContextValue = {
   open: false,
   section: "preferences",
   scienceAlarmSettings: DEFAULT_SCIENCE_ALARM_SETTINGS,
+  themeId: "mission-control-dark",
   closeSettings() {},
   openSettings() {},
   selectSection() {},
+  updateTheme() {},
   updateScienceAlarmSettings() {},
 };
 
@@ -106,6 +115,7 @@ export function SettingsProvider({ children }: PropsWithChildren) {
   const [open, setOpen] = useState(false);
   const [section, setSection] = useState<SettingsSection>("preferences");
   const [scienceAlarmSettings, setScienceAlarmSettings] = useState(readScienceAlarmSettings);
+  const [themeId, setThemeId] = useState(loadThemeId);
 
   const closeSettings = useCallback(() => setOpen(false), []);
   const openSettings = useCallback((nextSection: SettingsSection = "preferences") => {
@@ -113,6 +123,9 @@ export function SettingsProvider({ children }: PropsWithChildren) {
     setOpen(true);
   }, []);
   const selectSection = useCallback((nextSection: SettingsSection) => setSection(nextSection), []);
+  const updateTheme = useCallback((nextThemeId: ThemeId) => {
+    setThemeId(selectTheme(nextThemeId));
+  }, []);
   const updateScienceAlarmSettings = useCallback((next: Partial<ScienceAlarmDefaults> | ScienceAlarmDefaults) => {
     setScienceAlarmSettings((current) => {
       const merged = normalizeScienceAlarmSettings({ ...current, ...next });
@@ -128,8 +141,10 @@ export function SettingsProvider({ children }: PropsWithChildren) {
     scienceAlarmSettings,
     section,
     selectSection,
+    themeId,
+    updateTheme,
     updateScienceAlarmSettings,
-  }), [closeSettings, open, openSettings, scienceAlarmSettings, section, selectSection, updateScienceAlarmSettings]);
+  }), [closeSettings, open, openSettings, scienceAlarmSettings, section, selectSection, themeId, updateScienceAlarmSettings, updateTheme]);
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 }

--- a/frontend/src/settings/state.tsx
+++ b/frontend/src/settings/state.tsx
@@ -1,0 +1,144 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
+import type {
+  ScienceAlarmAction,
+  ScienceAlarmProviderPreference,
+} from "../telemetry/types";
+
+export const SCIENCE_ALARM_SETTINGS_KEY = "wmc-science-alarm-defaults-v1";
+
+export type ScienceAlarmLead = 1800 | 3600;
+
+export interface ScienceAlarmDefaults {
+  provider: ScienceAlarmProviderPreference;
+  leadSeconds: ScienceAlarmLead;
+  kacAction: ScienceAlarmAction;
+}
+
+export const DEFAULT_SCIENCE_ALARM_SETTINGS: ScienceAlarmDefaults = {
+  provider: "auto",
+  leadSeconds: 3600,
+  kacAction: "kill_warp",
+};
+
+export const SCIENCE_ALARM_ACTIONS: readonly { label: string; value: ScienceAlarmAction }[] = [
+  { label: "KILL WARP", value: "kill_warp" },
+  { label: "PAUSE GAME", value: "pause_game" },
+  { label: "MESSAGE ONLY", value: "message_only" },
+  { label: "DO NOTHING", value: "do_nothing" },
+];
+
+export const SCIENCE_ALARM_PROVIDERS: readonly { label: string; value: ScienceAlarmProviderPreference }[] = [
+  { label: "AUTO", value: "auto" },
+  { label: "KAC", value: "kac" },
+  { label: "STOCK", value: "stock" },
+];
+
+function isScienceAlarmAction(value: unknown): value is ScienceAlarmAction {
+  return SCIENCE_ALARM_ACTIONS.some((action) => action.value === value);
+}
+
+export function normalizeScienceAlarmSettings(value: unknown): ScienceAlarmDefaults {
+  const parsed = value as Partial<ScienceAlarmDefaults> | null;
+  return {
+    provider: parsed?.provider === "kac" || parsed?.provider === "stock" ? parsed.provider : "auto",
+    leadSeconds: parsed?.leadSeconds === 1800 ? 1800 : 3600,
+    kacAction: isScienceAlarmAction(parsed?.kacAction) ? parsed!.kacAction : "kill_warp",
+  };
+}
+
+export function readScienceAlarmSettings(storage: Storage | undefined = typeof localStorage === "undefined" ? undefined : localStorage): ScienceAlarmDefaults {
+  if (!storage) return DEFAULT_SCIENCE_ALARM_SETTINGS;
+  try {
+    return normalizeScienceAlarmSettings(JSON.parse(storage.getItem(SCIENCE_ALARM_SETTINGS_KEY) ?? "null"));
+  } catch {
+    return DEFAULT_SCIENCE_ALARM_SETTINGS;
+  }
+}
+
+export function persistScienceAlarmSettings(settings: ScienceAlarmDefaults, storage: Storage | undefined = typeof localStorage === "undefined" ? undefined : localStorage) {
+  if (!storage) return;
+  try {
+    storage.setItem(SCIENCE_ALARM_SETTINGS_KEY, JSON.stringify(normalizeScienceAlarmSettings(settings)));
+  } catch {
+    // Private browsing and embedded webviews may deny optional local storage.
+  }
+}
+
+export type SettingsSection = "preferences" | "features-mods" | "help" | "about" | "science-alarms";
+
+export const SETTINGS_SECTIONS: readonly { id: SettingsSection; label: string }[] = [
+  { id: "preferences", label: "Preferences" },
+  { id: "features-mods", label: "Features & Mods" },
+  { id: "help", label: "Help" },
+  { id: "about", label: "About" },
+];
+
+interface SettingsContextValue {
+  open: boolean;
+  section: SettingsSection;
+  scienceAlarmSettings: ScienceAlarmDefaults;
+  closeSettings(): void;
+  openSettings(section?: SettingsSection): void;
+  selectSection(section: SettingsSection): void;
+  updateScienceAlarmSettings(next: Partial<ScienceAlarmDefaults> | ScienceAlarmDefaults): void;
+}
+
+const fallbackSettings: SettingsContextValue = {
+  open: false,
+  section: "preferences",
+  scienceAlarmSettings: DEFAULT_SCIENCE_ALARM_SETTINGS,
+  closeSettings() {},
+  openSettings() {},
+  selectSection() {},
+  updateScienceAlarmSettings() {},
+};
+
+const SettingsContext = createContext<SettingsContextValue>(fallbackSettings);
+
+export function SettingsProvider({ children }: PropsWithChildren) {
+  const [open, setOpen] = useState(false);
+  const [section, setSection] = useState<SettingsSection>("preferences");
+  const [scienceAlarmSettings, setScienceAlarmSettings] = useState(readScienceAlarmSettings);
+
+  const closeSettings = useCallback(() => setOpen(false), []);
+  const openSettings = useCallback((nextSection: SettingsSection = "preferences") => {
+    setSection(nextSection);
+    setOpen(true);
+  }, []);
+  const selectSection = useCallback((nextSection: SettingsSection) => setSection(nextSection), []);
+  const updateScienceAlarmSettings = useCallback((next: Partial<ScienceAlarmDefaults> | ScienceAlarmDefaults) => {
+    setScienceAlarmSettings((current) => {
+      const merged = normalizeScienceAlarmSettings({ ...current, ...next });
+      persistScienceAlarmSettings(merged);
+      return merged;
+    });
+  }, []);
+
+  const value = useMemo<SettingsContextValue>(() => ({
+    closeSettings,
+    open,
+    openSettings,
+    scienceAlarmSettings,
+    section,
+    selectSection,
+    updateScienceAlarmSettings,
+  }), [closeSettings, open, openSettings, scienceAlarmSettings, section, selectSection, updateScienceAlarmSettings]);
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}
+
+export function useSettings() {
+  return useContext(SettingsContext);
+}
+
+export function useScienceAlarmSettings() {
+  const { scienceAlarmSettings, updateScienceAlarmSettings } = useSettings();
+  return { scienceAlarmSettings, updateScienceAlarmSettings };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2981,7 +2981,9 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 .settings-feature-list { display: grid; gap: 7px; }
 .settings-feature { overflow: hidden; border: 1px solid var(--surface-seam); border-left: 3px solid var(--slate-dim); border-radius: var(--surface-radius-face); background: var(--surface-plate); }
 .settings-feature-available { border-left-color: var(--green); }
+.settings-feature-installed { border-left-color: var(--cyan); }
 .settings-feature-fallback { border-left-color: var(--amber); }
+.settings-feature-not-detected { border-left-color: var(--danger); }
 .settings-feature-unavailable { border-left-color: var(--danger); }
 .settings-feature-toggle {
   display: grid;
@@ -3002,7 +3004,9 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 .settings-feature-toggle > span { min-width: 0; font-size: 11px; font-weight: 700; }
 .settings-feature-toggle > strong { color: var(--slate); font-size: 8px; letter-spacing: .06em; text-align: right; }
 .settings-feature-available .settings-feature-toggle > strong { color: var(--green); }
+.settings-feature-installed .settings-feature-toggle > strong { color: var(--cyan); }
 .settings-feature-fallback .settings-feature-toggle > strong { color: var(--amber); }
+.settings-feature-not-detected .settings-feature-toggle > strong { color: var(--danger); }
 .settings-feature-unavailable .settings-feature-toggle > strong { color: var(--danger); }
 .settings-feature-evidence { padding: 0 12px 12px; border-top: 1px solid var(--rule); color: var(--slate); font-size: 9px; line-height: 1.5; }
 .settings-feature-evidence p { margin: 10px 0 7px; color: var(--text-value); }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -87,17 +87,331 @@
   --surface-glow-amber: 0 0 13px rgba(255,180,84,.3);
   --surface-glow-cyan: 0 0 13px rgba(78,201,224,.3);
   --surface-glow-progress: 0 0 9px rgba(126,231,135,.45);
+  --page-background: #05070b;
+  --ambient-highlight: #0d1420;
+  --scanline-stripe: rgba(255,255,255,.012);
+  --panel-translucent: rgba(15,21,31,.78);
+  --table-text: #aeb9c7;
+  --row-text: #b8c5d3;
+  --row-text-muted: #91a1b4;
+  --row-selected-wash: rgba(78,201,224,.12);
+  --row-hover-wash: rgba(78,201,224,.055);
+  --control-pressed: #102633;
+  --rail-face: #211a12;
+  --rail-face-hover: #2b2115;
+  --rail-text-hover: #ffd498;
+  --note-cover: rgba(255,180,84,.08);
+  --chip-surface: #0b1119;
+  --tag-border: #385065;
+  --group-head-top: #3b444e;
+  --group-head-mid: #2f3740;
+  --group-head-bottom: #242b32;
+  --group-head-text: #f4f7fa;
+  --group-head-divider: #151b21;
+  --group-head-depth: inset 0 1px rgba(255,255,255,.13), inset 0 -1px rgba(0,0,0,.55), 0 1px 3px rgba(0,0,0,.38);
+  --group-head-text-shadow: 0 1px 1px rgba(0,0,0,.8);
+  --fact-rule: rgba(35,58,74,.66);
+  --crew-rule: rgba(35,58,74,.42);
+  --card-wash: rgba(5,10,15,.2);
+  --on-accent: #041016;
+  --destructive-border: #7b3838;
+  --destructive-surface: #211010;
+  --memorial-border: #5e4726;
+  --suit-ring: #e6a749;
+  --briefing-heading: #edf6fb;
+  --honor-name: #c4a476;
+  --honor-body: #8f8172;
   --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+  --display: var(--mono);
   color-scheme: dark;
   color: var(--amber);
-  background: #05070b;
+  background: var(--page-background);
   font-family: var(--mono);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
 }
 
+:root[data-theme="daylight-console"] {
+  --bg: #dde3ea;
+  --panel: #ffffff;
+  --panel-2: #f2f5f9;
+  --rule: #d5dde6;
+  --rule-bright: #bcc7d3;
+  --accent-border: #7fa7bb;
+  --accent-border-hover: #5d8ca2;
+  --amber: #8a5300;
+  --amber-dim: #8f6216;
+  --amber-accent: #c9ae82;
+  --cyan: #0d6379;
+  --slate: #4e5c6c;
+  --slate-dim: #7d8997;
+  --slate-muted-text: #5b6979;
+  --text-primary: #16202b;
+  --text-value: #243040;
+  --green: #1b7238;
+  --success-border: #8fc39f;
+  --warn: #b8431f;
+  --danger: #a81f19;
+  --error-text: #8f2922;
+  --error-text-muted: #8a3c35;
+  --control-surface: #e8edf3;
+  --control-surface-hover: #dbe5ee;
+  --instrument-surface: #f7f9fc;
+  --surface-panel-top: #ffffff;
+  --surface-panel-bottom: #eef2f7;
+  --surface-bezel-color: #b9c5d2;
+  --surface-bezel-lit: #9eafbf;
+  --surface-grout: #c9d3dd;
+  --surface-plate-edge: #c5d0dc;
+  --surface-plate-top: #fbfcfe;
+  --surface-plate-bottom: #f2f5f9;
+  --surface-well-top: #f4f7fa;
+  --surface-well-bottom: #e9eff5;
+  --surface-rail-top: #eff3f8;
+  --surface-rail-bottom: #e2e8f0;
+  --surface-raised-top: #ffffff;
+  --surface-raised-bottom: #edf1f6;
+  --surface-amber-face-top: #fff4df;
+  --surface-amber-face-bottom: #ead8b8;
+  --surface-amber-face-edge: #b78945;
+  --surface-amber-face-text: #704100;
+  --surface-cyan-face-top: #e2f1f5;
+  --surface-cyan-face-bottom: #cce2e9;
+  --surface-cyan-face-edge: #6d9faf;
+  --surface-status-frame: #d9e1e9;
+  --surface-status-cell-top: #f6f8fb;
+  --surface-status-cell-bottom: #e9eef4;
+  --surface-track: #d4dde6;
+  --surface-progress-top: #45a65e;
+  --surface-progress-bottom: #1b7238;
+  --surface-screw: radial-gradient(circle at 36% 30%, #ffffff 0%, #aebbc8 55%, #72808d 100%);
+  --surface-depth-raised: inset 0 1px 0 rgba(255,255,255,.95), inset 0 -1px 0 rgba(30,50,70,.12), 0 2px 8px rgba(30,50,70,.14);
+  --surface-depth-control: inset 0 1px 0 rgba(255,255,255,.9), 0 1px 2px rgba(30,50,70,.12);
+  --surface-depth-recessed: inset 0 1px 2px rgba(30,50,70,.12), inset 0 -1px 0 rgba(255,255,255,.7);
+  --surface-depth-deep: inset 0 1px 3px rgba(30,50,70,.22);
+  --surface-depth-engraved: inset 0 1px 0 rgba(255,255,255,.85), 0 1px 0 rgba(30,50,70,.06);
+  --surface-depth-plate: inset 0 1px 0 rgba(255,255,255,.9), inset 0 -1px 0 rgba(30,50,70,.12), 0 2px 10px rgba(30,50,70,.12);
+  --surface-etch: 0 1px 0 rgba(255,255,255,.8);
+  --surface-glow-amber: 0 0 8px rgba(138,83,0,.18);
+  --surface-glow-cyan: 0 0 8px rgba(13,99,121,.18);
+  --surface-glow-progress: 0 0 6px rgba(27,114,56,.2);
+  --page-background: #dde3ea;
+  --ambient-highlight: #f8fafc;
+  --scanline-stripe: rgba(24,40,60,.014);
+  --panel-translucent: rgba(255,255,255,.9);
+  --table-text: #2c3947;
+  --row-text: #2b3846;
+  --row-text-muted: #5b6979;
+  --row-selected-wash: rgba(13,99,121,.1);
+  --row-hover-wash: rgba(13,99,121,.06);
+  --control-pressed: #dbeef4;
+  --rail-face: #fff6e6;
+  --rail-face-hover: #f2e2c6;
+  --rail-text-hover: #704100;
+  --note-cover: rgba(138,83,0,.07);
+  --chip-surface: #f2f5f9;
+  --tag-border: #93b8c7;
+  --group-head-top: #dee5ed;
+  --group-head-mid: #ced7e1;
+  --group-head-bottom: #c1cbd7;
+  --group-head-text: #1a2531;
+  --group-head-divider: #b8c3cf;
+  --group-head-depth: inset 0 1px rgba(255,255,255,.8), inset 0 -1px rgba(30,50,70,.14), 0 1px 3px rgba(30,50,70,.12);
+  --group-head-text-shadow: 0 1px 0 rgba(255,255,255,.65);
+  --fact-rule: rgba(120,140,160,.35);
+  --crew-rule: rgba(120,140,160,.24);
+  --card-wash: rgba(255,255,255,.55);
+  --on-accent: #f3fbfd;
+  --destructive-border: #d8a09c;
+  --destructive-surface: #fbeceb;
+  --memorial-border: #d3b787;
+  --suit-ring: #b57a1c;
+  --briefing-heading: #101923;
+  --honor-name: #7a5a22;
+  --honor-body: #6d6252;
+  color-scheme: light;
+}
+
+:root[data-theme="warm-crt"] {
+  --bg: #0d0a06;
+  --panel: #1e1710;
+  --panel-2: #150f0a;
+  --rule: #2e2216;
+  --rule-bright: #46331f;
+  --accent-border: #6b4a22;
+  --accent-border-hover: #87602e;
+  --amber: #ffc36b;
+  --amber-dim: #b98a3e;
+  --amber-accent: #7d5c2f;
+  --cyan: #6fd0c2;
+  --slate: #b39a76;
+  --slate-dim: #755f43;
+  --slate-muted-text: #a68d6a;
+  --text-primary: #f4e2c6;
+  --text-value: #e9d5b4;
+  --green: #9ada6b;
+  --success-border: #4f6b32;
+  --warn: #ff8a4c;
+  --danger: #ff6b5b;
+  --error-text: #ff9b8f;
+  --error-text-muted: #e9988d;
+  --control-surface: #261b11;
+  --control-surface-hover: #352719;
+  --instrument-surface: #0b0704;
+  --surface-panel-top: #241b12;
+  --surface-panel-bottom: #1a130c;
+  --surface-bezel-color: #3d2c1b;
+  --surface-bezel-lit: #594026;
+  --surface-grout: #0d0906;
+  --surface-plate-edge: #352719;
+  --surface-plate-top: #1d160f;
+  --surface-plate-bottom: #150f0a;
+  --surface-well-top: #140e08;
+  --surface-well-bottom: #1a130c;
+  --surface-rail-top: #2c2116;
+  --surface-rail-bottom: #20180f;
+  --surface-raised-top: #33261a;
+  --surface-raised-bottom: #1e160e;
+  --surface-amber-face-top: #3a2b18;
+  --surface-amber-face-bottom: #21170d;
+  --surface-amber-face-edge: #8a6532;
+  --surface-amber-face-text: #ffd08a;
+  --surface-cyan-face-top: #18302a;
+  --surface-cyan-face-bottom: #0e1c19;
+  --surface-cyan-face-edge: #477f75;
+  --surface-status-frame: #251b12;
+  --surface-status-cell-top: #21180f;
+  --surface-status-cell-bottom: #181109;
+  --surface-track: #0f0a06;
+  --surface-progress-top: #b8e482;
+  --surface-progress-bottom: #79b94a;
+  --surface-screw: radial-gradient(circle at 36% 30%, #6a5035 0%, #38291b 55%, #120c07 100%);
+  --surface-glow-amber: 0 0 13px rgba(255,195,107,.28);
+  --surface-glow-cyan: 0 0 13px rgba(111,208,194,.25);
+  --surface-glow-progress: 0 0 9px rgba(154,218,107,.35);
+  --page-background: #0d0a06;
+  --ambient-highlight: #21170e;
+  --scanline-stripe: rgba(255,190,120,.022);
+  --panel-translucent: rgba(30,23,16,.82);
+  --table-text: #d9c4a2;
+  --row-text: #dcc9a9;
+  --row-text-muted: #a68d6a;
+  --row-selected-wash: rgba(111,208,194,.12);
+  --row-hover-wash: rgba(111,208,194,.06);
+  --control-pressed: #123029;
+  --rail-face: #2a2015;
+  --rail-face-hover: #3b2d1e;
+  --rail-text-hover: #ffda9a;
+  --note-cover: rgba(255,195,107,.08);
+  --chip-surface: #1a130c;
+  --tag-border: #3f6b62;
+  --group-head-top: #4a3a28;
+  --group-head-mid: #3b2d1e;
+  --group-head-bottom: #2e2317;
+  --group-head-text: #ffeccd;
+  --group-head-divider: #1a130c;
+  --fact-rule: rgba(90,70,45,.66);
+  --crew-rule: rgba(90,70,45,.42);
+  --card-wash: rgba(12,8,4,.35);
+  --on-accent: #06120f;
+  --destructive-border: #7b3838;
+  --destructive-surface: #241110;
+  --memorial-border: #7d5c2f;
+  --briefing-heading: #fff1d8;
+  color-scheme: dark;
+}
+
+:root[data-theme="green-phosphor"] {
+  --bg: #040a07;
+  --panel: #0c1810;
+  --panel-2: #07110b;
+  --rule: #16301f;
+  --rule-bright: #23472f;
+  --accent-border: #2c6b48;
+  --accent-border-hover: #40865e;
+  --amber: #ffc247;
+  --amber-dim: #b58a35;
+  --amber-accent: #5d5227;
+  --cyan: #bdf6cf;
+  --slate: #8fb89b;
+  --slate-dim: #557761;
+  --slate-muted-text: #7fa88c;
+  --text-primary: #d8f6e2;
+  --text-value: #c2ecd0;
+  --green: #4dff8f;
+  --success-border: #2e7a4b;
+  --warn: #ff6b5b;
+  --danger: #ff6b5b;
+  --error-text: #ff9b8f;
+  --error-text-muted: #e9988d;
+  --control-surface: #0b1b11;
+  --control-surface-hover: #11291a;
+  --instrument-surface: #030806;
+  --surface-panel-top: #0e1c14;
+  --surface-panel-bottom: #08120c;
+  --surface-bezel-color: #1e3b28;
+  --surface-bezel-lit: #2b5438;
+  --surface-grout: #040a06;
+  --surface-plate-edge: #163322;
+  --surface-plate-top: #0b1710;
+  --surface-plate-bottom: #07110b;
+  --surface-well-top: #061009;
+  --surface-well-bottom: #0a170f;
+  --surface-rail-top: #132618;
+  --surface-rail-bottom: #0d1b12;
+  --surface-raised-top: #16291c;
+  --surface-raised-bottom: #0c1710;
+  --surface-amber-face-top: #2b2612;
+  --surface-amber-face-bottom: #171309;
+  --surface-amber-face-edge: #71652e;
+  --surface-amber-face-text: #ffcf6c;
+  --surface-cyan-face-top: #173324;
+  --surface-cyan-face-bottom: #0b1b12;
+  --surface-cyan-face-edge: #3b8056;
+  --surface-status-frame: #0e2015;
+  --surface-status-cell-top: #0c1b12;
+  --surface-status-cell-bottom: #08130d;
+  --surface-track: #030906;
+  --surface-progress-top: #8affb5;
+  --surface-progress-bottom: #35cf70;
+  --surface-screw: radial-gradient(circle at 36% 30%, #416d50 0%, #213b29 55%, #07100a 100%);
+  --surface-glow-amber: 0 0 13px rgba(255,194,71,.25);
+  --surface-glow-cyan: 0 0 13px rgba(189,246,207,.25);
+  --surface-glow-progress: 0 0 9px rgba(77,255,143,.38);
+  --page-background: #040a07;
+  --ambient-highlight: #0a1c11;
+  --scanline-stripe: rgba(120,255,170,.022);
+  --panel-translucent: rgba(12,24,16,.82);
+  --table-text: #aedcbd;
+  --row-text: #b2e0c0;
+  --row-text-muted: #7fa88c;
+  --row-selected-wash: rgba(189,246,207,.1);
+  --row-hover-wash: rgba(189,246,207,.055);
+  --control-pressed: #123322;
+  --rail-face: #1c1a10;
+  --rail-face-hover: #2b2715;
+  --rail-text-hover: #ffe08a;
+  --note-cover: rgba(255,194,71,.07);
+  --chip-surface: #0a170f;
+  --tag-border: #2f6b4a;
+  --group-head-top: #2b4534;
+  --group-head-mid: #213629;
+  --group-head-bottom: #19291f;
+  --group-head-text: #dcffe8;
+  --group-head-divider: #0a170f;
+  --fact-rule: rgba(45,90,62,.66);
+  --crew-rule: rgba(45,90,62,.42);
+  --card-wash: rgba(4,12,8,.35);
+  --on-accent: #04140a;
+  --destructive-border: #7b3838;
+  --destructive-surface: #1c1010;
+  --memorial-border: #6b5a26;
+  --briefing-heading: #e9fff0;
+  color-scheme: dark;
+}
+
 * { box-sizing: border-box; }
-body { margin: 0; min-width: 320px; min-height: 100vh; background: #05070b; }
+body { margin: 0; min-width: 320px; min-height: 100vh; background: var(--page-background); }
 button { font: inherit; }
 
 .app-shell { min-height: 100vh; }
@@ -214,7 +528,7 @@ button { font: inherit; }
   padding: 10px 10px 42px;
   overflow: hidden;
   color: var(--amber);
-  background: radial-gradient(1200px 600px at 50% -10%, #0d1420 0%, var(--bg) 60%), var(--bg);
+  background: radial-gradient(1200px 600px at 50% -10%, var(--ambient-highlight) 0%, var(--bg) 60%), var(--bg);
   font-family: var(--mono);
   font-size: 13px;
   line-height: 1.3;
@@ -225,7 +539,7 @@ button { font: inherit; }
   inset: 0;
   content: "";
   pointer-events: none;
-  background: repeating-linear-gradient(0deg, rgba(255,255,255,.012) 0, rgba(255,255,255,.012) 1px, transparent 1px, transparent 3px);
+  background: repeating-linear-gradient(0deg, var(--scanline-stripe) 0, var(--scanline-stripe) 1px, transparent 1px, transparent 3px);
 }
 .dashboard-surface.inactive-mode { padding-left: 52px; }
 .dashboard-surface.flight-mode { padding-bottom: 10px; }
@@ -469,19 +783,19 @@ button { font: inherit; }
   opacity: 1;
   transform: translateX(0);
 }
-.notes-rail-tab.panel-rail-button { border-color: var(--accent-border); color: var(--cyan); background: #101c27; }
+.notes-rail-tab.panel-rail-button { border-color: var(--accent-border); color: var(--cyan); background: var(--control-surface); }
 .dashboard-rail .panel-rail-button,
 .dashboard-rail .notes-rail-tab.panel-rail-button {
   border-color: var(--amber-accent);
   color: var(--amber);
-  background: #211a12;
+  background: var(--rail-face);
 }
 .dashboard-rail .panel-rail-button:hover,
 .dashboard-rail .panel-rail-button:focus-visible,
 .dashboard-rail .panel-rail-button[aria-expanded="true"] {
   border-color: var(--amber-dim);
-  color: #ffd498;
-  background: #2b2115;
+  color: var(--rail-text-hover);
+  background: var(--rail-face-hover);
 }
 .dashboard-rail .panel-rail-icon .rail-note-cover { fill: rgba(255,180,84,.08); }
 .dashboard-rail .resonant-rail-icon i {
@@ -691,7 +1005,7 @@ button { font: inherit; }
 .overview-section-actions { display: flex; min-width: 28px; align-items: center; justify-content: flex-end; gap: 8px; }
 .overview-section-actions > strong { min-width: 28px; color: var(--cyan); font-size: 20px; font-weight: 500; text-align: right; }
 .overview-header-button { min-height: 26px; padding: 3px 7px; border: 1px solid var(--accent-border); border-radius: var(--surface-radius-face); color: var(--cyan); background: var(--surface-raised-face); box-shadow: var(--surface-depth-control); cursor: pointer; font: 8px var(--mono); letter-spacing: .04em; white-space: nowrap; }
-.overview-header-button:hover:not(:disabled), .overview-header-button:focus-visible, .overview-header-button[aria-expanded="true"], .overview-header-button[aria-pressed="true"] { border-color: var(--cyan); background: #102633; outline: 0; }
+.overview-header-button:hover:not(:disabled), .overview-header-button:focus-visible, .overview-header-button[aria-expanded="true"], .overview-header-button[aria-pressed="true"] { border-color: var(--cyan); background: var(--control-pressed); outline: 0; }
 .overview-header-button:disabled { opacity: .42; cursor: not-allowed; }
 .overview-alarm-source-buttons { display: flex; align-items: center; gap: 3px; }
 .overview-controls { display: grid; padding: 9px; align-items: end; grid-template-columns: minmax(135px,1.3fr) repeat(4,minmax(90px,.75fr)) auto; gap: 6px; border-bottom: 1px solid var(--surface-seam); background: var(--surface-rail); box-shadow: var(--surface-depth-engraved); }
@@ -721,41 +1035,41 @@ button { font: inherit; }
 .overview-table { width: 100%; border-collapse: collapse; font-size: 9px; font-variant-numeric: tabular-nums; }
 .overview-table th, .overview-table td { padding: 7px 9px; overflow: hidden; border-bottom: 1px solid var(--rule); text-align: left; text-overflow: ellipsis; white-space: nowrap; }
 .overview-table th { color: var(--slate-muted-text); background: var(--surface-well-top); font-size: 8px; font-weight: 500; letter-spacing: .12em; text-transform: uppercase; }
-.overview-table td { max-width: 190px; color: #aeb9c7; }
+.overview-table td { max-width: 190px; color: var(--table-text); }
 .overview-table td:first-child { color: var(--cyan); }
 .overview-table tbody tr:last-child td { border-bottom: 0; }
 .overview-table tbody tr:hover td { background: rgba(78,201,224,.035); }
 .overview-vessel-split { display: grid; min-width: 0; min-height: 180px; max-height: clamp(220px,38vh,420px); overflow: hidden; grid-template-columns: minmax(180px,.72fr) minmax(260px,1.28fr); background: var(--surface-plate); }
 .overview-vessel-index { min-width: 0; overflow: auto; border-right: 1px solid var(--surface-seam); background: var(--instrument-surface); overscroll-behavior: contain; }
-.overview-vessel-group h3 { min-height: 28px; margin: 0; color: #f4f7fa; background: linear-gradient(180deg,#3b444e 0%,#2f3740 46%,#242b32 100%); box-shadow: inset 0 1px rgba(255,255,255,.13),inset 0 -1px rgba(0,0,0,.55),0 1px 3px rgba(0,0,0,.38); font-size: 8px; font-weight: 600; letter-spacing: .12em; text-shadow: 0 1px 1px rgba(0,0,0,.8); text-transform: uppercase; }
-.overview-vessel-group + .overview-vessel-group h3 { border-top: 1px solid #151b21; }
-.overview-vessel-group-toggle { display: grid; width: 100%; min-width: 0; min-height: 28px; padding: 5px 9px; align-items: center; grid-template-columns: 12px minmax(0,1fr) auto; gap: 6px; border: 0; color: #f4f7fa; background: transparent; cursor: pointer; font: inherit; letter-spacing: inherit; text-align: left; text-transform: inherit; }
+.overview-vessel-group h3 { min-height: 28px; margin: 0; color: var(--group-head-text); background: linear-gradient(180deg,var(--group-head-top) 0%,var(--group-head-mid) 46%,var(--group-head-bottom) 100%); box-shadow: var(--group-head-depth); font-size: 8px; font-weight: 600; letter-spacing: .12em; text-shadow: var(--group-head-text-shadow); text-transform: uppercase; }
+.overview-vessel-group + .overview-vessel-group h3 { border-top: 1px solid var(--group-head-divider); }
+.overview-vessel-group-toggle { display: grid; width: 100%; min-width: 0; min-height: 28px; padding: 5px 9px; align-items: center; grid-template-columns: 12px minmax(0,1fr) auto; gap: 6px; border: 0; color: var(--group-head-text); background: transparent; cursor: pointer; font: inherit; letter-spacing: inherit; text-align: left; text-transform: inherit; }
 .overview-vessel-group-toggle:hover, .overview-vessel-group-toggle:focus-visible { color: #fff; background: linear-gradient(180deg,rgba(255,255,255,.09),rgba(255,255,255,.025)); outline: 0; }
 .overview-vessel-group-toggle strong { color: #fff; font-weight: 600; font-variant-numeric: tabular-nums; }
 .overview-vessel-group-chevron { display: block; width: 7px; height: 7px; align-self: center; justify-self: center; border-right: 1.5px solid #fff; border-bottom: 1.5px solid #fff; transform: rotate(45deg); transform-origin: center; }
 .overview-vessel-group.collapsed .overview-vessel-group-chevron { transform: rotate(-45deg); }
-.overview-vessel-row { display: grid; width: 100%; min-width: 0; min-height: 31px; padding: 5px 12px 5px 8px; align-items: center; grid-template-columns: 16px minmax(0,1fr) minmax(48px,auto); gap: 8px; overflow: hidden; border: 0; border-left: 2px solid transparent; color: #b8c5d3; background: transparent; cursor: pointer; font: 9px var(--mono); text-align: left; }
-.overview-vessel-row:hover, .overview-vessel-row:focus-visible { color: var(--cyan); background: rgba(78,201,224,.055); outline: 0; }
-.overview-vessel-row[aria-pressed="true"] { border-left-color: var(--cyan); color: var(--cyan); background: rgba(78,201,224,.12); }
+.overview-vessel-row { display: grid; width: 100%; min-width: 0; min-height: 31px; padding: 5px 12px 5px 8px; align-items: center; grid-template-columns: 16px minmax(0,1fr) minmax(48px,auto); gap: 8px; overflow: hidden; border: 0; border-left: 2px solid transparent; color: var(--row-text); background: transparent; cursor: pointer; font: 9px var(--mono); text-align: left; }
+.overview-vessel-row:hover, .overview-vessel-row:focus-visible { color: var(--cyan); background: var(--row-hover-wash); outline: 0; }
+.overview-vessel-row[aria-pressed="true"] { border-left-color: var(--cyan); color: var(--cyan); background: var(--row-selected-wash); }
 .overview-vessel-row svg { width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
 .overview-vessel-row span, .overview-vessel-row small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.overview-vessel-row small { color: #91a1b4; font-size: 9px; text-align: right; }
+.overview-vessel-row small { color: var(--row-text-muted); font-size: 9px; text-align: right; }
 .overview-vessel-detail { position: relative; display: flex; min-width: 0; padding: 13px 14px; overflow: auto; background: var(--surface-plate); flex-direction: column; overscroll-behavior: contain; }
 .overview-vessel-briefing-head { display: grid; min-width: 0; padding-bottom: 11px; align-items: center; grid-template-columns: 48px minmax(0,1fr) auto; gap: 11px; border-bottom: 1px solid var(--rule-bright); }
 .overview-vessel-briefing-glyph { display: grid; width: 48px; height: 48px; place-items: center; color: var(--cyan); background: var(--surface-well); box-shadow: var(--surface-depth-recessed); }
 .overview-vessel-briefing-glyph svg { width: 35px; height: 35px; fill: none; stroke: currentColor; stroke-width: 1.45; stroke-linecap: round; stroke-linejoin: round; }
 .overview-vessel-briefing-copy { display: grid; min-width: 0; gap: 3px; }
-.overview-vessel-briefing-copy strong { overflow: hidden; color: #edf6fb; font-size: 17px; font-weight: 560; letter-spacing: .045em; line-height: 1.1; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
+.overview-vessel-briefing-copy strong { overflow: hidden; color: var(--briefing-heading); font-size: 17px; font-weight: 560; letter-spacing: .045em; line-height: 1.1; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .overview-vessel-briefing-copy span { overflow: hidden; color: #b7c5d3; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-briefing-copy small { overflow: hidden; color: var(--cyan); font-size: 9px; font-weight: 600; letter-spacing: .05em; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-briefing-type { display: grid; align-self: start; justify-items: end; gap: 5px; }
 .overview-vessel-briefing-type > span:first-child { color: #cbd5df; font-size: 9px; letter-spacing: .08em; text-transform: uppercase; }
-.overview-vessel-briefing-type .overview-detail-badge { padding: 2px 4px; border: 1px solid #5e4726; border-radius: 2px; color: var(--amber); font-size: 9px; letter-spacing: .07em; text-transform: uppercase; }
+.overview-vessel-briefing-type .overview-detail-badge { padding: 2px 4px; border: 1px solid var(--memorial-border); border-radius: 2px; color: var(--amber); font-size: 9px; letter-spacing: .07em; text-transform: uppercase; }
 .overview-vessel-orbit-card { display: grid; min-width: 0; padding: 12px 0; border-bottom: 1px solid var(--rule); }
 .overview-vessel-orbit-data { display: grid; min-width: 0; gap: 8px; }
 .overview-vessel-orbit-data h3 { margin: 0; color: var(--slate); font-size: 10px; font-weight: 500; letter-spacing: .11em; text-transform: uppercase; }
 .overview-vessel-facts { display: grid; min-width: 0; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 0 18px; }
-.overview-vessel-facts > div { display: grid; min-width: 0; min-height: 25px; padding: 4px 2px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 8px; border-bottom: 1px solid rgba(35,58,74,.66); }
+.overview-vessel-facts > div { display: grid; min-width: 0; min-height: 25px; padding: 4px 2px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 8px; border-bottom: 1px solid var(--fact-rule); }
 .overview-vessel-facts > div:last-child { border-bottom: 0; }
 .overview-vessel-facts span { overflow: hidden; color: var(--slate-muted-text); font-size: 8px; letter-spacing: .08em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .overview-vessel-facts strong { overflow: hidden; color: #e4ebf2; font-size: 10px; font-weight: 500; font-variant-numeric: tabular-nums; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
@@ -764,21 +1078,21 @@ button { font: inherit; }
 .overview-vessel-crew-summary > header { display: flex; align-items: baseline; gap: 8px; }
 .overview-vessel-crew-summary > header span { color: var(--slate); font-size: 9px; letter-spacing: .1em; text-transform: uppercase; white-space: nowrap; }
 .overview-vessel-crew-summary > div { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 4px 12px; }
-.overview-vessel-crew-member { display: grid; min-width: 0; padding: 5px 0; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 12px; border-bottom: 1px solid rgba(35,58,74,.42); }
+.overview-vessel-crew-member { display: grid; min-width: 0; padding: 5px 0; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 12px; border-bottom: 1px solid var(--crew-rule); }
 .overview-vessel-crew-member strong { overflow: hidden; color: #d2dce6; font-size: 11px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-crew-member small { overflow: hidden; max-width: 110px; color: #bcc8d3; font-size: 11px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-crew-summary > p { margin: 0; color: var(--slate-muted-text); font-size: 9px; }
 .overview-vessel-next-event { display: grid; min-width: 0; margin-top: 10px; gap: 6px; }
 .overview-vessel-next-event > header { display: flex; align-items: center; }
 .overview-vessel-next-event > header span { color: var(--slate); font-size: 9px; letter-spacing: .1em; text-transform: uppercase; }
-.overview-vessel-next-event-row { display: grid; min-width: 0; min-height: 52px; padding: 8px 10px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 12px; border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: rgba(5,10,15,.2); }
+.overview-vessel-next-event-row { display: grid; min-width: 0; min-height: 52px; padding: 8px 10px; align-items: center; grid-template-columns: minmax(0,1fr) auto; gap: 12px; border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: var(--card-wash); }
 .overview-vessel-next-event-row > strong { overflow: hidden; color: var(--text-value); font-size: 11px; font-weight: 550; text-overflow: ellipsis; white-space: nowrap; }
 .overview-vessel-next-event-row time { display: grid; min-width: 0; gap: 3px; text-align: right; }
 .overview-vessel-next-event-row time strong { color: var(--amber); font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .overview-vessel-next-event-row time span { color: var(--slate-muted-text); font-size: 9px; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .overview-vessel-actions { display: grid; min-width: 0; margin-top: 16px; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 8px; }
 .overview-vessel-actions.has-lifecycle { grid-template-columns: repeat(3,minmax(0,1fr)); }
-.overview-switch-vessel { min-height: 32px; padding: 5px 9px; border: 1px solid var(--cyan); border-radius: 2px; color: #041016; background: var(--cyan); cursor: pointer; font: 10px var(--mono); font-weight: 650; letter-spacing: .04em; }
+.overview-switch-vessel { min-height: 32px; padding: 5px 9px; border: 1px solid var(--cyan); border-radius: 2px; color: var(--on-accent); background: var(--cyan); cursor: pointer; font: 10px var(--mono); font-weight: 650; letter-spacing: .04em; }
 .overview-switch-vessel:hover:not(:disabled), .overview-switch-vessel:focus-visible { border-color: #8be9fa; background: #8be9fa; outline: 0; }
 .overview-switch-vessel:disabled { cursor: not-allowed; opacity: .42; }
 .overview-rename-vessel { min-height: 32px; padding: 5px 9px; border: 1px solid var(--accent-border); border-radius: var(--surface-radius-face); color: var(--slate); background: var(--surface-raised-face); box-shadow: var(--surface-depth-control); cursor: pointer; font: 10px var(--mono); letter-spacing: .04em; }
@@ -787,7 +1101,7 @@ button { font: inherit; }
 .overview-recover-vessel, .overview-terminate-vessel { min-width: 0; min-height: 32px; width: 100%; padding: 5px 9px; border-radius: 2px; cursor: pointer; font: 10px var(--mono); letter-spacing: .04em; }
 .overview-recover-vessel { border: 1px solid #3d7648; color: var(--green); background: #0d1d13; }
 .overview-recover-vessel:hover:not(:disabled), .overview-recover-vessel:focus-visible { border-color: var(--green); background: #15301d; outline: 0; }
-.overview-terminate-vessel { border: 1px solid #7b3838; color: var(--danger); background: #211010; }
+.overview-terminate-vessel { border: 1px solid var(--destructive-border); color: var(--danger); background: var(--destructive-surface); }
 .overview-terminate-vessel:hover:not(:disabled), .overview-terminate-vessel:focus-visible { border-color: var(--danger); background: #341717; outline: 0; }
 .overview-recover-vessel:disabled, .overview-terminate-vessel:disabled { cursor: not-allowed; opacity: .42; }
 .overview-vessel-feedback { display: grid; min-width: 0; margin-top: 5px; gap: 3px; }
@@ -840,12 +1154,12 @@ button { font: inherit; }
 .overview-vessel-detail-empty { display: grid; color: var(--slate-muted-text); font-size: 9px; place-items: center; text-align: center; }
 .overview-roster-table-wrap { min-height: 180px; max-height: clamp(220px,38vh,420px); background: var(--surface-well-top); scrollbar-gutter: stable; overscroll-behavior: contain; }
 .overview-roster-summary { display: flex; min-width: 0; align-items: center; gap: 5px; }
-.overview-roster-summary-chip { display: flex; min-width: 62px; min-height: 24px; padding: 3px 6px; align-items: center; justify-content: space-between; gap: 7px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate); background: #0b1119; }
+.overview-roster-summary-chip { display: flex; min-width: 62px; min-height: 24px; padding: 3px 6px; align-items: center; justify-content: space-between; gap: 7px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate); background: var(--chip-surface); }
 .overview-roster-summary-chip > span { overflow: hidden; font-size: 9px; letter-spacing: .06em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .overview-roster-summary-chip > strong { color: var(--cyan); font-size: 10px; font-weight: 500; }
 .overview-roster-summary-chip.assigned { border-color: var(--accent-border); }
 .overview-roster-summary-chip.available { border-color: var(--success-border); }
-.overview-roster-summary-chip.dead, .overview-roster-summary-chip.missing { border-color: #5e4726; }
+.overview-roster-summary-chip.dead, .overview-roster-summary-chip.missing { border-color: var(--memorial-border); }
 .overview-roster-summary-chip.available > strong { color: var(--green); }
 .overview-roster-summary-chip.dead > strong, .overview-roster-summary-chip.missing > strong { color: var(--amber); }
 .overview-roster-table { min-width: 0; table-layout: fixed; }
@@ -856,13 +1170,13 @@ button { font: inherit; }
 .overview-roster-table thead th:nth-child(5), .overview-roster-table td:nth-child(5) { width: 82px; text-align: right; }
 .overview-roster-status-dot { display: inline-block; width: 7px; height: 7px; margin-right: 7px; border: 1px solid var(--accent-border); border-radius: 50%; background: var(--cyan); vertical-align: 1px; }
 .overview-roster-status-dot.available { border-color: var(--success-border); background: var(--green); }
-.overview-roster-status-dot.dead, .overview-roster-status-dot.missing { border-color: #5e4726; background: var(--amber); }
+.overview-roster-status-dot.dead, .overview-roster-status-dot.missing { border-color: var(--memorial-border); background: var(--amber); }
 .overview-roster-name { color: var(--cyan) !important; }
-.honor-row .overview-roster-name { color: #c4a476 !important; }
-.overview-orange-suit-dot { display: inline-block; width: 5px; height: 5px; margin-left: 6px; border: 1px solid #e6a749; border-radius: 50%; background: var(--amber); vertical-align: 1px; }
+.honor-row .overview-roster-name { color: var(--honor-name) !important; }
+.overview-orange-suit-dot { display: inline-block; width: 5px; height: 5px; margin-left: 6px; border: 1px solid var(--suit-ring); border-radius: 50%; background: var(--amber); vertical-align: 1px; }
 .overview-roster-unassigned { color: var(--slate-muted-text) !important; }
-.honor-row td { color: #8f8172; }
-.honor-row td:first-child { color: #c4a476; }
+.honor-row td { color: var(--honor-body); }
+.honor-row td:first-child { color: var(--honor-name); }
 .honor-star { margin-left: 6px; color: var(--amber); font-size: 9px; }
 .overview-empty { margin: 0; padding: 18px; color: var(--slate-muted-text); font-size: 9px; text-align: center; }
 .overview-service-warning { display: flex; min-height: 160px; margin: 0; padding: 22px; align-items: center; justify-content: center; color: var(--slate); text-align: center; flex-direction: column; gap: 7px; }
@@ -875,7 +1189,7 @@ button { font: inherit; }
 .overview-list-card strong { overflow: hidden; color: var(--text-value); font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .overview-list-card span { overflow: hidden; color: var(--slate-muted-text); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
 .overview-contract-list { display: flex; min-height: 0; flex-direction: column; }
-.overview-contract-card { border-bottom: 1px solid var(--rule); background: rgba(5,10,15,.2); }
+.overview-contract-card { border-bottom: 1px solid var(--rule); background: var(--card-wash); }
 .overview-contract-card:last-child { border-bottom: 0; }
 .overview-contract-summary { display: grid; width: 100%; min-height: 64px; padding: 9px 10px; align-items: center; grid-template-columns: 12px minmax(0,1fr) auto; gap: 8px; border: 0; color: inherit; background: transparent; cursor: pointer; font: inherit; text-align: left; }
 .overview-contract-summary:hover { background: rgba(78,201,224,.035); }
@@ -945,11 +1259,11 @@ button { font: inherit; }
 .overview-alarm-time { text-align: right; }
 .overview-alarm-time strong { color: var(--amber); font-variant-numeric: tabular-nums; }
 .overview-source { padding: 4px 5px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate) !important; font-size: 10px !important; letter-spacing: .06em; }
-.overview-source.stock { border-color: #385065; color: var(--cyan) !important; }
-.overview-source.kac { border-color: #5e4726; color: var(--amber) !important; }
+.overview-source.stock { border-color: var(--tag-border); color: var(--cyan) !important; }
+.overview-source.kac { border-color: var(--memorial-border); color: var(--amber) !important; }
 .overview-list-card > .overview-alarm-badges { align-items: center; justify-content: flex-start; flex-direction: row; gap: 5px; }
 .overview-alarm-badges > span { flex: none; }
-.overview-alarm-type { padding: 5px 7px; border: 1px solid #385065; border-radius: 2px; color: var(--cyan) !important; font-size: 10px !important; letter-spacing: .04em; }
+.overview-alarm-type { padding: 5px 7px; border: 1px solid var(--tag-border); border-radius: 2px; color: var(--cyan) !important; font-size: 10px !important; letter-spacing: .04em; }
 .overview-alarm-card { min-height: 68px; padding: 11px 12px; grid-template-columns: minmax(0,1fr) 106px 104px; gap: 13px; }
 .overview-alarm-card > div:first-child > strong { font-size: 12px; }
 .overview-alarm-card > div:first-child > span { font-size: 10px; }
@@ -2932,7 +3246,7 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 }
 .settings-section-nav button:hover,
 .settings-section-nav button:focus-visible { border-color: var(--accent-border); color: var(--cyan); background: var(--control-surface-hover); }
-.settings-section-nav button.active { border-color: var(--amber-accent); color: var(--amber); background: #211a12; box-shadow: inset 3px 0 var(--amber); }
+.settings-section-nav button.active { border-color: var(--amber-accent); color: var(--amber); background: var(--rail-face); box-shadow: inset 3px 0 var(--amber); }
 .settings-section {
   min-width: 0;
   padding: 20px;
@@ -2956,6 +3270,35 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 .settings-fieldset legend { padding: 0 5px; color: var(--cyan); font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
 .settings-fieldset p { margin: 0 0 10px; color: var(--text-value); font-size: 11px; }
 .settings-fieldset > small { display: block; margin-top: 9px; color: var(--slate-muted-text); font-size: 9px; line-height: 1.5; }
+.settings-theme-grid {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: repeat(2,minmax(0,1fr));
+  gap: 8px;
+}
+.settings-theme-option {
+  display: grid;
+  min-width: 0;
+  min-height: 92px;
+  padding: 10px;
+  align-content: start;
+  gap: 6px;
+  border: 1px solid var(--surface-seam);
+  border-radius: var(--surface-radius-face);
+  color: var(--text-primary);
+  background: var(--surface-well);
+  box-shadow: var(--surface-depth-recessed);
+  cursor: pointer;
+  text-align: left;
+}
+.settings-theme-option:hover,
+.settings-theme-option:focus-visible { border-color: var(--cyan); background: var(--control-surface-hover); }
+.settings-theme-option[aria-checked="true"] { border-color: var(--amber); background: var(--rail-face); box-shadow: inset 0 -2px var(--amber); }
+.settings-theme-option strong { color: var(--text-value); font-size: 10px; letter-spacing: .04em; }
+.settings-theme-option[aria-checked="true"] strong { color: var(--amber); }
+.settings-theme-option small { color: var(--slate-muted-text); font-size: 9px; line-height: 1.35; }
+.settings-theme-swatches { display: flex; height: 15px; overflow: hidden; border: 1px solid var(--surface-seam); border-radius: var(--surface-radius-face); }
+.settings-theme-swatches i { display: block; min-width: 0; flex: 1 1 0; }
 .settings-choice-row { display: flex; min-width: 0; flex-wrap: wrap; gap: 7px; }
 .settings-choice-row + .settings-choice-row { margin-top: 7px; }
 .settings-choice-row button,
@@ -2975,7 +3318,7 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 .settings-choice-row button:focus-visible,
 .settings-fieldset > button:hover:not(:disabled),
 .settings-fieldset > button:focus-visible { border-color: var(--cyan); color: var(--cyan); background: var(--control-surface-hover); }
-.settings-choice-row button[aria-pressed="true"] { border-color: var(--amber); color: #ffd498; background: #2b2115; box-shadow: inset 0 -2px var(--amber); }
+.settings-choice-row button[aria-pressed="true"] { border-color: var(--amber); color: var(--rail-text-hover); background: var(--rail-face-hover); box-shadow: inset 0 -2px var(--amber); }
 .settings-choice-row button:disabled,
 .settings-fieldset > button:disabled { cursor: not-allowed; opacity: .42; }
 .settings-feature-list { display: grid; gap: 7px; }
@@ -3017,9 +3360,9 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 .settings-diagnostics dd,
 .settings-about-list dd { min-width: 0; margin: 0; color: var(--text-value); font-size: 10px; overflow-wrap: anywhere; }
 .settings-link-list { display: grid; margin: 0; padding: 0; list-style: none; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 7px; }
-.settings-link-list a { display: flex; min-height: 40px; padding: 9px 10px; align-items: center; border: 1px solid var(--accent-border); border-radius: var(--surface-radius-face); color: var(--cyan); background: rgba(78,201,224,.05); font-size: 10px; line-height: 1.35; text-decoration: none; }
+.settings-link-list a { display: flex; min-height: 40px; padding: 9px 10px; align-items: center; border: 1px solid var(--accent-border); border-radius: var(--surface-radius-face); color: var(--cyan); background: var(--row-hover-wash); font-size: 10px; line-height: 1.35; text-decoration: none; }
 .settings-link-list a:hover,
-.settings-link-list a:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.11); text-decoration: underline; }
+.settings-link-list a:focus-visible { border-color: var(--cyan); background: var(--row-selected-wash); text-decoration: underline; }
 
 @media (max-width: 760px) {
   .resonant-drawer.settings-drawer { width: 100%; }
@@ -3034,6 +3377,7 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
   .settings-section { padding: 11px; }
   .settings-fieldset { padding: 11px; }
   .settings-choice-row button { flex: 1 1 120px; }
+  .settings-theme-grid { grid-template-columns: minmax(0,1fr); }
   .settings-feature-toggle { grid-template-columns: minmax(0,1fr); gap: 4px; }
   .settings-feature-toggle > strong { text-align: left; }
   .settings-link-list { grid-template-columns: minmax(0,1fr); }
@@ -3044,6 +3388,7 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 @media (pointer: coarse) {
   .settings-drawer > header > button,
   .settings-section-nav button,
+  .settings-theme-option,
   .settings-choice-row button,
   .settings-fieldset > button,
   .settings-link-list a { min-height: 44px; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2981,9 +2981,7 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 .settings-feature-list { display: grid; gap: 7px; }
 .settings-feature { overflow: hidden; border: 1px solid var(--surface-seam); border-left: 3px solid var(--slate-dim); border-radius: var(--surface-radius-face); background: var(--surface-plate); }
 .settings-feature-available { border-left-color: var(--green); }
-.settings-feature-installed { border-left-color: var(--cyan); }
-.settings-feature-fallback { border-left-color: var(--amber); }
-.settings-feature-not-detected { border-left-color: var(--danger); }
+.settings-feature-stock { border-left-color: var(--amber); }
 .settings-feature-unavailable { border-left-color: var(--danger); }
 .settings-feature-toggle {
   display: grid;
@@ -3004,9 +3002,7 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
 .settings-feature-toggle > span { min-width: 0; font-size: 11px; font-weight: 700; }
 .settings-feature-toggle > strong { color: var(--slate); font-size: 8px; letter-spacing: .06em; text-align: right; }
 .settings-feature-available .settings-feature-toggle > strong { color: var(--green); }
-.settings-feature-installed .settings-feature-toggle > strong { color: var(--cyan); }
-.settings-feature-fallback .settings-feature-toggle > strong { color: var(--amber); }
-.settings-feature-not-detected .settings-feature-toggle > strong { color: var(--danger); }
+.settings-feature-stock .settings-feature-toggle > strong { color: var(--amber); }
 .settings-feature-unavailable .settings-feature-toggle > strong { color: var(--danger); }
 .settings-feature-evidence { padding: 0 12px 12px; border-top: 1px solid var(--rule); color: var(--slate); font-size: 9px; line-height: 1.5; }
 .settings-feature-evidence p { margin: 10px 0 7px; color: var(--text-value); }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1794,26 +1794,6 @@ button { font: inherit; }
 .sci-alarm-settings svg { width: 14px; height: 14px; fill: currentColor; }
 .sci-alarm-feedback { margin-top: 7px; padding-top: 6px; border-top: 1px solid var(--rule); color: var(--green); font-size: 10px; line-height: 1.4; }
 .sci-alarm-feedback.error { color: var(--warn); }
-.sci-alarm-modal-backdrop { z-index: 24; padding: 10px; }
-.sci-alarm-modal { width: min(390px,100%); border: 1px solid var(--accent-border); border-radius: 4px; color: var(--text-primary); background: #081018; box-shadow: 0 16px 45px rgba(0,0,0,.72); }
-.sci-alarm-modal > header { display: flex; padding: 12px 14px; align-items: flex-start; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--rule); background: linear-gradient(90deg,rgba(78,210,230,.08),transparent); }
-.sci-alarm-modal > header div { display: grid; gap: 2px; }
-.sci-alarm-modal > header span, .sci-alarm-modal legend { color: var(--cyan); font-size: 9px; letter-spacing: .1em; text-transform: uppercase; }
-.sci-alarm-modal > header h3 { margin: 0; color: #e1eaf0; font-size: 13px; font-weight: 500; }
-.sci-alarm-modal > header button { display: grid; width: 27px; height: 27px; padding: 0; place-items: center; border: 0; color: var(--text-primary); background: transparent; cursor: pointer; font: 21px var(--mono); }
-.sci-alarm-modal-body { display: grid; padding: 13px 14px; gap: 10px; }
-.sci-alarm-modal fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
-.sci-alarm-modal legend { margin-bottom: 6px; }
-.sci-alarm-options { display: grid; grid-template-columns: repeat(3,1fr); gap: 5px; }
-.sci-alarm-options.lead { grid-template-columns: repeat(2,1fr); }
-.sci-alarm-options.action { grid-template-columns: repeat(2,1fr); }
-.sci-alarm-options button { min-height: 31px; border: 1px solid var(--rule-bright); border-radius: 2px; color: var(--slate); background: #0a121a; cursor: pointer; font: 10px var(--mono); }
-.sci-alarm-options button[aria-pressed="true"] { border-color: var(--cyan); color: #061115; background: var(--cyan); }
-.sci-alarm-options button:disabled { cursor: not-allowed; opacity: .35; }
-.sci-alarm-modal-body > small { color: var(--slate); font-size: 9px; line-height: 1.45; }
-.sci-alarm-modal > footer { display: flex; padding: 0 14px 14px; justify-content: flex-end; gap: 7px; }
-.sci-alarm-modal > footer button { min-height: 31px; padding: 6px 10px; border: 1px solid var(--accent-border); color: var(--slate); background: var(--control-surface); cursor: pointer; font: 10px var(--mono); }
-.sci-alarm-modal > footer button:last-child { border-color: var(--cyan); color: #061115; background: var(--cyan); }
 .sci-lab-empty { padding: 9px 10px; border: 1px solid var(--rule); border-radius: 4px; color: var(--slate); background: var(--panel-2); font-size: 9px; text-align: center; }
 .sci-lab-empty.unavailable { color: var(--slate-muted-text); }
 .sci-experiment-view { display: grid; height: 100%; overflow: hidden; border: 1px solid var(--rule); border-radius: 4px; background: var(--panel-2); grid-template-rows: auto minmax(0,1fr); }
@@ -2911,4 +2891,161 @@ body, .app-shell, .dashboard-surface { min-height: 100dvh; }
     grid-area: rate;
     justify-self: end;
   }
+}
+
+/* Global Settings: one cross-scene utility drawer with bounded local scroll. */
+.resonant-drawer.settings-drawer { width: min(860px,94vw); }
+.settings-drawer > header > button { width: 36px; min-width: 36px; height: 36px; }
+.resonant-drawer .settings-drawer-body {
+  display: grid;
+  min-width: 0;
+  overflow: hidden;
+  grid-template-areas: none;
+  grid-template-columns: minmax(172px,210px) minmax(0,1fr);
+  grid-template-rows: minmax(0,1fr);
+  align-content: stretch;
+  background: var(--surface-grout);
+}
+.settings-section-nav {
+  display: flex;
+  min-width: 0;
+  padding: 14px 10px;
+  overflow: auto;
+  border-right: 1px solid var(--surface-seam);
+  background: var(--surface-plate);
+  flex-direction: column;
+  gap: 6px;
+}
+.settings-section-nav button {
+  min-height: 40px;
+  padding: 9px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--surface-radius-face);
+  color: var(--slate);
+  background: transparent;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-align: left;
+  text-transform: uppercase;
+}
+.settings-section-nav button:hover,
+.settings-section-nav button:focus-visible { border-color: var(--accent-border); color: var(--cyan); background: var(--control-surface-hover); }
+.settings-section-nav button.active { border-color: var(--amber-accent); color: var(--amber); background: #211a12; box-shadow: inset 3px 0 var(--amber); }
+.settings-section {
+  min-width: 0;
+  padding: 20px;
+  overflow: auto;
+  background: var(--surface-bezel);
+  overscroll-behavior: contain;
+}
+.settings-section > h3 { margin: 0 0 15px; color: var(--amber); font-size: 15px; letter-spacing: .08em; text-transform: uppercase; }
+.settings-section > h4 { margin: 20px 0 8px; color: var(--cyan); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; }
+.settings-section-intro { max-width: 68ch; margin: -5px 0 14px; color: var(--slate); font-size: 10px; line-height: 1.55; }
+.settings-fieldset {
+  min-width: 0;
+  margin: 0 0 14px;
+  padding: 14px;
+  border: 1px solid var(--surface-seam);
+  border-radius: var(--surface-radius-bezel);
+  color: var(--text-primary);
+  background: var(--surface-plate);
+  box-shadow: var(--surface-depth-engraved);
+}
+.settings-fieldset legend { padding: 0 5px; color: var(--cyan); font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.settings-fieldset p { margin: 0 0 10px; color: var(--text-value); font-size: 11px; }
+.settings-fieldset > small { display: block; margin-top: 9px; color: var(--slate-muted-text); font-size: 9px; line-height: 1.5; }
+.settings-choice-row { display: flex; min-width: 0; flex-wrap: wrap; gap: 7px; }
+.settings-choice-row + .settings-choice-row { margin-top: 7px; }
+.settings-choice-row button,
+.settings-fieldset > button {
+  min-height: 38px;
+  padding: 8px 11px;
+  border: 1px solid var(--rule-bright);
+  border-radius: var(--surface-radius-face);
+  color: var(--slate);
+  background: var(--control-surface);
+  cursor: pointer;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .05em;
+}
+.settings-choice-row button:hover:not(:disabled),
+.settings-choice-row button:focus-visible,
+.settings-fieldset > button:hover:not(:disabled),
+.settings-fieldset > button:focus-visible { border-color: var(--cyan); color: var(--cyan); background: var(--control-surface-hover); }
+.settings-choice-row button[aria-pressed="true"] { border-color: var(--amber); color: #ffd498; background: #2b2115; box-shadow: inset 0 -2px var(--amber); }
+.settings-choice-row button:disabled,
+.settings-fieldset > button:disabled { cursor: not-allowed; opacity: .42; }
+.settings-feature-list { display: grid; gap: 7px; }
+.settings-feature { overflow: hidden; border: 1px solid var(--surface-seam); border-left: 3px solid var(--slate-dim); border-radius: var(--surface-radius-face); background: var(--surface-plate); }
+.settings-feature-available { border-left-color: var(--green); }
+.settings-feature-fallback { border-left-color: var(--amber); }
+.settings-feature-unavailable { border-left-color: var(--danger); }
+.settings-feature-toggle {
+  display: grid;
+  width: 100%;
+  min-height: 48px;
+  padding: 10px 12px;
+  align-items: center;
+  grid-template-columns: minmax(0,1fr) auto;
+  gap: 10px;
+  border: 0;
+  color: var(--text-primary);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+.settings-feature-toggle:hover,
+.settings-feature-toggle:focus-visible { background: var(--control-surface-hover); }
+.settings-feature-toggle > span { min-width: 0; font-size: 11px; font-weight: 700; }
+.settings-feature-toggle > strong { color: var(--slate); font-size: 8px; letter-spacing: .06em; text-align: right; }
+.settings-feature-available .settings-feature-toggle > strong { color: var(--green); }
+.settings-feature-fallback .settings-feature-toggle > strong { color: var(--amber); }
+.settings-feature-unavailable .settings-feature-toggle > strong { color: var(--danger); }
+.settings-feature-evidence { padding: 0 12px 12px; border-top: 1px solid var(--rule); color: var(--slate); font-size: 9px; line-height: 1.5; }
+.settings-feature-evidence p { margin: 10px 0 7px; color: var(--text-value); }
+.settings-feature-evidence ul { margin: 0; padding-left: 18px; }
+.settings-feature-evidence li { margin-top: 4px; overflow-wrap: anywhere; }
+.settings-diagnostics,
+.settings-about-list { display: grid; margin: 14px 0 0; gap: 1px; background: var(--surface-grout); }
+.settings-diagnostics > div,
+.settings-about-list > div { display: grid; min-width: 0; padding: 10px 11px; grid-template-columns: minmax(125px,.55fr) minmax(0,1.45fr); gap: 12px; background: var(--panel); }
+.settings-diagnostics dt,
+.settings-about-list dt { color: var(--slate); font-size: 9px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+.settings-diagnostics dd,
+.settings-about-list dd { min-width: 0; margin: 0; color: var(--text-value); font-size: 10px; overflow-wrap: anywhere; }
+.settings-link-list { display: grid; margin: 0; padding: 0; list-style: none; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 7px; }
+.settings-link-list a { display: flex; min-height: 40px; padding: 9px 10px; align-items: center; border: 1px solid var(--accent-border); border-radius: var(--surface-radius-face); color: var(--cyan); background: rgba(78,201,224,.05); font-size: 10px; line-height: 1.35; text-decoration: none; }
+.settings-link-list a:hover,
+.settings-link-list a:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.11); text-decoration: underline; }
+
+@media (max-width: 760px) {
+  .resonant-drawer.settings-drawer { width: 100%; }
+  .resonant-drawer .settings-drawer-body { grid-template-columns: minmax(0,1fr); grid-template-rows: auto minmax(0,1fr); }
+  .settings-section-nav { padding: 8px; overflow-x: auto; overflow-y: hidden; border-right: 0; border-bottom: 1px solid var(--surface-seam); flex-direction: row; }
+  .settings-section-nav button { min-width: max-content; min-height: 44px; text-align: center; }
+  .settings-section-nav button.active { box-shadow: inset 0 -3px var(--amber); }
+  .settings-section { padding: 14px; }
+}
+
+@media (max-width: 460px) {
+  .settings-section { padding: 11px; }
+  .settings-fieldset { padding: 11px; }
+  .settings-choice-row button { flex: 1 1 120px; }
+  .settings-feature-toggle { grid-template-columns: minmax(0,1fr); gap: 4px; }
+  .settings-feature-toggle > strong { text-align: left; }
+  .settings-link-list { grid-template-columns: minmax(0,1fr); }
+  .settings-diagnostics > div,
+  .settings-about-list > div { grid-template-columns: minmax(0,1fr); gap: 4px; }
+}
+
+@media (pointer: coarse) {
+  .settings-drawer > header > button,
+  .settings-section-nav button,
+  .settings-choice-row button,
+  .settings-fieldset > button,
+  .settings-link-list a { min-height: 44px; }
+  .settings-drawer > header > button { width: 44px; min-width: 44px; }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -87,6 +87,58 @@
   --surface-glow-amber: 0 0 13px rgba(255,180,84,.3);
   --surface-glow-cyan: 0 0 13px rgba(78,201,224,.3);
   --surface-glow-progress: 0 0 9px rgba(126,231,135,.45);
+  /* Flight chrome and Plan state washes are composite roles rather than raw
+     colors. Keeping them here prevents a light palette from inheriting dark
+     recesses, lenses, and tinted card grounds. */
+  --flight-screw-shadow: drop-shadow(0 1px 0 rgba(255,255,255,.06));
+  --flight-status-border-top: #2d3d51;
+  --flight-status-depth: inset 0 1px 0 rgba(255,255,255,.055), 0 2px 9px rgba(0,0,0,.5);
+  --flight-status-cell-depth: inset 0 1px 0 rgba(255,255,255,.035);
+  --flight-divider-dark: rgba(0,0,0,.7);
+  --flight-divider-light: rgba(255,255,255,.05);
+  --flight-label-shadow: 0 1px 0 rgba(0,0,0,.9);
+  --flight-selector-face: linear-gradient(180deg,#173248 0%,#0f2534 100%);
+  --flight-selector-depth: inset 0 1px 0 rgba(78,201,224,.22);
+  --flight-rebalance-border: #2f4152;
+  --flight-rebalance-face: radial-gradient(circle at 50% 28%,#1c2632 0%,#0c1219 100%);
+  --flight-rebalance-face-hover: radial-gradient(circle at 50% 28%,#263443 0%,#111923 100%);
+  --flight-rebalance-depth: inset 0 1px 0 rgba(255,255,255,.07), 0 1px 2px rgba(0,0,0,.6);
+  --flight-context-face: linear-gradient(135deg,#101a28,#0a0f17);
+  --flight-context-subtext: #aeb9c8;
+  --flight-unlit-border: #39414a;
+  --flight-unlit-text: #65707a;
+  --flight-unlit-face: radial-gradient(120% 90% at 50% 6%,rgba(255,255,255,.09) 0%,rgba(255,255,255,.015) 24%,#10151a 58%,#080b0f 100%);
+  --flight-unlit-depth: inset 0 1px 0 rgba(255,255,255,.05), inset 0 -2px 4px rgba(0,0,0,.7), 0 1px 2px rgba(0,0,0,.6);
+  --flight-stage-button-wash: rgba(78,201,224,.05);
+  --flight-stage-button-wash-hover: rgba(78,201,224,.1);
+  --flight-trajectory-amber-face: rgba(63,39,12,.32);
+  --flight-trajectory-amber-border: #6c4c20;
+  --flight-trajectory-cyan-face: rgba(32,85,105,.12);
+  --flight-trajectory-cyan-border: #245367;
+  --flight-trajectory-muted-face: rgba(64,78,94,.12);
+  --datalink-on-border: #356641;
+  --datalink-on-face: #102016;
+  --datalink-on-face-hover: #142a1b;
+  --stage-current-face: #0e2029;
+  --state-wash-amber: linear-gradient(100deg,rgba(255,180,84,.11),rgba(15,21,31,.78));
+  --state-wash-cyan: linear-gradient(100deg,rgba(78,201,224,.085),rgba(15,21,31,.78));
+  --state-wash-green: linear-gradient(100deg,rgba(126,231,135,.09),rgba(15,21,31,.78));
+  --state-wash-red: linear-gradient(100deg,rgba(255,107,91,.11),rgba(15,21,31,.78));
+  --state-wash-depth: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 3px rgba(0,0,0,.5);
+  --state-border-amber: rgba(255,180,84,.48);
+  --state-border-cyan: rgba(78,201,224,.34);
+  --state-border-green: rgba(126,231,135,.38);
+  --state-border-red: rgba(255,107,91,.58);
+  --state-body-text: #b9cad5;
+  --state-body-muted: #c5ced9;
+  --state-amber-text: #f0c987;
+  --state-red-text: #ff9b8f;
+  --plan-panel-ground: #090f17;
+  --plan-step-face: linear-gradient(180deg,#101823 0%,#0b1118 100%);
+  --plan-route-wash: rgba(9,15,23,.65);
+  --plan-route-wash-strong: rgba(9,15,23,.8);
+  --plan-control-face: #0a131d;
+  --plan-target-face: #0c141e;
   --page-background: #05070b;
   --ambient-highlight: #0d1420;
   --scanline-stripe: rgba(255,255,255,.012);
@@ -192,9 +244,58 @@
   --surface-depth-engraved: inset 0 1px 0 rgba(255,255,255,.85), 0 1px 0 rgba(30,50,70,.06);
   --surface-depth-plate: inset 0 1px 0 rgba(255,255,255,.9), inset 0 -1px 0 rgba(30,50,70,.12), 0 2px 10px rgba(30,50,70,.12);
   --surface-etch: 0 1px 0 rgba(255,255,255,.8);
-  --surface-glow-amber: 0 0 8px rgba(138,83,0,.18);
-  --surface-glow-cyan: 0 0 8px rgba(13,99,121,.18);
-  --surface-glow-progress: 0 0 6px rgba(27,114,56,.2);
+  --surface-glow-amber: none;
+  --surface-glow-cyan: none;
+  --surface-glow-progress: none;
+  --flight-screw-shadow: drop-shadow(0 1px 0 rgba(30,50,70,.18));
+  --flight-status-border-top: #aab8c6;
+  --flight-status-depth: inset 0 1px 0 rgba(255,255,255,.95), 0 2px 9px rgba(40,60,85,.13);
+  --flight-status-cell-depth: inset 0 1px 0 rgba(255,255,255,.9);
+  --flight-divider-dark: rgba(30,50,70,.18);
+  --flight-divider-light: rgba(255,255,255,.95);
+  --flight-label-shadow: 0 1px 0 rgba(255,255,255,.8);
+  --flight-selector-face: linear-gradient(180deg,#d9edf3 0%,#c2dce5 100%);
+  --flight-selector-depth: inset 0 1px 0 rgba(255,255,255,.9);
+  --flight-rebalance-border: #9aaaba;
+  --flight-rebalance-face: radial-gradient(circle at 50% 28%,#ffffff 0%,#dce4ec 100%);
+  --flight-rebalance-face-hover: radial-gradient(circle at 50% 28%,#ffffff 0%,#cfdbe5 100%);
+  --flight-rebalance-depth: inset 0 1px 0 rgba(255,255,255,.95), 0 1px 2px rgba(30,50,70,.16);
+  --flight-context-face: linear-gradient(135deg,#ffffff,#edf2f7);
+  --flight-context-subtext: #526273;
+  --flight-unlit-border: #a7b3c0;
+  --flight-unlit-text: #667482;
+  --flight-unlit-face: linear-gradient(180deg,#e9eef3,#cbd5df);
+  --flight-unlit-depth: inset 0 1px 0 rgba(255,255,255,.9), inset 0 -2px 4px rgba(30,50,70,.12), 0 1px 2px rgba(30,50,70,.12);
+  --flight-stage-button-wash: rgba(13,99,121,.06);
+  --flight-stage-button-wash-hover: rgba(13,99,121,.11);
+  --flight-trajectory-amber-face: rgba(138,83,0,.09);
+  --flight-trajectory-amber-border: #b28c50;
+  --flight-trajectory-cyan-face: rgba(13,99,121,.08);
+  --flight-trajectory-cyan-border: #73a2b3;
+  --flight-trajectory-muted-face: rgba(78,92,108,.08);
+  --datalink-on-border: #78ad89;
+  --datalink-on-face: #e8f5ec;
+  --datalink-on-face-hover: #dcefe2;
+  --stage-current-face: #dbeef4;
+  --state-wash-amber: linear-gradient(100deg,rgba(138,83,0,.1),rgba(255,255,255,.9));
+  --state-wash-cyan: linear-gradient(100deg,rgba(13,99,121,.09),rgba(255,255,255,.9));
+  --state-wash-green: linear-gradient(100deg,rgba(27,114,56,.09),rgba(255,255,255,.9));
+  --state-wash-red: linear-gradient(100deg,rgba(168,31,25,.09),rgba(255,255,255,.9));
+  --state-wash-depth: inset 0 1px 0 rgba(255,255,255,.9), inset 0 -1px 3px rgba(40,60,85,.1);
+  --state-border-amber: rgba(138,83,0,.36);
+  --state-border-cyan: rgba(13,99,121,.34);
+  --state-border-green: rgba(27,114,56,.38);
+  --state-border-red: rgba(168,31,25,.4);
+  --state-body-text: #2b3846;
+  --state-body-muted: #4e5c6c;
+  --state-amber-text: #704100;
+  --state-red-text: #8f2922;
+  --plan-panel-ground: #ffffff;
+  --plan-step-face: linear-gradient(180deg,#ffffff 0%,#f1f5f9 100%);
+  --plan-route-wash: rgba(255,255,255,.75);
+  --plan-route-wash-strong: rgba(255,255,255,.85);
+  --plan-control-face: #e8f2f6;
+  --plan-target-face: #eef2f7;
   --page-background: #dde3ea;
   --ambient-highlight: #f8fafc;
   --scanline-stripe: rgba(24,40,60,.014);
@@ -289,6 +390,45 @@
   --surface-glow-amber: 0 0 13px rgba(255,195,107,.28);
   --surface-glow-cyan: 0 0 13px rgba(111,208,194,.25);
   --surface-glow-progress: 0 0 9px rgba(154,218,107,.35);
+  --flight-screw-shadow: drop-shadow(0 1px 0 rgba(255,225,180,.08));
+  --flight-status-border-top: #584127;
+  --flight-label-shadow: 0 1px 0 rgba(0,0,0,.9);
+  --flight-selector-face: linear-gradient(180deg,#1d3b35 0%,#112a25 100%);
+  --flight-selector-depth: inset 0 1px 0 rgba(111,208,194,.2);
+  --flight-rebalance-border: #5a4329;
+  --flight-rebalance-face: radial-gradient(circle at 50% 28%,#3c2e20 0%,#171009 100%);
+  --flight-rebalance-face-hover: radial-gradient(circle at 50% 28%,#4b3927 0%,#21170e 100%);
+  --flight-context-face: linear-gradient(135deg,#281e13,#151009);
+  --flight-context-subtext: #d1b894;
+  --flight-unlit-border: #5d4932;
+  --flight-unlit-text: #9b8260;
+  --flight-unlit-face: radial-gradient(120% 90% at 50% 6%,rgba(255,225,180,.09) 0%,rgba(255,225,180,.015) 24%,#241a11 58%,#100b06 100%);
+  --flight-stage-button-wash: rgba(111,208,194,.06);
+  --flight-stage-button-wash-hover: rgba(111,208,194,.11);
+  --flight-trajectory-amber-face: rgba(255,195,107,.09);
+  --flight-trajectory-amber-border: #7d5c2f;
+  --flight-trajectory-cyan-face: rgba(111,208,194,.08);
+  --flight-trajectory-cyan-border: #477f75;
+  --flight-trajectory-muted-face: rgba(179,154,118,.08);
+  --datalink-on-border: #557943;
+  --datalink-on-face: #172312;
+  --datalink-on-face-hover: #213019;
+  --stage-current-face: #1c3a34;
+  --state-wash-amber: linear-gradient(100deg,rgba(255,195,107,.12),rgba(20,14,8,.78));
+  --state-wash-cyan: linear-gradient(100deg,rgba(111,208,194,.09),rgba(20,14,8,.78));
+  --state-wash-green: linear-gradient(100deg,rgba(154,218,107,.09),rgba(20,14,8,.78));
+  --state-wash-red: linear-gradient(100deg,rgba(255,107,91,.11),rgba(20,14,8,.78));
+  --state-wash-depth: inset 0 1px 0 rgba(255,225,180,.05), inset 0 -1px 3px rgba(0,0,0,.5);
+  --state-body-text: #dcc9a9;
+  --state-body-muted: #cbb18a;
+  --state-amber-text: #ffd08a;
+  --state-red-text: #ff9b8f;
+  --plan-panel-ground: #150f09;
+  --plan-step-face: linear-gradient(180deg,#241a11 0%,#170f09 100%);
+  --plan-route-wash: rgba(20,14,8,.7);
+  --plan-route-wash-strong: rgba(20,14,8,.82);
+  --plan-control-face: #241a11;
+  --plan-target-face: #1a130c;
   --page-background: #0d0a06;
   --ambient-highlight: #21170e;
   --scanline-stripe: rgba(255,190,120,.022);
@@ -378,6 +518,45 @@
   --surface-glow-amber: 0 0 13px rgba(255,194,71,.25);
   --surface-glow-cyan: 0 0 13px rgba(189,246,207,.25);
   --surface-glow-progress: 0 0 9px rgba(77,255,143,.38);
+  --flight-screw-shadow: drop-shadow(0 1px 0 rgba(190,255,215,.08));
+  --flight-status-border-top: #28533a;
+  --flight-label-shadow: 0 1px 0 rgba(0,0,0,.9);
+  --flight-selector-face: linear-gradient(180deg,#173a27 0%,#0d2819 100%);
+  --flight-selector-depth: inset 0 1px 0 rgba(189,246,207,.18);
+  --flight-rebalance-border: #28553a;
+  --flight-rebalance-face: radial-gradient(circle at 50% 28%,#24432e 0%,#08130c 100%);
+  --flight-rebalance-face-hover: radial-gradient(circle at 50% 28%,#2f563b 0%,#0d1b12 100%);
+  --flight-context-face: linear-gradient(135deg,#102417,#07110b);
+  --flight-context-subtext: #9ac3a6;
+  --flight-unlit-border: #2a4a35;
+  --flight-unlit-text: #658d70;
+  --flight-unlit-face: radial-gradient(120% 90% at 50% 6%,rgba(190,255,215,.08) 0%,rgba(190,255,215,.012) 24%,#0e1c13 58%,#040a06 100%);
+  --flight-stage-button-wash: rgba(189,246,207,.05);
+  --flight-stage-button-wash-hover: rgba(189,246,207,.1);
+  --flight-trajectory-amber-face: rgba(255,194,71,.09);
+  --flight-trajectory-amber-border: #71652e;
+  --flight-trajectory-cyan-face: rgba(189,246,207,.07);
+  --flight-trajectory-cyan-border: #3b8056;
+  --flight-trajectory-muted-face: rgba(143,184,155,.07);
+  --datalink-on-border: #2e7a4b;
+  --datalink-on-face: #0b2013;
+  --datalink-on-face-hover: #10301c;
+  --stage-current-face: #123322;
+  --state-wash-amber: linear-gradient(100deg,rgba(255,194,71,.11),rgba(6,16,9,.78));
+  --state-wash-cyan: linear-gradient(100deg,rgba(189,246,207,.08),rgba(6,16,9,.78));
+  --state-wash-green: linear-gradient(100deg,rgba(77,255,143,.09),rgba(6,16,9,.78));
+  --state-wash-red: linear-gradient(100deg,rgba(255,107,91,.11),rgba(6,16,9,.78));
+  --state-wash-depth: inset 0 1px 0 rgba(190,255,215,.05), inset 0 -1px 3px rgba(0,0,0,.5);
+  --state-body-text: #b2e0c0;
+  --state-body-muted: #91bda0;
+  --state-amber-text: #ffcf6c;
+  --state-red-text: #ff9b8f;
+  --plan-panel-ground: #071109;
+  --plan-step-face: linear-gradient(180deg,#0e1c13 0%,#081209 100%);
+  --plan-route-wash: rgba(6,16,9,.7);
+  --plan-route-wash-strong: rgba(6,16,9,.82);
+  --plan-control-face: #0e1c13;
+  --plan-target-face: #0a170f;
   --page-background: #040a07;
   --ambient-highlight: #0a1c11;
   --scanline-stripe: rgba(120,255,170,.022);
@@ -921,7 +1100,7 @@ button { font: inherit; }
 .st-row > span { min-width: 0; padding: 4px 8px; overflow: hidden; color: var(--amber); background: var(--panel-2); font-size: 11px; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .st-head > span { color: var(--slate-muted-text); font-size: 8px; letter-spacing: .14em; text-transform: uppercase; }
 .st-row .sname { color: var(--slate); }
-.st-row.cur > span { color: var(--cyan); background: #0e2029; }
+.st-row.cur > span { color: var(--cyan); background: var(--stage-current-face); }
 .stage-table.editor .st-row { grid-template-columns: 72px 1.35fr 1.35fr .85fr .85fr 1fr; }
 .stage-table.editor .st-row > span { padding-block: 6px; font-size: 13px; }
 .stage-table.editor .st-head > span { font-size: 11px; }
@@ -955,8 +1134,8 @@ button { font: inherit; }
 .flight-stage-group > span { display: flex; min-width: 0; align-items: baseline; gap: 8px; }
 .flight-stage-group strong { color: var(--cyan); font-size: 10px; font-weight: 600; white-space: nowrap; }
 .flight-stage-group small { overflow: hidden; color: var(--slate-muted-text); font-size: 8px; letter-spacing: .04em; text-overflow: ellipsis; white-space: nowrap; }
-.flight-stage-group button { min-height: 20px; padding: 1px 7px; border: 1px solid var(--accent-border); border-radius: 2px; color: var(--cyan); background: rgba(78,201,224,.05); cursor: pointer; font: 10px var(--mono); font-weight: 700; letter-spacing: .04em; }
-.flight-stage-group button:hover, .flight-stage-group button:focus-visible { border-color: var(--cyan); background: rgba(78,201,224,.1); outline: none; }
+.flight-stage-group button { min-height: 20px; padding: 1px 7px; border: 1px solid var(--accent-border); border-radius: 2px; color: var(--cyan); background: var(--flight-stage-button-wash); cursor: pointer; font: 10px var(--mono); font-weight: 700; letter-spacing: .04em; }
+.flight-stage-group button:hover, .flight-stage-group button:focus-visible { border-color: var(--cyan); background: var(--flight-stage-button-wash-hover); outline: none; }
 .stage-table.flight.has-stage-group.expanded .flight-stage-rows { max-height: 92px; overflow-y: auto; scrollbar-gutter: stable; }
 .stage-table.flight .st-row > .sname { padding-left: 8px; text-align: left; }
 .stage-table.flight .st-row.cur > .sname { box-shadow: inset 3px 0 var(--green); }
@@ -1386,7 +1565,7 @@ button { font: inherit; }
   background: var(--surface-screw) left center / 6px 6px no-repeat,
               var(--surface-screw) right center / 6px 6px no-repeat;
   content: "";
-  filter: drop-shadow(0 1px 0 rgba(255,255,255,.06));
+  filter: var(--flight-screw-shadow);
   pointer-events: none;
 }
 .flight-fixed-region::before, .flight-tabbed-region::before { top: 2px; }
@@ -1397,15 +1576,15 @@ button { font: inherit; }
    rows deliberately remain flat for fast scanning. */
 .flight-workspace-shell > .status-strip {
   border: 1px solid var(--surface-bezel-color);
-  border-top-color: #2d3d51;
+  border-top-color: var(--flight-status-border-top);
   border-radius: var(--surface-radius-bezel);
   background: var(--surface-status-frame);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.055), 0 2px 9px rgba(0,0,0,.5);
+  box-shadow: var(--flight-status-depth);
 }
 .flight-workspace-shell > .status-strip > .panel { border: 0; border-radius: 0; box-shadow: none; }
 .flight-workspace-shell > .status-strip :is(.flight-context-identity,.clockcell,.cs-cell) {
   background: linear-gradient(180deg,var(--surface-status-cell-top) 0%,var(--surface-status-cell-bottom) 100%);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.035);
+  box-shadow: var(--flight-status-cell-depth);
 }
 .flight-workspace-shell :is(#asc .sas-box,#asc .asc-flight-metric:not(.hero),#asc .attitude-strip > div,#asc .stats-grid .stat,#target .tgt-grid .stat,#elec .ec-overview-card,#sci .sci-overview-card,#heat .heat-idle-state,#heat .heat-entity) {
   border-color: var(--surface-plate-edge);
@@ -1438,8 +1617,8 @@ button { font: inherit; }
   box-shadow: var(--surface-depth-raised);
 }
 .flight-workspace-controls { display: flex; min-width: 0; align-items: center; gap: 8px; flex: 0 0 auto; }
-.flight-control-divider { width: 2px; align-self: stretch; margin: 2px 0; border-left: 1px solid rgba(0,0,0,.7); border-right: 1px solid rgba(255,255,255,.05); }
-.flight-workspace-label { color: var(--slate-muted-text); font-size: 9px; font-weight: 700; letter-spacing: .16em; text-shadow: 0 1px 0 rgba(0,0,0,.9); text-transform: uppercase; white-space: nowrap; }
+.flight-control-divider { width: 2px; align-self: stretch; margin: 2px 0; border-left: 1px solid var(--flight-divider-dark); border-right: 1px solid var(--flight-divider-light); }
+.flight-workspace-label { color: var(--slate-muted-text); font-size: 9px; font-weight: 700; letter-spacing: .16em; text-shadow: var(--flight-label-shadow); text-transform: uppercase; white-space: nowrap; }
 .flight-workspace-selector {
   position: relative;
   display: inline-flex;
@@ -1459,8 +1638,8 @@ button { font: inherit; }
   height: calc(100% - 4px);
   border: 1px solid var(--accent-border-hover);
   border-radius: var(--surface-radius-hw);
-  background: linear-gradient(180deg,#173248 0%,#0f2534 100%);
-  box-shadow: inset 0 1px 0 rgba(78,201,224,.22);
+  background: var(--flight-selector-face);
+  box-shadow: var(--flight-selector-depth);
   transition: transform .3s cubic-bezier(.34,1.45,.44,1);
   transform: translateX(0);
 }
@@ -1481,12 +1660,12 @@ button { font: inherit; }
   font-size: 10px;
   font-weight: 700;
   letter-spacing: .12em;
-  text-shadow: 0 1px 0 rgba(0,0,0,.8);
+  text-shadow: var(--flight-label-shadow);
 }
 .flight-workspace-selector button[aria-selected="true"] { color: var(--cyan); text-shadow: var(--surface-etch); }
 .flight-workspace-selector button:hover { color: var(--cyan); }
-.flight-workspace-rebalance { display: grid; width: 30px; height: 30px; min-width: 30px; padding: 0; place-items: center; border: 1px solid #2f4152; border-radius: 50%; color: var(--amber); background: radial-gradient(circle at 50% 28%,#1c2632 0%,#0c1219 100%); box-shadow: inset 0 1px 0 rgba(255,255,255,.07), 0 1px 2px rgba(0,0,0,.6); cursor: pointer; font: 15px var(--mono); }
-.flight-workspace-rebalance:hover { border-color: var(--amber-accent); background: radial-gradient(circle at 50% 28%,#263443 0%,#111923 100%); }
+.flight-workspace-rebalance { display: grid; width: 30px; height: 30px; min-width: 30px; padding: 0; place-items: center; border: 1px solid var(--flight-rebalance-border); border-radius: 50%; color: var(--amber); background: var(--flight-rebalance-face); box-shadow: var(--flight-rebalance-depth); cursor: pointer; font: 15px var(--mono); }
+.flight-workspace-rebalance:hover { border-color: var(--amber-accent); background: var(--flight-rebalance-face-hover); }
 .flight-workspace-view { position: relative; width: 100%; min-width: 0; }
 .flight-workspace-view[hidden] { display: none; }
 .flight-workspace-view > [data-flight-panel-host] { left: 0; top: 0; }
@@ -1546,7 +1725,7 @@ button { font: inherit; }
     width: calc(100% - 16px);
     overflow: hidden;
     border: 1px solid var(--surface-bezel-color);
-    border-top-color: #2d3d51;
+    border-top-color: var(--flight-status-border-top);
     border-radius: var(--surface-radius-bezel);
     background: var(--surface-status-frame);
   }
@@ -1587,7 +1766,7 @@ button { font: inherit; }
     border: 0;
     justify-content: flex-start;
     background: linear-gradient(180deg,var(--surface-status-cell-top) 0%,var(--surface-status-cell-bottom) 100%);
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.035);
+    box-shadow: var(--flight-status-cell-depth);
   }
   .flight-workspace-shell[data-arrangement="stacked"] > .status-strip .clockcell { display: flex; flex-direction: column; }
   .flight-workspace-shell[data-arrangement="stacked"] > .status-strip .calendar-toggle { min-width: 0; min-height: 22px; padding-inline: 3px; }
@@ -1646,8 +1825,8 @@ button { font: inherit; }
 .datalink-controls button:hover:not(:disabled), .datalink-controls button:focus-visible { border-color: var(--amber); background: #2b2115; outline: none; }
 .datalink-controls button.power-off { border-color: #61322e; color: #e9988d; background: #1b1111; }
 .datalink-controls button.power-off:hover:not(:disabled), .datalink-controls button.power-off:focus-visible { border-color: var(--warn); background: #281414; }
-.datalink-controls button.power-on { border-color: #356641; color: var(--green); background: #102016; }
-.datalink-controls button.power-on:hover:not(:disabled), .datalink-controls button.power-on:focus-visible { border-color: var(--green); background: #142a1b; }
+.datalink-controls button.power-on { border-color: var(--datalink-on-border); color: var(--green); background: var(--datalink-on-face); }
+.datalink-controls button.power-on:hover:not(:disabled), .datalink-controls button.power-on:focus-visible { border-color: var(--green); background: var(--datalink-on-face-hover); }
 .datalink-controls button:disabled { cursor: not-allowed; opacity: .38; }
 .datalink-controls button span { font-size: 10px; font-weight: 700; letter-spacing: .08em; }
 .datalink-controls button small { color: var(--slate); font-size: 8px; line-height: 1.45; }
@@ -1669,9 +1848,9 @@ button { font: inherit; }
   .datalink-diagnostics, .datalink-controls { grid-template-columns: minmax(0,1fr); }
 }
 #clock .body { padding: 0; }
-.flight-context-identity { display: flex; min-width: 0; padding: 10px 12px; border-bottom: 1px solid var(--rule); background: linear-gradient(135deg,#101a28,#0a0f17); flex-direction: column; justify-content: center; gap: 3px; }
+.flight-context-identity { display: flex; min-width: 0; padding: 10px 12px; border-bottom: 1px solid var(--rule); background: var(--flight-context-face); flex-direction: column; justify-content: center; gap: 3px; }
 .flight-context-identity strong { overflow: hidden; color: var(--cyan); font-size: 17px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
-.flight-context-identity > span:last-child { overflow: hidden; color: #aeb9c8; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.flight-context-identity > span:last-child { overflow: hidden; color: var(--flight-context-subtext); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
 .clock-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--surface-grout); }
 .clockcell { padding: 10px 12px; background: var(--panel); }
 .clockcell .label { margin-bottom: 5px; }
@@ -1680,7 +1859,7 @@ button { font: inherit; }
 .clockcell .big { color: var(--amber); font-size: 22px; letter-spacing: .04em; text-shadow: var(--surface-glow-amber); font-variant-numeric: tabular-nums; }
 .clockcell .sub { margin-top: 3px; color: var(--slate-muted-text); font-size: 10px; letter-spacing: .06em; }
 .met-cell .big { color: var(--cyan); text-shadow: var(--surface-glow-cyan); }
-.flight-context-identity strong { text-shadow: 0 0 13px rgba(78,201,224,.26); }
+.flight-context-identity strong { text-shadow: var(--surface-glow-cyan); }
 .calendar-toggle { padding: 0; border: 0; color: var(--slate-muted-text); background: transparent; cursor: pointer; font: inherit; letter-spacing: inherit; }
 .calendar-toggle:hover { color: var(--cyan); }
 .comms-strip { display: grid; grid-template-columns: minmax(0,1fr); gap: 1px; border-top: 1px solid var(--surface-grout); background: var(--surface-grout); }
@@ -1692,7 +1871,7 @@ button { font: inherit; }
 .cs-delay .cs-val { min-width: 0; font-size: 11px; }
 .label-muted { color: var(--slate-muted-text); }
 .flight-annunciator { position: relative; display: flex; min-width: 0; align-items: center; gap: 8px; }
-.annunciator-lamp { position: relative; display: flex; width: 94px; height: 48px; min-width: 94px; padding: 5px 6px; overflow: hidden; align-items: center; justify-content: center; border: 1px solid #39414a; border-radius: 4px; color: #65707a; background: radial-gradient(120% 90% at 50% 6%,rgba(255,255,255,.09) 0%,rgba(255,255,255,.015) 24%,#10151a 58%,#080b0f 100%); box-shadow: inset 0 1px 0 rgba(255,255,255,.05), inset 0 -2px 4px rgba(0,0,0,.7), 0 1px 2px rgba(0,0,0,.6); cursor: pointer; font-family: var(--mono); line-height: 1; flex-direction: column; gap: 4px; }
+.annunciator-lamp { position: relative; display: flex; width: 94px; height: 48px; min-width: 94px; padding: 5px 6px; overflow: hidden; align-items: center; justify-content: center; border: 1px solid var(--flight-unlit-border); border-radius: 4px; color: var(--flight-unlit-text); background: var(--flight-unlit-face); box-shadow: var(--flight-unlit-depth); cursor: pointer; font-family: var(--mono); line-height: 1; flex-direction: column; gap: 4px; }
 .annunciator-lamp::before, .annunciator-indicator::before { position: absolute; top: 1px; left: 3px; right: 3px; height: 7px; border-radius: 3px 3px 8px 8px; background: linear-gradient(180deg,rgba(255,255,255,.13) 0%,rgba(255,255,255,0) 100%); content: ""; pointer-events: none; }
 .annunciator-lamp::before { top: 2px; left: 4px; right: 4px; height: 14px; }
 .annunciator-lamp span, .annunciator-lamp strong { position: relative; z-index: 1; }
@@ -1703,7 +1882,7 @@ button { font: inherit; }
 .annunciator-lamp:not(.dark)::before { height: 8px; background: linear-gradient(180deg,rgba(255,255,255,.3) 0%,rgba(255,255,255,0) 100%); }
 .annunciator-lamp:focus-visible { outline: 2px solid var(--cyan); outline-offset: 2px; }
 .annunciator-indicators { display: grid; min-width: 0; align-content: center; grid-template-columns: repeat(6,86px); gap: 4px; }
-.annunciator-indicator { position: relative; min-width: 0; min-height: 22px; padding: 3px 5px; overflow: hidden; border: 1px solid #39414a; border-radius: 3px; color: #65707a; background: radial-gradient(120% 90% at 50% 6%,rgba(255,255,255,.09) 0%,rgba(255,255,255,.015) 24%,#10151a 58%,#080b0f 100%); box-shadow: inset 0 1px 0 rgba(255,255,255,.05), inset 0 -2px 4px rgba(0,0,0,.7), 0 1px 2px rgba(0,0,0,.6); cursor: default; font: 10px var(--mono); font-weight: 700; letter-spacing: .04em; text-overflow: ellipsis; white-space: nowrap; }
+.annunciator-indicator { position: relative; min-width: 0; min-height: 22px; padding: 3px 5px; overflow: hidden; border: 1px solid var(--flight-unlit-border); border-radius: 3px; color: var(--flight-unlit-text); background: var(--flight-unlit-face); box-shadow: var(--flight-unlit-depth); cursor: default; font: 10px var(--mono); font-weight: 700; letter-spacing: .04em; text-overflow: ellipsis; white-space: nowrap; }
 .annunciator-reserved-space { display: block; min-width: 0; min-height: 22px; }
 .annunciator-indicator:disabled { opacity: 1; }
 .annunciator-indicator.new { border-color: #b74738; color: #240705; background: linear-gradient(180deg,#ff826f 0%,#e2584a 64%,#d84132 100%); box-shadow: 0 0 4px rgba(255,107,91,.26), inset 0 0 3px rgba(255,220,211,.2), 0 1px 2px rgba(0,0,0,.6); cursor: pointer; }
@@ -1765,10 +1944,10 @@ button { font: inherit; }
 /* Ascension instruments. */
 #asc .body { display: flex; flex-direction: column; gap: 10px; }
 :is(.flight-grid,.flight-workspace-shell) #asc.panel-compact > h2 { min-height: 38px; padding: 4px 12px; }
-.asc-trajectory { display: inline-flex; min-width: 0; padding: 4px 9px; align-items: center; gap: 7px; overflow: hidden; border: 1px solid #6c4c20; border-radius: 2px; color: var(--amber); background: rgba(63,39,12,.32); font-size: 9px; font-weight: 700; letter-spacing: .12em; text-overflow: ellipsis; white-space: nowrap; }
+.asc-trajectory { display: inline-flex; min-width: 0; padding: 4px 9px; align-items: center; gap: 7px; overflow: hidden; border: 1px solid var(--flight-trajectory-amber-border); border-radius: 2px; color: var(--amber); background: var(--flight-trajectory-amber-face); font-size: 9px; font-weight: 700; letter-spacing: .12em; text-overflow: ellipsis; white-space: nowrap; }
 .asc-trajectory-dot { width: 5px; height: 5px; flex: 0 0 5px; border-radius: 50%; background: currentColor; }
-.asc-trajectory.elliptic { border-color: #245367; color: var(--cyan); background: rgba(32,85,105,.12); }
-.asc-trajectory.suborbital, .asc-trajectory.trajectory { border-color: var(--rule-bright); color: var(--slate); background: rgba(64,78,94,.12); }
+.asc-trajectory.elliptic { border-color: var(--flight-trajectory-cyan-border); color: var(--cyan); background: var(--flight-trajectory-cyan-face); }
+.asc-trajectory.suborbital, .asc-trajectory.trajectory { border-color: var(--rule-bright); color: var(--slate); background: var(--flight-trajectory-muted-face); }
 .asc-cockpit { display: grid; min-width: 0; min-height: 310px; align-items: stretch; grid-template-columns: 200px 44px minmax(0,1fr); gap: 12px; }
 .asc-instrument-column { display: grid; min-width: 0; min-height: 0; align-items: center; justify-items: center; grid-template-rows: 20px minmax(0,1fr) auto; gap: 8px; }
 .sas-box { display: flex; min-width: 0; min-height: 43px; padding: 8px 10px; border: 1px solid var(--rule); border-radius: 3px; background: var(--panel); align-items: center; justify-content: space-between; gap: 12px; }

--- a/frontend/src/telemetry/fixtures.ts
+++ b/frontend/src/telemetry/fixtures.ts
@@ -41,21 +41,25 @@ const activeNote: NoteTelemetry = {
 export const dashboardCapabilitiesFixture: DashboardCapabilitiesSnapshot = {
   schemaVersion: 1,
   features: {
-    notes: { status: "available", reason: "ready", evidence: [{ id: "notes", status: "active", source: "runtime" }] },
+    // Development fixtures deliberately represent a fully provisioned install.
+    // Settings consumes only root-scan evidence so its dashboard-wide inventory
+    // stays independent from whichever scene fixture is currently selected.
+    notes: { status: "available", reason: "ready", evidence: [{ id: "notes", status: "active", source: "runtime" }, { id: "notes", status: "detected", source: "root_scan" }] },
     science_telemetry: { status: "available", reason: "ready", evidence: [{ id: "vessel_science", status: "active", source: "runtime" }, { id: "wcs", status: "detected", source: "root_scan" }] },
-    science_alarms: { status: "available", reason: "ready", evidence: [{ id: "kac", status: "active", source: "runtime" }, { id: "stock", status: "active", source: "runtime" }] },
-    communications: { status: "available", reason: "ready", evidence: [{ id: "remote_tech", status: "active", source: "runtime" }] },
-    stage_analysis: { status: "available", reason: "ready", evidence: [{ id: "stage_stats", status: "active", source: "runtime" }, { id: "mechjeb", status: "detected", source: "root_scan" }] },
-    live_transfer_calculations: { status: "available", reason: "ready", evidence: [{ id: "woobies_mechjeb", status: "active", source: "runtime" }, { id: "mechjeb", status: "detected", source: "runtime", version: "2.15.3.0" }] },
-    heat_monitoring: { status: "available", reason: "ready", evidence: [{ id: "system_heat", status: "active", source: "runtime" }] },
-    heat_controls: { status: "available", reason: "ready", evidence: [{ id: "system_heat_service", status: "active", source: "runtime" }] },
-    editor_electricity: { status: "available", reason: "ready", evidence: [{ id: "dynamic_battery_storage", status: "active", source: "runtime", version: "2.3.0.0" }] },
-    damage_monitoring: { status: "available", reason: "ready", evidence: [{ id: "vessel_damage", status: "active", source: "runtime" }] },
+    science_alarms: { status: "available", reason: "ready", evidence: [{ id: "kac", status: "active", source: "runtime" }, { id: "stock", status: "active", source: "runtime" }, { id: "kac", status: "detected", source: "root_scan" }] },
+    communications: { status: "available", reason: "ready", evidence: [{ id: "remote_tech", status: "active", source: "runtime" }, { id: "remote_tech", status: "detected", source: "root_scan" }] },
+    stage_analysis: { status: "available", reason: "ready", evidence: [{ id: "stage_stats", status: "active", source: "runtime" }, { id: "stage_stats", status: "detected", source: "root_scan" }, { id: "mechjeb", status: "detected", source: "root_scan" }] },
+    live_transfer_calculations: { status: "available", reason: "ready", evidence: [{ id: "woobies_mechjeb", status: "active", source: "runtime" }, { id: "mechjeb", status: "detected", source: "runtime", version: "2.15.3.0" }, { id: "woobies_mechjeb", status: "detected", source: "root_scan" }, { id: "mechjeb", status: "detected", source: "root_scan" }] },
+    heat_monitoring: { status: "available", reason: "ready", evidence: [{ id: "system_heat", status: "active", source: "runtime" }, { id: "system_heat_service", status: "detected", source: "root_scan" }, { id: "system_heat_mod", status: "detected", source: "root_scan" }] },
+    heat_controls: { status: "available", reason: "ready", evidence: [{ id: "system_heat_service", status: "active", source: "runtime" }, { id: "system_heat_service", status: "detected", source: "root_scan" }, { id: "system_heat_mod", status: "detected", source: "root_scan" }] },
+    editor_electricity: { status: "available", reason: "ready", evidence: [{ id: "dynamic_battery_storage", status: "active", source: "runtime", version: "2.3.0.0" }, { id: "dynamic_battery_storage", status: "detected", source: "root_scan" }] },
+    damage_monitoring: { status: "available", reason: "ready", evidence: [{ id: "vessel_damage", status: "active", source: "runtime" }, { id: "wcs", status: "detected", source: "root_scan" }] },
   },
 };
 
 const notesFixture = {
   "dashboard.capabilities": dashboardCapabilitiesFixture,
+  "sci.alarmProviders": { kac: true, stock: true },
   "notes.available": true,
   "notes.activeFound": true,
   "notes.message": "",
@@ -236,7 +240,6 @@ export const flightTelemetryFixture: TelemetrySnapshot = {
   "sci.krpc.labTelemetryAvailable": true,
   "sci.krpc.labDaySeconds": 21_600,
   "sci.krpc.labCount": 1,
-  "sci.alarmProviders": { kac: true, stock: true },
   "sci.krpc.failedLabCount": 0,
   "sci.krpc.malformedLabCount": 0,
   "sci.krpc.labs": [{

--- a/frontend/src/telemetry/fixtures.ts
+++ b/frontend/src/telemetry/fixtures.ts
@@ -1,4 +1,4 @@
-import type { NoteTelemetry, TelemetrySnapshot } from "./types";
+import type { DashboardCapabilitiesSnapshot, NoteTelemetry, TelemetrySnapshot } from "./types";
 import { representativeElectricityFixture } from "../electricityPlanner/fixtures";
 
 const editorStages = [
@@ -38,7 +38,24 @@ const activeNote: NoteTelemetry = {
   truncated: false,
 };
 
+export const dashboardCapabilitiesFixture: DashboardCapabilitiesSnapshot = {
+  schemaVersion: 1,
+  features: {
+    notes: { status: "available", reason: "ready", evidence: [{ id: "notes", status: "active", source: "runtime" }] },
+    science_telemetry: { status: "available", reason: "ready", evidence: [{ id: "vessel_science", status: "active", source: "runtime" }, { id: "wcs", status: "detected", source: "root_scan" }] },
+    science_alarms: { status: "available", reason: "ready", evidence: [{ id: "kac", status: "active", source: "runtime" }, { id: "stock", status: "active", source: "runtime" }] },
+    communications: { status: "available", reason: "ready", evidence: [{ id: "remote_tech", status: "active", source: "runtime" }] },
+    stage_analysis: { status: "available", reason: "ready", evidence: [{ id: "stage_stats", status: "active", source: "runtime" }, { id: "mechjeb", status: "detected", source: "root_scan" }] },
+    live_transfer_calculations: { status: "available", reason: "ready", evidence: [{ id: "woobies_mechjeb", status: "active", source: "runtime" }, { id: "mechjeb", status: "detected", source: "runtime", version: "2.15.3.0" }] },
+    heat_monitoring: { status: "available", reason: "ready", evidence: [{ id: "system_heat", status: "active", source: "runtime" }] },
+    heat_controls: { status: "available", reason: "ready", evidence: [{ id: "system_heat_service", status: "active", source: "runtime" }] },
+    editor_electricity: { status: "available", reason: "ready", evidence: [{ id: "dynamic_battery_storage", status: "active", source: "runtime", version: "2.3.0.0" }] },
+    damage_monitoring: { status: "available", reason: "ready", evidence: [{ id: "vessel_damage", status: "active", source: "runtime" }] },
+  },
+};
+
 const notesFixture = {
+  "dashboard.capabilities": dashboardCapabilitiesFixture,
   "notes.available": true,
   "notes.activeFound": true,
   "notes.message": "",

--- a/frontend/src/telemetry/subscriptions.ts
+++ b/frontend/src/telemetry/subscriptions.ts
@@ -195,6 +195,17 @@ export function notesSnapshotsEqual(
   return fieldsEqual(left, right, [...keys]);
 }
 
+export function settingsSnapshotsEqual(
+  left: TelemetrySnapshot | null,
+  right: TelemetrySnapshot | null,
+) {
+  return fieldsEqual(left, right, [
+    "context.mode",
+    "dashboard.capabilities",
+    "sci.alarmProviders",
+  ]);
+}
+
 export function clockSnapshotsEqual(left: TelemetrySnapshot | null, right: TelemetrySnapshot | null) {
   return fieldsEqual(left, right, ["context.mode", "t.universalTime", "v.name", "v.body", "v.situationString", "v.missionTime", "rt.available", "rt.hasConnection", "rt.signalDelay", "comm.krpc.canCommunicate", "comm.krpc.signalStrength"]);
 }

--- a/frontend/src/telemetry/types.ts
+++ b/frontend/src/telemetry/types.ts
@@ -379,6 +379,49 @@ export interface OverviewCapabilities {
   contracts: boolean;
 }
 
+export type DashboardFeatureId =
+  | "notes"
+  | "science_telemetry"
+  | "science_alarms"
+  | "communications"
+  | "stage_analysis"
+  | "live_transfer_calculations"
+  | "heat_monitoring"
+  | "heat_controls"
+  | "editor_electricity"
+  | "damage_monitoring";
+
+export type DashboardCapabilityStatus = "available" | "fallback" | "unavailable" | "unknown";
+export type DashboardCapabilityReason =
+  | "ready"
+  | "fallback_active"
+  | "dependency_missing"
+  | "provider_unavailable"
+  | "not_observed"
+  | "scan_unconfigured"
+  | "probe_error";
+export type DashboardCapabilityEvidenceStatus = "active" | "detected" | "missing" | "unavailable" | "unknown";
+export type DashboardCapabilityEvidenceSource = "runtime" | "root_scan";
+
+export interface DashboardCapabilityEvidence {
+  id: string;
+  status: DashboardCapabilityEvidenceStatus;
+  source: DashboardCapabilityEvidenceSource;
+  version?: string;
+}
+
+export interface DashboardFeatureCapability {
+  status: DashboardCapabilityStatus;
+  reason: DashboardCapabilityReason;
+  provider?: string;
+  evidence: DashboardCapabilityEvidence[];
+}
+
+export interface DashboardCapabilitiesSnapshot {
+  schemaVersion: 1;
+  features: Record<DashboardFeatureId, DashboardFeatureCapability>;
+}
+
 export interface CelestialBodyTelemetry {
   name: string;
   parent?: string;
@@ -462,6 +505,7 @@ export interface TelemetrySnapshot {
   "overview.gameMode"?: string;
   "overview.readOnly"?: boolean;
   "overview.capabilities"?: OverviewCapabilities;
+  "dashboard.capabilities"?: DashboardCapabilitiesSnapshot;
   "overview.funds"?: number;
   "overview.science"?: number;
   "overview.reputation"?: number;

--- a/frontend/src/theme.test.ts
+++ b/frontend/src/theme.test.ts
@@ -8,43 +8,53 @@ import {
   DEFAULT_THEME_METADATA,
   loadThemeId,
   parseStoredThemeId,
+  selectTheme,
   serializeThemeId,
   SUPPORTED_THEME_IDS,
+  THEME_METADATA,
+  THEME_OPTIONS,
   THEME_STORAGE_KEY,
 } from "./theme";
 
-describe("current theme contract", () => {
+describe("dashboard theme contract", () => {
   beforeEach(() => {
     localStorage.clear();
-    delete document.documentElement.dataset.theme;
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.removeProperty("color-scheme");
   });
 
   afterEach(() => {
     localStorage.clear();
-    delete document.documentElement.dataset.theme;
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.removeProperty("color-scheme");
   });
 
-  it("defines one current dark palette and its canonical JSON storage form", () => {
+  it("defines four stable themes while preserving Mission Control Dark as the default", () => {
     expect(DEFAULT_THEME_ID).toBe("mission-control-dark");
-    expect(SUPPORTED_THEME_IDS).toEqual([DEFAULT_THEME_ID]);
-    expect(CURRENT_THEME_METADATA).toEqual({
-      id: DEFAULT_THEME_ID,
-      label: "Mission Control Dark",
-      colorScheme: "dark",
-      palette: "mission-control",
-    });
+    expect(SUPPORTED_THEME_IDS).toEqual([
+      "mission-control-dark",
+      "daylight-console",
+      "warm-crt",
+      "green-phosphor",
+    ]);
+    expect(THEME_OPTIONS.map(({ id, label, colorScheme }) => ({ id, label, colorScheme }))).toEqual([
+      { id: "mission-control-dark", label: "Mission Control Dark", colorScheme: "dark" },
+      { id: "daylight-console", label: "Daylight Console", colorScheme: "light" },
+      { id: "warm-crt", label: "Warm CRT", colorScheme: "dark" },
+      { id: "green-phosphor", label: "Green Phosphor", colorScheme: "dark" },
+    ]);
     expect(DEFAULT_THEME_METADATA).toBe(CURRENT_THEME_METADATA);
+    expect(THEME_METADATA[DEFAULT_THEME_ID].palette).toBe("mission-control");
     expect(serializeThemeId(DEFAULT_THEME_ID)).toBe('"mission-control-dark"');
   });
 
-  it("loads the valid canonical JSON string and compatible raw identifier", () => {
-    expect(parseStoredThemeId(serializeThemeId(DEFAULT_THEME_ID))).toBe(DEFAULT_THEME_ID);
-    expect(parseStoredThemeId(DEFAULT_THEME_ID)).toBe(DEFAULT_THEME_ID);
-
-    localStorage.setItem(THEME_STORAGE_KEY, serializeThemeId(DEFAULT_THEME_ID));
-    expect(loadThemeId()).toBe(DEFAULT_THEME_ID);
-    localStorage.setItem(THEME_STORAGE_KEY, DEFAULT_THEME_ID);
-    expect(loadThemeId()).toBe(DEFAULT_THEME_ID);
+  it("loads every valid canonical JSON string and compatible raw identifier", () => {
+    for (const themeId of SUPPORTED_THEME_IDS) {
+      expect(parseStoredThemeId(serializeThemeId(themeId))).toBe(themeId);
+      expect(parseStoredThemeId(themeId)).toBe(themeId);
+      localStorage.setItem(THEME_STORAGE_KEY, serializeThemeId(themeId));
+      expect(loadThemeId()).toBe(themeId);
+    }
   });
 
   it("falls back safely for malformed, unknown, and non-string values", () => {
@@ -53,24 +63,23 @@ describe("current theme contract", () => {
     expect(parseStoredThemeId("future-theme")).toBe(DEFAULT_THEME_ID);
     expect(parseStoredThemeId(null)).toBe(DEFAULT_THEME_ID);
     expect(parseStoredThemeId(undefined)).toBe(DEFAULT_THEME_ID);
-
-    localStorage.setItem(THEME_STORAGE_KEY, "{not-json");
-    expect(loadThemeId()).toBe(DEFAULT_THEME_ID);
   });
 
-  it("bootstraps the validated ID on the document root without storage writes", () => {
-    localStorage.setItem(THEME_STORAGE_KEY, serializeThemeId(DEFAULT_THEME_ID));
-    expect(bootstrapTheme()).toBe(DEFAULT_THEME_ID);
-    expect(document.documentElement.dataset.theme).toBe(DEFAULT_THEME_ID);
-    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe(serializeThemeId(DEFAULT_THEME_ID));
+  it("bootstraps the stored theme before React without rewriting storage", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, serializeThemeId("daylight-console"));
+    expect(bootstrapTheme()).toBe("daylight-console");
+    expect(document.documentElement.dataset.theme).toBe("daylight-console");
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe(serializeThemeId("daylight-console"));
   });
 
-  it("applies idempotently and rejects runtime IDs outside the single theme", () => {
-    expect(applyTheme(DEFAULT_THEME_ID)).toBe(DEFAULT_THEME_ID);
-    expect(applyTheme(DEFAULT_THEME_ID)).toBe(DEFAULT_THEME_ID);
-    expect(document.documentElement.dataset.theme).toBe(DEFAULT_THEME_ID);
+  it("applies, persists, and rejects runtime IDs outside the supported set", () => {
+    expect(selectTheme("warm-crt")).toBe("warm-crt");
+    expect(document.documentElement.dataset.theme).toBe("warm-crt");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe(serializeThemeId("warm-crt"));
+
     expect(applyTheme("future-theme")).toBe(DEFAULT_THEME_ID);
     expect(document.documentElement.dataset.theme).toBe(DEFAULT_THEME_ID);
-    expect(SUPPORTED_THEME_IDS).toHaveLength(1);
   });
 });

--- a/frontend/src/theme.test.ts
+++ b/frontend/src/theme.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyTheme,
+  bootstrapTheme,
+  CURRENT_THEME_METADATA,
+  DEFAULT_THEME_ID,
+  DEFAULT_THEME_METADATA,
+  loadThemeId,
+  parseStoredThemeId,
+  serializeThemeId,
+  SUPPORTED_THEME_IDS,
+  THEME_STORAGE_KEY,
+} from "./theme";
+
+describe("current theme contract", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    delete document.documentElement.dataset.theme;
+  });
+
+  it("defines one current dark palette and its canonical JSON storage form", () => {
+    expect(DEFAULT_THEME_ID).toBe("mission-control-dark");
+    expect(SUPPORTED_THEME_IDS).toEqual([DEFAULT_THEME_ID]);
+    expect(CURRENT_THEME_METADATA).toEqual({
+      id: DEFAULT_THEME_ID,
+      label: "Mission Control Dark",
+      colorScheme: "dark",
+      palette: "mission-control",
+    });
+    expect(DEFAULT_THEME_METADATA).toBe(CURRENT_THEME_METADATA);
+    expect(serializeThemeId(DEFAULT_THEME_ID)).toBe('"mission-control-dark"');
+  });
+
+  it("loads the valid canonical JSON string and compatible raw identifier", () => {
+    expect(parseStoredThemeId(serializeThemeId(DEFAULT_THEME_ID))).toBe(DEFAULT_THEME_ID);
+    expect(parseStoredThemeId(DEFAULT_THEME_ID)).toBe(DEFAULT_THEME_ID);
+
+    localStorage.setItem(THEME_STORAGE_KEY, serializeThemeId(DEFAULT_THEME_ID));
+    expect(loadThemeId()).toBe(DEFAULT_THEME_ID);
+    localStorage.setItem(THEME_STORAGE_KEY, DEFAULT_THEME_ID);
+    expect(loadThemeId()).toBe(DEFAULT_THEME_ID);
+  });
+
+  it("falls back safely for malformed, unknown, and non-string values", () => {
+    expect(parseStoredThemeId("{not-json")).toBe(DEFAULT_THEME_ID);
+    expect(parseStoredThemeId('"future-theme"')).toBe(DEFAULT_THEME_ID);
+    expect(parseStoredThemeId("future-theme")).toBe(DEFAULT_THEME_ID);
+    expect(parseStoredThemeId(null)).toBe(DEFAULT_THEME_ID);
+    expect(parseStoredThemeId(undefined)).toBe(DEFAULT_THEME_ID);
+
+    localStorage.setItem(THEME_STORAGE_KEY, "{not-json");
+    expect(loadThemeId()).toBe(DEFAULT_THEME_ID);
+  });
+
+  it("bootstraps the validated ID on the document root without storage writes", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, serializeThemeId(DEFAULT_THEME_ID));
+    expect(bootstrapTheme()).toBe(DEFAULT_THEME_ID);
+    expect(document.documentElement.dataset.theme).toBe(DEFAULT_THEME_ID);
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe(serializeThemeId(DEFAULT_THEME_ID));
+  });
+
+  it("applies idempotently and rejects runtime IDs outside the single theme", () => {
+    expect(applyTheme(DEFAULT_THEME_ID)).toBe(DEFAULT_THEME_ID);
+    expect(applyTheme(DEFAULT_THEME_ID)).toBe(DEFAULT_THEME_ID);
+    expect(document.documentElement.dataset.theme).toBe(DEFAULT_THEME_ID);
+    expect(applyTheme("future-theme")).toBe(DEFAULT_THEME_ID);
+    expect(document.documentElement.dataset.theme).toBe(DEFAULT_THEME_ID);
+    expect(SUPPORTED_THEME_IDS).toHaveLength(1);
+  });
+});

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,85 @@
+/**
+ * The dashboard currently exposes one intentional visual theme. Keeping the
+ * identifier and storage contract separate from CSS leaves a safe seam for a
+ * future palette without presenting an unusable theme chooser today.
+ */
+export const THEME_STORAGE_KEY = "wmc-theme-v1";
+export const DEFAULT_THEME_ID = "mission-control-dark" as const;
+export type ThemeId = typeof DEFAULT_THEME_ID;
+
+export interface ThemeMetadata {
+  id: ThemeId;
+  label: string;
+  colorScheme: "dark";
+  palette: "mission-control";
+}
+
+export const CURRENT_THEME_METADATA: Readonly<ThemeMetadata> = Object.freeze({
+  id: DEFAULT_THEME_ID,
+  label: "Mission Control Dark",
+  colorScheme: "dark",
+  palette: "mission-control",
+});
+
+export const DEFAULT_THEME_METADATA = CURRENT_THEME_METADATA;
+export const SUPPORTED_THEME_IDS: readonly ThemeId[] = [DEFAULT_THEME_ID];
+
+/** The canonical persisted form is a JSON string; raw IDs remain readable. */
+export function serializeThemeId(themeId: ThemeId): string {
+  return JSON.stringify(themeId);
+}
+
+export function isThemeId(value: unknown): value is ThemeId {
+  return value === DEFAULT_THEME_ID;
+}
+
+/**
+ * Parse a stored value without allowing malformed or unknown identifiers to
+ * reach the DOM. Raw identifiers are accepted for compatibility with an
+ * earlier pre-JSON draft of this reserved key.
+ */
+export function parseStoredThemeId(stored: string | null | undefined): ThemeId {
+  if (typeof stored !== "string") return DEFAULT_THEME_ID;
+  const candidate = stored.trim();
+  if (isThemeId(candidate)) return candidate;
+
+  try {
+    const parsed: unknown = JSON.parse(candidate);
+    return isThemeId(parsed) ? parsed : DEFAULT_THEME_ID;
+  } catch {
+    return DEFAULT_THEME_ID;
+  }
+}
+
+function browserStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadThemeId(storage: Storage | null | undefined = browserStorage()): ThemeId {
+  let stored: string | null = null;
+  try {
+    stored = storage?.getItem(THEME_STORAGE_KEY) ?? null;
+  } catch {
+    // Private browsing and restricted origins can reject localStorage reads.
+  }
+  return parseStoredThemeId(stored);
+}
+
+/** Apply the validated ID to the document root; repeated calls are harmless. */
+export function applyTheme(themeId: unknown = DEFAULT_THEME_ID): ThemeId {
+  const resolved = isThemeId(themeId) ? themeId : DEFAULT_THEME_ID;
+  if (typeof document !== "undefined") {
+    const root = document.documentElement;
+    if (root.dataset.theme !== resolved) root.dataset.theme = resolved;
+  }
+  return resolved;
+}
+
+/** Load and apply the current theme before React mounts. This never writes storage. */
+export function bootstrapTheme(storage?: Storage | null): ThemeId {
+  return applyTheme(loadThemeId(storage));
+}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,43 +1,76 @@
-/**
- * The dashboard currently exposes one intentional visual theme. Keeping the
- * identifier and storage contract separate from CSS leaves a safe seam for a
- * future palette without presenting an unusable theme chooser today.
- */
 export const THEME_STORAGE_KEY = "wmc-theme-v1";
-export const DEFAULT_THEME_ID = "mission-control-dark" as const;
-export type ThemeId = typeof DEFAULT_THEME_ID;
+
+export const SUPPORTED_THEME_IDS = [
+  "mission-control-dark",
+  "daylight-console",
+  "warm-crt",
+  "green-phosphor",
+] as const;
+
+export type ThemeId = typeof SUPPORTED_THEME_IDS[number];
 
 export interface ThemeMetadata {
   id: ThemeId;
   label: string;
-  colorScheme: "dark";
-  palette: "mission-control";
+  colorScheme: "dark" | "light";
+  palette: string;
+  description: string;
+  swatches: readonly [string, string, string];
 }
 
-export const CURRENT_THEME_METADATA: Readonly<ThemeMetadata> = Object.freeze({
-  id: DEFAULT_THEME_ID,
-  label: "Mission Control Dark",
-  colorScheme: "dark",
-  palette: "mission-control",
-});
+export const DEFAULT_THEME_ID: ThemeId = "mission-control-dark";
 
-export const DEFAULT_THEME_METADATA = CURRENT_THEME_METADATA;
-export const SUPPORTED_THEME_IDS: readonly ThemeId[] = [DEFAULT_THEME_ID];
+export const THEME_OPTIONS: readonly ThemeMetadata[] = [
+  {
+    id: "mission-control-dark",
+    label: "Mission Control Dark",
+    colorScheme: "dark",
+    palette: "mission-control",
+    description: "Deep navy console with amber headings and cyan active states.",
+    swatches: ["#05070b", "#ffb454", "#4ec9e0"],
+  },
+  {
+    id: "daylight-console",
+    label: "Daylight Console",
+    colorScheme: "light",
+    palette: "daylight",
+    description: "High-contrast light surfaces for bright rooms.",
+    swatches: ["#dde3ea", "#8a5300", "#0d6379"],
+  },
+  {
+    id: "warm-crt",
+    label: "Warm CRT",
+    colorScheme: "dark",
+    palette: "warm-crt",
+    description: "Amber and warm brown console surfaces with teal active states.",
+    swatches: ["#0d0a06", "#ffc36b", "#6fd0c2"],
+  },
+  {
+    id: "green-phosphor",
+    label: "Green Phosphor",
+    colorScheme: "dark",
+    palette: "green-phosphor",
+    description: "Deep green terminal surfaces with phosphor active states.",
+    swatches: ["#040a07", "#ffc247", "#bdf6cf"],
+  },
+] as const;
 
-/** The canonical persisted form is a JSON string; raw IDs remain readable. */
+export const THEME_METADATA: Readonly<Record<ThemeId, ThemeMetadata>> = Object.freeze(
+  Object.fromEntries(THEME_OPTIONS.map((theme) => [theme.id, theme])) as Record<ThemeId, ThemeMetadata>,
+);
+
+export const DEFAULT_THEME_METADATA = THEME_METADATA[DEFAULT_THEME_ID];
+/** Backward-compatible name used by existing About content. */
+export const CURRENT_THEME_METADATA = DEFAULT_THEME_METADATA;
+
 export function serializeThemeId(themeId: ThemeId): string {
   return JSON.stringify(themeId);
 }
 
 export function isThemeId(value: unknown): value is ThemeId {
-  return value === DEFAULT_THEME_ID;
+  return typeof value === "string" && (SUPPORTED_THEME_IDS as readonly string[]).includes(value);
 }
 
-/**
- * Parse a stored value without allowing malformed or unknown identifiers to
- * reach the DOM. Raw identifiers are accepted for compatibility with an
- * earlier pre-JSON draft of this reserved key.
- */
 export function parseStoredThemeId(stored: string | null | undefined): ThemeId {
   if (typeof stored !== "string") return DEFAULT_THEME_ID;
   const candidate = stored.trim();
@@ -69,17 +102,31 @@ export function loadThemeId(storage: Storage | null | undefined = browserStorage
   return parseStoredThemeId(stored);
 }
 
-/** Apply the validated ID to the document root; repeated calls are harmless. */
+export function persistThemeId(themeId: ThemeId, storage: Storage | null | undefined = browserStorage()): void {
+  try {
+    storage?.setItem(THEME_STORAGE_KEY, serializeThemeId(themeId));
+  } catch {
+    // Theme selection still applies for the session when storage is denied.
+  }
+}
+
 export function applyTheme(themeId: unknown = DEFAULT_THEME_ID): ThemeId {
   const resolved = isThemeId(themeId) ? themeId : DEFAULT_THEME_ID;
   if (typeof document !== "undefined") {
     const root = document.documentElement;
     if (root.dataset.theme !== resolved) root.dataset.theme = resolved;
+    root.style.colorScheme = THEME_METADATA[resolved].colorScheme;
   }
   return resolved;
 }
 
-/** Load and apply the current theme before React mounts. This never writes storage. */
+export function selectTheme(themeId: unknown, storage?: Storage | null): ThemeId {
+  const resolved = applyTheme(themeId);
+  persistThemeId(resolved, storage);
+  return resolved;
+}
+
+/** Load and apply the current theme before React mounts to avoid a palette flash. */
 export function bootstrapTheme(storage?: Storage | null): ThemeId {
   return applyTheme(loadThemeId(storage));
 }

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -39,6 +39,11 @@ from electricity import (
     solar_summary,
 )
 from damage import gather_part_damage, read_loss_fields
+from dashboard_capabilities import (
+    TELEMETRY_KEY as DASHBOARD_CAPABILITIES_KEY,
+    build_dashboard_capabilities,
+    scan_root_capabilities,
+)
 from heat import enrich_system_heat_result
 from heat_electricity_snapshot import decode_heat_electricity_snapshot
 from flight_core_snapshot import decode_flight_core_snapshot
@@ -131,6 +136,8 @@ _damage_cache_key = None
 _damage_last_ut = None
 _damage_loss_cache = None
 _damage_loss_revision = None
+_dashboard_capability_scan_root = None
+_dashboard_capability_scan = None
 _res_cache = {}
 _res_last_poll = 0.0
 _res_cache_key = None
@@ -4566,14 +4573,31 @@ def _gather_overview_telemetry(conn, scene, now=None):
     return data
 
 
+def _dashboard_capability_installation_scan():
+    """Read the fixed install markers once per configured root."""
+    global _dashboard_capability_scan_root, _dashboard_capability_scan
+    configured_root = os.environ.get("WOOBIE_KSP_ROOT", "").strip()
+    if (
+        _dashboard_capability_scan is None
+        or configured_root != _dashboard_capability_scan_root
+    ):
+        _dashboard_capability_scan_root = configured_root
+        _dashboard_capability_scan = scan_root_capabilities(configured_root)
+    return _dashboard_capability_scan
+
+
 def _finalize_telemetry(conn, payload):
-    """Attach shared planning and derived fields to one scene payload."""
+    """Attach shared planning, capabilities, and derived fields to one scene."""
     payload.update(_mission_planning.gather(
         conn,
         payload.get("context.mode"),
         payload.get("t.universalTime"),
     ))
     payload.update(_electricity_flow.update(payload))
+    payload[DASHBOARD_CAPABILITIES_KEY] = build_dashboard_capabilities(
+        payload,
+        _dashboard_capability_installation_scan(),
+    )
     return payload
 
 

--- a/tests/test_dashboard_capabilities.py
+++ b/tests/test_dashboard_capabilities.py
@@ -43,11 +43,18 @@ class DashboardCapabilitiesTests(unittest.TestCase):
             root = Path(temp)
             self.make_notes(root)
             self.make_file(root, ("gAmEdAtA", "WoObIeSCoNtRoLStAtS", "wOobiEsControlStats.DLL"))
-            self.make_file(root, ("gAmEdAtA", "ReMoTeTeCh", "rEmOtEtEcH.DLL"))
+            self.make_file(root, ("gAmEdAtA", "ReMoTeTeCh", "pLuGiNs", "rEmOtEtEcH.DLL"))
+            self.make_file(root, ("gAmEdAtA", "TrIgGeRtEcH", "KeRbAlAlArMcLoCk", "PlUgInS", "kErBaLaLaRmClOcK.DLL"))
+            self.make_file(root, ("gAmEdAtA", "DyNaMiCbAtTeRyStOrAgE", "PlUgInS", "dYnAmIcBaTtErYsToRaGe.DLL"))
             scan = capabilities.scan_root_capabilities(root)
         self.assertEqual(scan["dependencies"]["notes"]["status"], "detected")
         self.assertEqual(scan["dependencies"]["wcs"]["status"], "detected")
         self.assertEqual(scan["dependencies"]["remote_tech"]["status"], "detected")
+        self.assertEqual(scan["dependencies"]["kac"]["status"], "detected")
+        self.assertEqual(
+            scan["dependencies"]["dynamic_battery_storage"]["status"],
+            "detected",
+        )
         self.assertNotIn("root", scan)
         self.assertNotIn("path", scan)
         self.assertNotIn("hash", repr(scan).casefold())
@@ -63,27 +70,18 @@ class DashboardCapabilitiesTests(unittest.TestCase):
         self.assertEqual(built["features"]["notes"]["reason"], "probe_error")
         self.assertEqual(built["features"]["notes"]["status"], "unknown")
 
-    def test_missing_optional_providers_report_stock_fallbacks(self):
+    def test_missing_scan_markers_do_not_infer_runtime_fallbacks(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "GameData").mkdir()
             result = capabilities.build_dashboard_capabilities(
                 {}, capabilities.scan_root_capabilities(root)
             )
-        self.assertEqual(result["features"]["notes"]["status"], "unavailable")
-        self.assertEqual(result["features"]["stage_analysis"]["status"], "unavailable")
-        self.assertEqual(result["features"]["live_transfer_calculations"]["status"], "unavailable")
-        self.assertEqual(result["features"]["heat_controls"]["status"], "unavailable")
-        for feature in (
-            "science_telemetry",
-            "science_alarms",
-            "communications",
-            "heat_monitoring",
-            "editor_electricity",
-            "damage_monitoring",
-        ):
-            self.assertEqual(result["features"][feature]["status"], "fallback")
-            self.assertEqual(result["features"][feature]["reason"], "fallback_active")
+        for feature in capabilities.FEATURE_IDS:
+            self.assertEqual(result["features"][feature]["status"], "unknown")
+            self.assertEqual(
+                result["features"][feature]["reason"], "dependency_missing"
+            )
 
     def test_scan_is_cached_and_reset_reprobes(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/tests/test_dashboard_capabilities.py
+++ b/tests/test_dashboard_capabilities.py
@@ -1,0 +1,256 @@
+import sys
+import tempfile
+import unittest
+import ast
+import inspect
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import dashboard_capabilities as capabilities
+import telemetry_server
+
+
+class DashboardCapabilitiesTests(unittest.TestCase):
+    def setUp(self):
+        capabilities.reset_scan_cache()
+
+    def make_file(self, root, relative):
+        target = root.joinpath(*relative)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"known marker")
+
+    def make_notes(self, root):
+        target = root / "gamedata" / "nOtEs" / "pLuGiNs" / "pLuGiNdAtA" / "NoTeS"
+        target.mkdir(parents=True)
+
+    def test_complete_stable_shape_and_order(self):
+        result = capabilities.build_dashboard_capabilities({})
+        self.assertEqual(result["schemaVersion"], 1)
+        self.assertEqual(tuple(result["features"]), capabilities.FEATURE_IDS)
+        self.assertEqual(len(result["features"]), 10)
+        for feature in capabilities.FEATURE_IDS:
+            row = result["features"][feature]
+            self.assertEqual(set(row), {"status", "reason", "evidence"})
+            self.assertIn(row["status"], capabilities.STATUSES)
+            self.assertIn(row["reason"], capabilities.REASONS)
+
+    def test_whitelist_scan_is_case_insensitive_and_sanitised(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.make_notes(root)
+            self.make_file(root, ("gAmEdAtA", "WoObIeSCoNtRoLStAtS", "wOobiEsControlStats.DLL"))
+            self.make_file(root, ("gAmEdAtA", "ReMoTeTeCh", "rEmOtEtEcH.DLL"))
+            scan = capabilities.scan_root_capabilities(root)
+        self.assertEqual(scan["dependencies"]["notes"]["status"], "detected")
+        self.assertEqual(scan["dependencies"]["wcs"]["status"], "detected")
+        self.assertEqual(scan["dependencies"]["remote_tech"]["status"], "detected")
+        self.assertNotIn("root", scan)
+        self.assertNotIn("path", scan)
+        self.assertNotIn("hash", repr(scan).casefold())
+        self.assertNotIn("arbitrary", repr(scan).casefold())
+
+    def test_unconfigured_and_scan_error_are_safe(self):
+        unconfigured = capabilities.scan_root_capabilities("")
+        self.assertFalse(unconfigured["configured"])
+        self.assertEqual(unconfigured["dependencies"], {})
+        with mock.patch.object(capabilities, "_scan_uncached", return_value={"configured": True, "dependencies": {}, "error": True}):
+            result = capabilities.scan_root_capabilities("C:/configured")
+        built = capabilities.build_dashboard_capabilities({}, result)
+        self.assertEqual(built["features"]["notes"]["reason"], "probe_error")
+        self.assertEqual(built["features"]["notes"]["status"], "unknown")
+
+    def test_missing_optional_providers_report_stock_fallbacks(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "GameData").mkdir()
+            result = capabilities.build_dashboard_capabilities(
+                {}, capabilities.scan_root_capabilities(root)
+            )
+        self.assertEqual(result["features"]["notes"]["status"], "unavailable")
+        self.assertEqual(result["features"]["stage_analysis"]["status"], "unavailable")
+        self.assertEqual(result["features"]["live_transfer_calculations"]["status"], "unavailable")
+        self.assertEqual(result["features"]["heat_controls"]["status"], "unavailable")
+        for feature in (
+            "science_telemetry",
+            "science_alarms",
+            "communications",
+            "heat_monitoring",
+            "editor_electricity",
+            "damage_monitoring",
+        ):
+            self.assertEqual(result["features"][feature]["status"], "fallback")
+            self.assertEqual(result["features"][feature]["reason"], "fallback_active")
+
+    def test_scan_is_cached_and_reset_reprobes(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            with mock.patch.object(capabilities, "_scan_uncached", wraps=capabilities._scan_uncached) as probe:
+                capabilities.scan_root_capabilities(root)
+                capabilities.scan_root_capabilities(root)
+                self.assertEqual(probe.call_count, 1)
+                capabilities.reset_scan_cache()
+                capabilities.scan_root_capabilities(root)
+                self.assertEqual(probe.call_count, 2)
+
+    def test_runtime_evidence_overrides_detected_scan_dependency(self):
+        scan = {
+            "configured": True,
+            "error": False,
+            "dependencies": {
+                "stage_stats": {"source": "root_scan", "status": "detected"},
+                "mechjeb": {"source": "root_scan", "status": "detected"},
+            },
+        }
+        result = capabilities.build_dashboard_capabilities({"stage.available": False}, scan)
+        row = result["features"]["stage_analysis"]
+        self.assertEqual(row["status"], "unknown")
+        self.assertEqual(row["reason"], "not_observed")
+        self.assertEqual(row["evidence"][0]["source"], "runtime")
+        self.assertEqual(row["evidence"][0]["status"], "unavailable")
+        self.assertEqual(row["evidence"][1]["source"], "root_scan")
+        self.assertEqual(row["evidence"][1]["status"], "detected")
+
+    def test_stock_fallbacks_and_provider_requirements(self):
+        telemetry = {
+            "sci.krpc.backend": "SpaceCenter experiments fallback",
+            "comm.krpc.signalStrength": 0.7,
+            "heat.backend": "stock",
+            "editor.elec.backend": "stock",
+            "damage.source": "stock_krpc",
+        }
+        result = capabilities.build_dashboard_capabilities(telemetry)
+        self.assertEqual(result["features"]["science_telemetry"]["status"], "fallback")
+        self.assertEqual(result["features"]["communications"]["status"], "fallback")
+        self.assertEqual(result["features"]["heat_monitoring"]["status"], "fallback")
+        self.assertEqual(result["features"]["heat_controls"]["status"], "unavailable")
+        self.assertEqual(result["features"]["editor_electricity"]["status"], "fallback")
+        self.assertEqual(result["features"]["damage_monitoring"]["status"], "fallback")
+        self.assertEqual(result["features"]["live_transfer_calculations"]["status"], "unknown")
+
+    def test_notes_runtime_availability_is_authoritative(self):
+        available = capabilities.build_dashboard_capabilities({"notes.available": True})
+        unavailable = capabilities.build_dashboard_capabilities({"notes.available": False})
+        self.assertEqual(available["features"]["notes"]["status"], "available")
+        self.assertEqual(unavailable["features"]["notes"]["status"], "unavailable")
+
+    def test_alarm_provider_matrix_and_runtime_versions(self):
+        telemetry = {
+            "sci.alarmProviders": {"kac": False, "stock": True},
+            "mj.transfer.available": True,
+            "mj.transfer.compatibilityReady": True,
+            "mj.transfer.detectedVersion": "2.15.3.0",
+            "mj.transfer.compatibilityTarget": "0.8.10",
+        }
+        result = capabilities.build_dashboard_capabilities(telemetry)
+        alarms = result["features"]["science_alarms"]
+        self.assertEqual(alarms["status"], "fallback")
+        self.assertEqual(alarms["reason"], "fallback_active")
+        self.assertEqual(
+            {item["id"] for item in alarms["evidence"]}, {"kac", "stock"}
+        )
+        transfer = result["features"]["live_transfer_calculations"]
+        self.assertEqual(transfer["status"], "available")
+        versions = [item for item in transfer["evidence"] if "version" in item]
+        self.assertEqual({item["version"] for item in versions}, {"2.15.3.0", "0.8.10"})
+
+    def test_scan_missing_resolves_an_unobserved_required_runtime_provider(self):
+        scan = {
+            "configured": True,
+            "error": False,
+            "dependencies": {
+                "stage_stats": {"source": "root_scan", "status": "missing"},
+                "mechjeb": {"source": "root_scan", "status": "detected"},
+            },
+        }
+        result = capabilities.build_dashboard_capabilities(
+            {"stage.available": False}, scan
+        )
+        self.assertEqual(result["features"]["stage_analysis"]["status"], "unavailable")
+        self.assertEqual(result["features"]["stage_analysis"]["reason"], "dependency_missing")
+
+    def test_no_paths_hashes_or_arbitrary_mod_listing_in_builder(self):
+        result = capabilities.build_dashboard_capabilities(
+            {"mj.transfer.detectedVersion": "2.15.3.0"},
+            {
+                "configured": True,
+                "error": False,
+                "dependencies": {
+                    "mechjeb": {
+                        "source": "root_scan",
+                        "status": "detected",
+                        "path": "C:/secret/GameData/MechJeb2/Plugins/MechJeb2.dll",
+                        "sha256": "deadbeef",
+                        "name": "ArbitraryMod",
+                    }
+                },
+            },
+        )
+        text = repr(result).casefold()
+        self.assertNotIn("c:/secret", text)
+        self.assertNotIn("sha256", text)
+        self.assertNotIn("deadbeef", text)
+        self.assertNotIn("arbitrarymod", text)
+
+    def test_finalize_attaches_one_cached_complete_snapshot_across_scenes(self):
+        scan = {
+            "configured": True,
+            "error": False,
+            "dependencies": {},
+        }
+        telemetry_server._dashboard_capability_scan_root = None
+        telemetry_server._dashboard_capability_scan = None
+        with (
+            mock.patch.dict(
+                telemetry_server.os.environ,
+                {"WOOBIE_KSP_ROOT": "C:/configured-ksp"},
+                clear=False,
+            ),
+            mock.patch.object(
+                telemetry_server,
+                "scan_root_capabilities",
+                return_value=scan,
+            ) as root_scan,
+            mock.patch.object(
+                telemetry_server._mission_planning,
+                "gather",
+                return_value={},
+            ),
+            mock.patch.object(
+                telemetry_server._electricity_flow,
+                "update",
+                return_value={},
+            ),
+        ):
+            for mode in ("flight", "editor_vab", "editor_sph", "inactive"):
+                result = telemetry_server._finalize_telemetry(
+                    object(), {"context.mode": mode}
+                )
+                snapshot = result[capabilities.TELEMETRY_KEY]
+                self.assertEqual(snapshot["schemaVersion"], 1)
+                self.assertEqual(
+                    tuple(snapshot["features"]), capabilities.FEATURE_IDS
+                )
+            self.assertEqual(root_scan.call_count, 1)
+
+            telemetry_server.os.environ["WOOBIE_KSP_ROOT"] = "D:/another-ksp"
+            telemetry_server._finalize_telemetry(
+                object(), {"context.mode": "inactive"}
+            )
+            self.assertEqual(root_scan.call_count, 2)
+
+    def test_every_gather_scene_return_uses_the_shared_finalizer(self):
+        tree = ast.parse(inspect.getsource(telemetry_server.gather_telemetry))
+        returns = [node for node in ast.walk(tree) if isinstance(node, ast.Return)]
+        self.assertGreaterEqual(len(returns), 5)
+        for statement in returns:
+            self.assertIsInstance(statement.value, ast.Call)
+            self.assertIsInstance(statement.value.func, ast.Name)
+            self.assertEqual(statement.value.func.id, "_finalize_telemetry")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -635,6 +635,7 @@ class ReleaseContractTests(unittest.TestCase):
             encoding="utf-8"
         )
         for module in (
+            "dashboard_capabilities.py",
             "damage.py",
             "electricity.py",
             "editor_electrical_snapshot.py",

--- a/tools/Publish-Release.ps1
+++ b/tools/Publish-Release.ps1
@@ -281,6 +281,7 @@ $sourceFiles = @(
     @{ Source = 'runtime_update_helper.py'; Destination = 'Dashboard/runtime_update_helper.py' },
     @{ Source = 'runtime-update-contract.json'; Destination = 'Dashboard/runtime-update-contract.json' },
     @{ Source = 'panel_bridge.py'; Destination = 'Dashboard/panel_bridge.py' },
+    @{ Source = 'dashboard_capabilities.py'; Destination = 'Dashboard/dashboard_capabilities.py' },
     @{ Source = 'damage.py'; Destination = 'Dashboard/damage.py' },
     @{ Source = 'electricity.py'; Destination = 'Dashboard/electricity.py' },
     @{ Source = 'editor_electrical_snapshot.py'; Destination = 'Dashboard/editor_electrical_snapshot.py' },


### PR DESCRIPTION
## Summary

- add a production-visible Settings tool drawer with Preferences, Features & Mods, Help, and About
- centralize time-system and science-alarm preferences, panel restoration, focus handling, and tool-drawer mutual exclusion
- add Mission Control Dark, Daylight Console, Warm CRT, and Green Phosphor palettes with validated browser persistence
- expose a sanitized, installation-derived capability inventory without leaking paths, hashes, or arbitrary mod data
- make deterministic development fixtures present all supported integrations as healthy for screenshots and UI review
- refine Delta-V plan management, theme inheritance, header density, and mission-wide transfer-planning placement
- update user documentation, release source allowlists, and focused regression coverage

## Why

Dashboard behavior and integration availability were spread across individual panels or invisible to users. This gives the dashboard one discoverable place to understand and change browser-local behavior, see which supported integrations are installed, choose an appearance, and reach documentation.

The capability presentation is deliberately dashboard-wide rather than scene-dependent: Settings derives its headline status from the configured KSP installation scan. Runtime observations remain diagnostic telemetry and do not make installed integrations appear missing merely because the current scene cannot exercise them.

## User impact

- Settings is available from every dashboard scene as the final item in the left-rail Tools group.
- Preferences apply immediately and preserve existing storage keys where applicable.
- Theme selection changes color roles only; existing layout and typography are preserved.
- Features & Mods covers a fixed known integration set and treats unavailable detection separately from an absent marker.
- The browser still does not install/repair DLLs, select the KSP folder, apply launcher updates, or write live GameData.

## Validation

- Python: 447/447
- Frontend Vitest: 497/497
- Chrome/Edge Playwright: 56/56
- TypeScript `tsc --noEmit`
- CSS token/contrast contract
- Vite production build and staged runtime web
- `Start KSP Dashboard.bat --check` reports Dashboard and ESP32 Controlpad READY
- independent read-only audit of exact base `9013344` through exact head `8b489b3`: no findings
- staged `frontend/dist` and `web` hashes match

No custom kRPC service DLL or selected service version changes are included. Final pointer-free release screenshots, product version selection, release packaging, wiki publication, and release publication remain separate gates.