### PR TITLE
Fix Flight navball orientation and launch COMMS caution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable public changes will be recorded here.
 
+## Unreleased
+
+- Added a projected orange north-reference line to the vector Flight navball so
+  its orientation and roll direction remain immediately legible.
+
 ## v0.7.3 - Portrait layouts and visual options
 
 - Added development-fixture controls for independently enabling and disabling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable public changes will be recorded here.
 - Added a projected orange north-reference line to the vector Flight navball
   and corrected the shared vector/textured roll direction to match KSP's
   positive right-bank convention.
+- Prevented RemoteTech's brief Editor-to-launchpad initialization gap from
+  raising a false COMMS Master Caution while retaining the established-flight
+  link-loss response.
 
 ## v0.7.3 - Portrait layouts and visual options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable public changes will be recorded here.
 
 ## Unreleased
 
-- Added a projected orange north-reference line to the vector Flight navball so
-  its orientation and roll direction remain immediately legible.
+- Added a projected orange north-reference line to the vector Flight navball
+  and corrected the shared vector/textured roll direction to match KSP's
+  positive right-bank convention.
 
 ## v0.7.3 - Portrait layouts and visual options
 

--- a/frontend/src/annunciator/engine.test.ts
+++ b/frontend/src/annunciator/engine.test.ts
@@ -341,4 +341,109 @@ describe("annunciator lifecycle and watchdog", () => {
     }, policy);
     expect(state.episodes).toEqual([]);
   });
+
+  it("applies a rule lifecycle grace only to a fresh Flight or vessel lifecycle", () => {
+    const commsRule = rule(() => ({
+      kind: "known",
+      complete: true,
+      observations: [{ instanceId: "active-vessel", state: "active", message: "No connection." }],
+    }), {
+      activationDwellMs: 100,
+      lifecycleGraceMs: 500,
+      ruleId: "comms-link-lost",
+      sourceId: "comms",
+      subsystem: "COMMS",
+    });
+    let state = evaluateAnnunciatorSnapshot(
+      createAnnunciatorState(),
+      [commsRule],
+      snapshot,
+      { nowMs: 0, vesselIdentity: "vessel-a" },
+      policy,
+    );
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 499,
+      vesselIdentity: "vessel-a",
+    }, policy);
+    expect(state.episodes).toEqual([]);
+
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 500,
+      vesselIdentity: "vessel-a",
+    }, policy);
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 599,
+      vesselIdentity: "vessel-a",
+    }, policy);
+    expect(state.episodes).toEqual([]);
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 600,
+      vesselIdentity: "vessel-a",
+    }, policy);
+    expect(state.episodes).toHaveLength(1);
+
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 700,
+      vesselIdentity: "vessel-b",
+    }, policy);
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 1_199,
+      vesselIdentity: "vessel-b",
+    }, policy);
+    expect(state.episodes).toEqual([]);
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 1_200,
+      vesselIdentity: "vessel-b",
+    }, policy);
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 1_300,
+      vesselIdentity: "vessel-b",
+    }, policy);
+    expect(state.episodes).toHaveLength(1);
+  });
+
+  it("retains the ordinary activation dwell after the lifecycle grace expires", () => {
+    let disconnected = false;
+    const commsRule = rule(() => ({
+      kind: "known",
+      complete: true,
+      observations: [{
+        instanceId: "active-vessel",
+        state: disconnected ? "active" : "clear",
+        message: "No connection.",
+      }],
+    }), {
+      activationDwellMs: 100,
+      lifecycleGraceMs: 500,
+      ruleId: "comms-link-lost",
+      sourceId: "comms",
+      subsystem: "COMMS",
+    });
+    let state = evaluateAnnunciatorSnapshot(
+      createAnnunciatorState(),
+      [commsRule],
+      snapshot,
+      { nowMs: 0, vesselIdentity: "vessel-a" },
+      policy,
+    );
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 500,
+      vesselIdentity: "vessel-a",
+    }, policy);
+    disconnected = true;
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 1_000,
+      vesselIdentity: "vessel-a",
+    }, policy);
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 1_099,
+      vesselIdentity: "vessel-a",
+    }, policy);
+    expect(state.episodes).toEqual([]);
+    state = evaluateAnnunciatorSnapshot(state, [commsRule], snapshot, {
+      nowMs: 1_100,
+      vesselIdentity: "vessel-a",
+    }, policy);
+    expect(state.episodes).toHaveLength(1);
+  });
 });

--- a/frontend/src/annunciator/engine.ts
+++ b/frontend/src/annunciator/engine.ts
@@ -27,6 +27,7 @@ export interface AnnunciatorRule {
   defaultTier: AnnunciatorTier;
   latchSubDwell?: boolean;
   activationDwellMs?: number;
+  lifecycleGraceMs?: number;
   evaluate(snapshot: TelemetrySnapshot, context: RuleEvaluationContext): RuleEvaluation;
 }
 
@@ -452,6 +453,8 @@ export function evaluateAnnunciatorSnapshot(
   const sourceApplicable = new Set<string>();
 
   rules.forEach((rule) => {
+    const lifecycleAgeMs = input.nowMs - (next.feed.startedAtMs ?? input.nowMs);
+    if (lifecycleAgeMs < nonNegative(rule.lifecycleGraceMs ?? 0)) return;
     const definitionBase = {
       ruleId: rule.ruleId,
       sourceId: rule.sourceId,

--- a/frontend/src/annunciator/rules.test.ts
+++ b/frontend/src/annunciator/rules.test.ts
@@ -198,6 +198,43 @@ describe("Flight annunciator rule catalog", () => {
     expect(evaluate(COMMS_LINK_RULE, {})).toEqual({ kind: "source-unknown" });
   });
 
+  it("suppresses only the initial RemoteTech false-negative before using the normal loss dwell", () => {
+    const disconnected: TelemetrySnapshot = {
+      "context.mode": "flight",
+      "rt.available": true,
+      "rt.hasConnection": false,
+    };
+    let state = evaluateAnnunciatorSnapshot(
+      createAnnunciatorState(),
+      [COMMS_LINK_RULE],
+      disconnected,
+      { nowMs: 0, vesselIdentity: "vessel-a" },
+    );
+    state = evaluateAnnunciatorSnapshot(state, [COMMS_LINK_RULE], disconnected, {
+      nowMs: 4_999,
+      vesselIdentity: "vessel-a",
+    });
+    expect(state.episodes).toEqual([]);
+    state = evaluateAnnunciatorSnapshot(state, [COMMS_LINK_RULE], disconnected, {
+      nowMs: 5_000,
+      vesselIdentity: "vessel-a",
+    });
+    state = evaluateAnnunciatorSnapshot(state, [COMMS_LINK_RULE], disconnected, {
+      nowMs: 6_499,
+      vesselIdentity: "vessel-a",
+    });
+    expect(state.episodes).toEqual([]);
+    state = evaluateAnnunciatorSnapshot(state, [COMMS_LINK_RULE], disconnected, {
+      nowMs: 6_500,
+      vesselIdentity: "vessel-a",
+    });
+    expect(state.episodes).toMatchObject([{
+      ruleId: "comms-link-lost",
+      subsystem: "COMMS",
+      message: "RemoteTech reports no vessel connection.",
+    }]);
+  });
+
   it("raises immediate grouped damage warnings only from complete authoritative scans", () => {
     expect(evaluate(PART_DAMAGE_RULE, { "damage.status": "unknown" })).toEqual({ kind: "source-unknown" });
     expect(evaluate(PART_DAMAGE_RULE, { "damage.status": "incomplete", "damage.parts": [] })).toEqual({ kind: "source-unknown" });

--- a/frontend/src/annunciator/rules.ts
+++ b/frontend/src/annunciator/rules.ts
@@ -15,6 +15,7 @@ export interface FlightAnnunciatorConditionContract {
   subsystem: string;
   tier: AnnunciatorTier | "caution-to-warning";
   activationDwellMs?: number;
+  lifecycleGraceMs?: number;
   latchSubDwell: boolean;
   trip: string;
   reset: string;
@@ -38,6 +39,7 @@ const ELECTRIC_CHARGE_CAUTION_TRIP = 0.40;
 const ELECTRIC_CHARGE_CAUTION_RESET = 0.45;
 const ELECTRIC_CHARGE_WARNING_TRIP = 0.15;
 const COMMS_ACTIVATION_DWELL_MS = 1_500;
+const COMMS_LIFECYCLE_GRACE_MS = 5_000;
 
 function active(
   instanceId: string,
@@ -420,6 +422,7 @@ export const COMMS_LINK_RULE: AnnunciatorRule = {
   subsystem: "COMMS",
   defaultTier: "caution",
   activationDwellMs: COMMS_ACTIVATION_DWELL_MS,
+  lifecycleGraceMs: COMMS_LIFECYCLE_GRACE_MS,
   evaluate: commsEvaluation,
 };
 
@@ -505,12 +508,13 @@ export const FLIGHT_ANNUNCIATOR_CONDITION_TABLE: FlightAnnunciatorConditionContr
     subsystem: "COMMS",
     tier: "caution",
     activationDwellMs: COMMS_ACTIVATION_DWELL_MS,
+    lifecycleGraceMs: COMMS_LIFECYCLE_GRACE_MS,
     latchSubDwell: false,
-    trip: "RemoteTech (authoritative when available) or stock CommNet reports no connection for 1.5 s.",
+    trip: "After a 5 s Flight/vessel lifecycle initialization grace, RemoteTech (authoritative when available) or stock CommNet reports no connection for 1.5 s.",
     reset: "Authoritative connection remains restored through global clear dwell.",
     identity: "Singleton active vessel, reset on persistent vessel change or revert.",
     completeness: "RemoteTech availability and connection boolean, otherwise stock canCommunicate boolean, sampled every frame.",
-    rationale: "Short handoff drops are diagnostic blips; sustained loss is actionable but not inherently destructive.",
+    rationale: "RemoteTech can briefly report no connection while a newly loaded vessel initializes. The one-time lifecycle grace suppresses that false launch caution without extending the established-vessel loss dwell.",
   },
   {
     ruleId: PART_DAMAGE_RULE.ruleId,

--- a/frontend/src/components/AscensionPanel.test.tsx
+++ b/frontend/src/components/AscensionPanel.test.tsx
@@ -102,11 +102,13 @@ describe("Ascension information hierarchy", () => {
     expect(view.container.querySelector(".navball-stage .navball")).not.toBeNull();
     expect(view.container.querySelectorAll(".navball .nav-spherical-grid path")).toHaveLength(16);
     expect(view.container.querySelector(".navball .nav-spherical-horizon")).not.toBeNull();
+    expect(view.container.querySelector(".navball .nav-spherical-north-reference")?.getAttribute("d")).toBeTruthy();
     expect(view.container.querySelector(".navball .nav-sphere-rim")).not.toBeNull();
     const clippedWorld = view.container.querySelector(".navball .nav-sphere-world");
     expect(clippedWorld?.getAttribute("clip-path")).toMatch(/^url\(#navball-clip-/);
     expect(clippedWorld?.querySelector(".nav-sphere-sky")).not.toBeNull();
     expect(clippedWorld?.querySelector(".nav-spherical-grid")).not.toBeNull();
+    expect(clippedWorld?.querySelector(".nav-spherical-north-reference")).not.toBeNull();
     expect(clippedWorld?.querySelector(".nav-cardinals")).not.toBeNull();
     expect(clippedWorld?.contains(view.container.querySelector(".nav-sphere-rim"))).toBe(false);
     expect(view.container.querySelector(".navball .aircraft")?.getAttribute("d")).toBe("M52 84 H71 L84 95 L97 84 H116");

--- a/frontend/src/components/AscensionPanel.tsx
+++ b/frontend/src/components/AscensionPanel.tsx
@@ -55,7 +55,7 @@ function MissionControlNavball({ heading, pitch, roll }: { heading?: number; pit
   const skyGradientId = `navball-sky-${id}`;
   const clipId = `navball-clip-${id}`;
   return (
-    <svg aria-label={`Navball at heading ${Math.round(geometry.heading)}, pitch ${Math.round(geometry.pitch)}, roll ${Math.round(geometry.roll)}`} className="navball" role="img" viewBox="0 0 168 168">
+    <svg aria-label={`Navball with north reference line at heading ${Math.round(geometry.heading)}, pitch ${Math.round(geometry.pitch)}, roll ${Math.round(geometry.roll)}`} className="navball" role="img" viewBox="0 0 168 168">
       <defs>
         <linearGradient id={skyGradientId} x1="0" x2="0" y1="0" y2="1">
           <stop offset="0" stopColor="#63a9dd" />
@@ -72,6 +72,7 @@ function MissionControlNavball({ heading, pitch, roll }: { heading?: number; pit
           {geometry.grid.map((line, index) => <path d={line.path} key={index} opacity={line.opacity} />)}
         </g>
         {geometry.horizonPath && <path className="nav-spherical-horizon" d={geometry.horizonPath} />}
+        {geometry.northReferencePath && <path className="nav-spherical-north-reference" d={geometry.northReferencePath} />}
         <g className="nav-cardinals">
           {geometry.cardinals.map((cardinal) => <text key={cardinal.label} x={cardinal.x.toFixed(1)} y={cardinal.y.toFixed(1)}>{cardinal.label}</text>)}
         </g>

--- a/frontend/src/components/navballGeometry.test.ts
+++ b/frontend/src/components/navballGeometry.test.ts
@@ -23,6 +23,12 @@ describe("spherical navball geometry", () => {
     expect(geometry.cardinals).toEqual([{ label: "N", x: 84, y: 80 }]);
   });
 
+  it("rotates the world left for a positive right bank", () => {
+    const projectedSkyPole = projectNavballPoint([0, 0, 1], makeNavballBasis(0, 0, 90));
+    expect(projectedSkyPole.x).toBeCloseTo(6, 10);
+    expect(projectedSkyPole.y).toBeCloseTo(84, 10);
+  });
+
   it("hides the north reference on the far side of a level south-facing ball", () => {
     expect(buildNavballGeometry({ heading: 180, pitch: 0, roll: 0 }).northReferencePath).toBe("");
   });

--- a/frontend/src/components/navballGeometry.test.ts
+++ b/frontend/src/components/navballGeometry.test.ts
@@ -18,8 +18,13 @@ describe("spherical navball geometry", () => {
     const geometry = buildNavballGeometry({ heading: 0, pitch: 0, roll: 0 });
     expect(geometry.grid).toHaveLength(9);
     expect(geometry.horizonPath).not.toBe("");
+    expect(geometry.northReferencePath).toContain("L84.0 84.0");
     expect(geometry.skyPath).not.toBe("");
     expect(geometry.cardinals).toEqual([{ label: "N", x: 84, y: 80 }]);
+  });
+
+  it("hides the north reference on the far side of a level south-facing ball", () => {
+    expect(buildNavballGeometry({ heading: 180, pitch: 0, roll: 0 }).northReferencePath).toBe("");
   });
 
   it("matches the supplied 45-degree eastward ascent reference attitude", () => {
@@ -33,6 +38,7 @@ describe("spherical navball geometry", () => {
     const geometry = buildNavballGeometry({ heading: 0, pitch: 90, roll: 0 });
     expect(geometry.skyPath).toBe("M6 84A78 78 0 1 1 162 84A78 78 0 1 1 6 84Z");
     expect(geometry.horizonPath).toBe("");
+    expect(geometry.northReferencePath).not.toBe("");
     expect(geometry.cardinals).toHaveLength(0);
   });
 

--- a/frontend/src/components/navballGeometry.ts
+++ b/frontend/src/components/navballGeometry.ts
@@ -16,6 +16,7 @@ export interface NavballGeometry {
   grid: readonly { path: string; opacity: number }[];
   heading: number;
   horizonPath: string;
+  northReferencePath: string;
   pitch: number;
   roll: number;
   skyPath: string;
@@ -201,6 +202,7 @@ export function buildNavballGeometry({
     grid,
     heading,
     horizonPath: curvePath(latitudeRing(0, 200), basis),
+    northReferencePath: curvePath(halfMeridian(0, 90), basis),
     pitch,
     roll,
     skyPath: skyRegion(basis),

--- a/frontend/src/components/navballGeometry.ts
+++ b/frontend/src/components/navballGeometry.ts
@@ -45,7 +45,9 @@ function combine(a: Vector3, aScale: number, b: Vector3, bScale: number): Vector
 export function makeNavballBasis(heading: number, pitch: number, roll: number): NavballBasis {
   const headingRadians = heading * degreesToRadians;
   const pitchRadians = pitch * degreesToRadians;
-  const rollRadians = roll * degreesToRadians;
+  // kRPC reports positive roll as a right bank. An attitude indicator keeps
+  // the aircraft fixed, so the world must rotate in the opposite direction.
+  const rollRadians = roll === 0 ? 0 : -roll * degreesToRadians;
   const forward: Vector3 = [
     Math.sin(headingRadians) * Math.cos(pitchRadians),
     Math.cos(headingRadians) * Math.cos(pitchRadians),

--- a/frontend/src/components/navballTexture.test.ts
+++ b/frontend/src/components/navballTexture.test.ts
@@ -10,9 +10,9 @@ describe("textured navball projection", () => {
     expect(navballTextureCoordinates(makeNavballBasis(0, -90, 0), 0, 0)).toEqual({ u: .5, v: 1 });
   });
 
-  it("rotates the texture with roll and wraps equivalent headings", () => {
+  it("rotates the texture left for a positive right bank and wraps equivalent headings", () => {
     const rolledTop = navballTextureCoordinates(makeNavballBasis(0, 0, 90), 0, 1);
-    expect(rolledTop?.u).toBeCloseTo(.25, 10);
+    expect(rolledTop?.u).toBeCloseTo(.75, 10);
     expect(rolledTop?.v).toBeCloseTo(.5, 10);
     expect(navballTextureCoordinates(makeNavballBasis(360, 0, 0), 0, 0)?.u).toBeCloseTo(.5, 10);
   });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2145,6 +2145,7 @@ button { font: inherit; }
 .nav-sphere-ground { fill: #6b4f33; }
 .nav-spherical-grid { fill: none; stroke: #fff; stroke-width: .8; }
 .nav-spherical-horizon { fill: none; stroke: #f2f8fc; stroke-width: 1.4; stroke-opacity: .9; }
+.nav-spherical-north-reference { fill: none; stroke: #f28c28; stroke-width: 1.8; stroke-linecap: round; }
 .nav-cardinals { fill: #fff; font: 9px var(--mono); text-anchor: middle; }
 .nav-sphere-rim { fill: none; stroke: #0a1119; stroke-width: 2; stroke-opacity: .55; }
 .aircraft { fill: none; stroke: var(--amber); stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; }


### PR DESCRIPTION
## Summary

- add a projected orange north-reference cue to the vector Flight navball
- correct the shared vector and KSP2-textured roll direction to match KSP's positive right-bank convention
- suppress RemoteTech's brief false no-connection reading during fresh Flight/vessel initialization without extending the established 1.5-second COMMS loss dwell

## Root cause

The shared navball attitude basis applied the roll sign opposite to KSP's displayed-world convention. Separately, RemoteTech can briefly report no vessel connection while an Editor-to-launchpad vessel binding initializes; that false state could outlast the existing 1.5-second dwell and leave an unacknowledged cleared caution.

## Impact

This is a frontend-only patch. It changes no telemetry contract, service DLL, persisted preference, maneuver boundary, or live KSP state. RemoteTech remains authoritative once the bounded five-second lifecycle grace expires.

## Validation

- navball geometry/texture/component: 22/22
- annunciator engine/rule/controller: 27/27
- full frontend: 52 files, 515/515
- CSS contract, strict TypeScript, and production build passed
- source launcher `--check`: Dashboard READY
- live Chrome comparison matched the in-game navball orientation
- user-led Editor-to-launchpad retest confirmed the false COMMS caution no longer occurs
- three independent Terra read-only audit lanes found no blocking issue

Fixes #51