### PR TITLE
Add opt-in trusted-LAN dashboard access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable public changes will be recorded here.
   confirmation before enabling the unauthenticated, unencrypted,
   command-capable listener. The warning can be remembered explicitly and is
   versioned so materially changed capabilities require a new acknowledgement.
+  Starting a LAN-enabled feed leaves the host browser closed; users can copy the
+  LAN URL for another device or explicitly open the local dashboard.
 - Hardened LAN serving with simultaneous listener-specific peer, Host, and
   WebSocket Origin validation. Wildcard, public, stale, and unavailable binds
   remain blocked, visible settings explicitly override inherited environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable public changes will be recorded here.
 
 ## Unreleased
 
+- Reworked the desktop launcher into a screen-efficient two-column workbench
+  with responsive single-column fallback, paired compatibility/service status
+  rows, a compact live-kRPC card, and a larger resizable Mission Log. The log
+  now supports source and warning filters, warning counts, copy, clear, and a
+  follow-tail toggle while retaining every existing launcher action.
 - Added opt-in trusted-LAN dashboard access while preserving the launcher's
   loopback dashboard. The launcher discovers active private IPv4 interfaces,
   lets the user select one and copy its URL, and requires a detailed warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable public changes will be recorded here.
   rows, a compact live-kRPC card, and a larger resizable Mission Log. The log
   now supports source and warning filters, warning counts, copy, clear, and a
   follow-tail toggle while retaining every existing launcher action.
+- Clarified the optional Notes compatibility entry as zer0Kerbal's Notes
+  (Kollege Ruled) and now reports whether its detected version matches the
+  tested v0.17.0.0 release.
 - Added opt-in trusted-LAN dashboard access while preserving the launcher's
   loopback dashboard. The launcher discovers active private IPv4 interfaces,
   lets the user select one and copy its URL, and requires a detailed warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable public changes will be recorded here.
 
+## Unreleased
+
+- Added opt-in trusted-LAN dashboard access while preserving the launcher's
+  loopback dashboard. The launcher discovers active private IPv4 interfaces,
+  lets the user select one and copy its URL, and requires a detailed warning
+  confirmation before enabling the unauthenticated, unencrypted,
+  command-capable listener. The warning can be remembered explicitly and is
+  versioned so materially changed capabilities require a new acknowledgement.
+- Hardened LAN serving with simultaneous listener-specific peer, Host, and
+  WebSocket Origin validation. Wildcard, public, stale, and unavailable binds
+  remain blocked, visible settings explicitly override inherited environment
+  values, and changing LAN configuration stops a running feed until the user
+  starts it again.
+- Documented Private-network Windows firewall guidance and the data and command
+  access granted to trusted LAN peers. No firewall rules are created
+  automatically, and no authentication, TLS, IPv6, telemetry-schema, or custom
+  service-DLL changes are included.
+
 ## v0.7.4 - Flight navball and launch communications
 
 - Added a projected orange north-reference line to the vector Flight navball

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -90,8 +90,8 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    running. It confirms that kRPC responds and that services for the installed
    integration DLLs are registered.
    In the Mission Control launcher, start Dashboard feed (telemetry + React).
-   The launcher waits for the loopback server and opens the dashboard in your
-   browser automatically. Each tool stops after 10
+   With LAN access off, the launcher waits for the loopback server and opens
+   the dashboard in your browser automatically. Each tool stops after 10
    failed kRPC attempts (about 20 seconds) instead of retrying forever. Its
    connection status then turns amber and recommends Test connection.
 
@@ -107,8 +107,10 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    the warning returns every time LAN access is turned on.
 
    Enabling, disabling, or changing the LAN address stops a running Dashboard
-   feed. Click Start again, then use the copied LAN URL from the trusted device;
-   the local browser continues to use http://127.0.0.1:8090/. If Windows shows
+   feed. Click Start again, then use the copied LAN URL from the trusted device.
+   Start does not automatically open a browser on the host while LAN access is
+   enabled; choose Open dashboard if you also want a local loopback tab at
+   http://127.0.0.1:8090/. If Windows shows
    a firewall prompt, allow access on Private networks only. Mission Control
    does not create firewall rules. Never forward port 8090 through a router or
    expose it on a public network, and verify the chosen adapter on VPN or

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -95,6 +95,25 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    failed kRPC attempts (about 20 seconds) instead of retrying forever. Its
    connection status then turns amber and recommends Test connection.
 
+   OPTIONAL TRUSTED-LAN ACCESS: Leave Allow local network access off unless
+   every device on the selected network is trusted. Choose an active private
+   IPv4 address from the LAN address list; Refresh rescans the host and Copy
+   LAN URL copies the address for a second device. Turning LAN access on opens
+   a warning that explains the listener has no authentication or encryption.
+   LAN peers can view telemetry, finances, contracts, Notes, and vessel data,
+   and can issue every dashboard command, including vessel recovery or
+   termination, system controls, and maneuver-node creation. Choose Cancel to
+   leave LAN access off. The Remember checkbox is off by default; without it,
+   the warning returns every time LAN access is turned on.
+
+   Enabling, disabling, or changing the LAN address stops a running Dashboard
+   feed. Click Start again, then use the copied LAN URL from the trusted device;
+   the local browser continues to use http://127.0.0.1:8090/. If Windows shows
+   a firewall prompt, allow access on Private networks only. Mission Control
+   does not create firewall rules. Never forward port 8090 through a router or
+   expose it on a public network, and verify the chosen adapter on VPN or
+   multi-network computers.
+
    In Space Center and Tracking Station scenes, Mission Control shows a
    read-only program overview with save-mode-appropriate economy totals,
    filterable tracked vessels and roster, active contracts, and a combined

--- a/QUICKSTART.txt
+++ b/QUICKSTART.txt
@@ -135,12 +135,13 @@ from http://127.0.0.1:8090/. Node.js and Vite are not required.
    confirmation. Mission Control never executes the node, warps, steers,
    stages, or changes throttle.
 
-   OPTIONAL NOTES INTEGRATION: When the Notes mod is detected at the selected
-   KSP location, a Notes button appears in the dashboard during flight and
-   opens the active vessel's ship log in a right-side drawer. Select any saved
-   note and choose Pin to flight to show it in a scrollable final flight panel.
-   Use A- and A+ in either Notes view to adjust text size; click the size value
-   to return to the default.
+   OPTIONAL NOTES INTEGRATION: The launcher checks for zer0Kerbal's Notes
+   (Kollege Ruled) v0.17.0.0, the release tested with Mission Control. When the
+   mod is detected at the selected KSP location, a Notes button appears in the
+   dashboard during flight and opens the active vessel's ship log in a
+   right-side drawer. Select any saved note and choose Pin to flight to show it
+   in a scrollable final flight panel. Use A- and A+ in either Notes view to
+   adjust text size; click the size value to return to the default.
 
    SETTINGS RAIL: The Settings rail groups browser-local Preferences, known
    Features & Mods, curated external Help links, and About information.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ does not execute nodes, warp, steer, stage, or change throttle.
 - Space Center and Tracking Station views with guarded switching to a selected
   vessel.
 - VAB/SPH craft totals and atmospheric or vacuum stage simulation.
-- Optional Notes, Kerbal Alarm Clock, RemoteTech, System Heat, and ESP32
+- Optional zer0Kerbal's Notes (Kollege Ruled), Kerbal Alarm Clock, RemoteTech,
+  System Heat, and ESP32
   integrations without making them requirements for the rest of the dashboard.
 
 ## Settings, Help, and About

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ RFC1918 IPv4 address selected from the launcher's address picker. The routed
 default is preselected when available; **Refresh** updates the active choices,
 and **Copy LAN URL** copies the address to share with a trusted device. Changing
 enablement or the selected address stops a running feed, so click **Start** again
-to apply the displayed configuration.
+to apply the displayed configuration. While LAN access is enabled, **Start**
+does not automatically open a browser on the host; **Open dashboard** remains
+available when a local loopback tab is also wanted.
 
 Enabling LAN access requires confirmation that the listener has no
 authentication or encryption. Trusted peers can view telemetry, finances,

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Current public release: **[v0.7.4](https://github.com/SacredWoobie/woobies-missi
 
 Woobie's Mission Control is a local browser dashboard and mission-planning
 workspace for Kerbal Space Program 1. It uses kRPC for live game data and serves
-the dashboard from your own computer at `http://127.0.0.1:8090/`. An optional
-ESP32 bridge provides physical stage and abort controls.
+the dashboard from your own computer at `http://127.0.0.1:8090/`. Opt-in
+trusted-LAN access can add a second listener on a selected private IPv4 address.
+An optional ESP32 bridge provides physical stage and abort controls.
 
 Version 0.7.4 corrects the shared vector and textured Flight navball roll
 direction, adds an orange north-reference line to the vector navball, and
@@ -206,12 +207,24 @@ The accepted local endpoints are:
 | kRPC stream port | `50001` |
 | Mission Control dashboard | `http://127.0.0.1:8090/` |
 
-The launcher's "Allow local network access" toggle (off by default) lets the
-dashboard feed serve other devices on your own network instead of only this
-computer. When enabled, it auto-detects this machine's private LAN address
-(e.g. `192.168.x.x`, `10.x.x.x`) and binds only there -- it never binds to a
-public-facing address, and every connection is independently checked against
-the same private-address ranges before being accepted.
+The launcher's **Allow local network access** toggle is off by default. It keeps
+the local listener at `127.0.0.1:8090` and can add a second listener on an active
+RFC1918 IPv4 address selected from the launcher's address picker. The routed
+default is preselected when available; **Refresh** updates the active choices,
+and **Copy LAN URL** copies the address to share with a trusted device. Changing
+enablement or the selected address stops a running feed, so click **Start** again
+to apply the displayed configuration.
+
+Enabling LAN access requires confirmation that the listener has no
+authentication or encryption. Trusted peers can view telemetry, finances,
+contracts, Notes, and vessel information and can issue every dashboard command,
+including vessel recovery or termination, system controls, and maneuver-node
+creation. The warning appears on every off-to-on transition unless the user
+explicitly checks **Remember that I understand this warning**. Mission Control
+rejects loopback, wildcard, public, stale, and unavailable LAN selections. It
+does not create firewall rules; if Windows prompts, allow Python/Mission Control
+on **Private networks only**, never Public networks. VPN and multi-adapter hosts
+should verify the selected interface before starting the feed.
 
 See [`QUICKSTART.txt`](QUICKSTART.txt) for the compact offline walkthrough. The
 [project wiki](https://github.com/SacredWoobie/woobies-mission-control/wiki)
@@ -237,9 +250,11 @@ contains the full setup, planning, compatibility, and troubleshooting guides.
   creates exactly one node.
 - Planner records are stored in a shared local Mission Control file so multiple
   dashboard tabs and scenes see the same saved plans.
-- The WebSocket feed has no authentication. Keep it on `127.0.0.1` unless you
-  deliberately enable "Allow local network access", and only do so on a
-  network you trust.
+- Trusted-LAN dashboard access has no authentication or encryption and grants
+  peers the same data and command access as the local dashboard. Keep it off
+  unless every device on the selected Private network is trusted; never expose
+  port `8090` through a router, VPN route, public firewall profile, or the
+  internet.
 - The optional ESP32 bridge can stage or abort a vessel. Test its arm/safe
   behavior on a disposable craft first.
 - Logs can contain local paths; review them before posting them publicly.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ The accepted local endpoints are:
 | kRPC stream port | `50001` |
 | Mission Control dashboard | `http://127.0.0.1:8090/` |
 
+The launcher's "Allow local network access" toggle (off by default) lets the
+dashboard feed serve other devices on your own network instead of only this
+computer. When enabled, it auto-detects this machine's private LAN address
+(e.g. `192.168.x.x`, `10.x.x.x`) and binds only there -- it never binds to a
+public-facing address, and every connection is independently checked against
+the same private-address ranges before being accepted.
+
 See [`QUICKSTART.txt`](QUICKSTART.txt) for the compact offline walkthrough. The
 [project wiki](https://github.com/SacredWoobie/woobies-mission-control/wiki)
 contains the full setup, planning, compatibility, and troubleshooting guides.
@@ -230,7 +237,9 @@ contains the full setup, planning, compatibility, and troubleshooting guides.
   creates exactly one node.
 - Planner records are stored in a shared local Mission Control file so multiple
   dashboard tabs and scenes see the same saved plans.
-- The WebSocket feed has no authentication. Keep it on `127.0.0.1`.
+- The WebSocket feed has no authentication. Keep it on `127.0.0.1` unless you
+  deliberately enable "Allow local network access", and only do so on a
+  network you trust.
 - The optional ESP32 bridge can stage or abort a vessel. Test its arm/safe
   behavior on a disposable craft first.
 - Logs can contain local paths; review them before posting them publicly.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -56,7 +56,10 @@ populated scenes; `--drop-every 4` exercises reconnect behavior. Use
 
 To test the compiled production dashboard instead of Vite, double-click
 `tools\Mock Mission Control.bat`. That controller serves both the dashboard and
-the same populated telemetry on the production loopback port `8090`.
+the same populated telemetry on the production loopback port `8090`. The
+production client derives its WebSocket endpoint from the page origin, so a
+dashboard loaded through an enabled trusted-LAN URL connects back to that same
+LAN address while the launcher's local browser continues to use loopback.
 
 ## Verification and production build
 

--- a/frontend/src/App.production.test.tsx
+++ b/frontend/src/App.production.test.tsx
@@ -6,14 +6,28 @@ import { App } from "./App.production";
 import { liveTelemetryStore } from "./telemetry/store";
 
 
+const originalLocation = window.location;
+
+function stubLocation(url: string) {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: new URL(url),
+  });
+}
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
 });
 
 
 describe("Production dashboard entry", () => {
   it("connects directly to loopback without exposing developer controls", () => {
+    stubLocation("http://127.0.0.1:8090/");
     const connect = vi.spyOn(liveTelemetryStore, "connect").mockImplementation(() => undefined);
     const disconnect = vi.spyOn(liveTelemetryStore, "disconnect").mockImplementation(() => undefined);
 
@@ -34,5 +48,17 @@ describe("Production dashboard entry", () => {
 
     view.unmount();
     expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("connects back to the LAN address that actually served the page", () => {
+    stubLocation("http://192.168.1.201:8090/");
+    const connect = vi.spyOn(liveTelemetryStore, "connect").mockImplementation(() => undefined);
+    vi.spyOn(liveTelemetryStore, "disconnect").mockImplementation(() => undefined);
+
+    const view = render(<App />);
+
+    expect(connect).toHaveBeenCalledWith("ws://192.168.1.201:8090");
+
+    view.unmount();
   });
 });

--- a/frontend/src/App.production.tsx
+++ b/frontend/src/App.production.tsx
@@ -2,23 +2,24 @@ import { useEffect, useState } from "react";
 import {
   DashboardAppFrame,
   DashboardProviders,
-  DEFAULT_LIVE_ENDPOINT,
   LiveDashboard,
+  resolveLiveEndpoint,
 } from "./appShell";
 import { liveTelemetryStore } from "./telemetry/store";
 
 function ProductionDashboardApp() {
   const [notesOpen, setNotesOpen] = useState(false);
+  const [liveEndpoint] = useState(resolveLiveEndpoint);
 
   useEffect(() => {
-    liveTelemetryStore.connect(DEFAULT_LIVE_ENDPOINT);
+    liveTelemetryStore.connect(liveEndpoint);
     return () => liveTelemetryStore.disconnect();
-  }, []);
+  }, [liveEndpoint]);
 
   return (
     <DashboardAppFrame notesOpen={notesOpen}>
       <LiveDashboard
-        endpointDraft={DEFAULT_LIVE_ENDPOINT}
+        endpointDraft={liveEndpoint}
         footerLabel="Production"
         notesOpen={notesOpen}
         onCloseNotes={() => setNotesOpen(false)}

--- a/frontend/src/appShell.tsx
+++ b/frontend/src/appShell.tsx
@@ -61,6 +61,20 @@ import { TimeSystemProvider, useTimeSystem } from "./timeSystem";
 
 export const DEFAULT_LIVE_ENDPOINT = "ws://127.0.0.1:8090";
 
+/**
+ * Derive the telemetry WebSocket endpoint from the page's own origin rather
+ * than assuming loopback -- the same-origin server may be reachable from a
+ * LAN address (see Mission Control's local-network-access toggle), so the
+ * client must connect back to whatever host actually served it.
+ */
+export function resolveLiveEndpoint(
+  location: { protocol: string; host: string } = window.location,
+): string {
+  if (!location.host) return DEFAULT_LIVE_ENDPOINT;
+  const wsProtocol = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${wsProtocol}//${location.host}`;
+}
+
 const emptyTelemetry: TelemetrySnapshot = { "context.mode": "inactive" };
 const normalFlightPanels = new Set<DashboardPanelId>(["asc", "cons", "heat", "elec", "sci", "stage"]);
 

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -324,6 +324,7 @@ KRPC_SERVICE_ATTRIBUTES = (
 )
 SYSTEM_HEAT_MOD_PATH = Path("SystemHeat") / "Plugin" / "SystemHeat.dll"
 NOTES_MOD_NAME = "zer0Kerbal's Notes (Kollege Ruled)"
+NOTES_MOD_DISPLAY_NAME = "zer0Kerbal's Notes\n(Kollege Ruled)"
 NOTES_TESTED_VERSION = "0.17.0.0"
 NOTES_MOD_DIRECTORIES = ("Notes", "notes")
 KSP_PREREQUISITES = (
@@ -2930,7 +2931,7 @@ class App:
             ),
             ("__system_heat", "System Heat thermal backend"),
             ("__krpc_configuration", "kRPC server configuration"),
-            ("__notes", NOTES_MOD_NAME),
+            ("__notes", NOTES_MOD_DISPLAY_NAME),
         ]
         compatibility_labels = build_paired_status_grid(
             prerequisites,

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -4,7 +4,7 @@ The launcher discovers the optional components beside this file. A component is
 shown only when its Python script exists, so a distribution may include either
 script or both:
 
-  * telemetry_server.py -- React dashboard loopback and telemetry server
+  * telemetry_server.py -- React dashboard loopback and optional LAN server
   * panel_bridge.py     -- ESP32 serial/kRPC control bridge
 
 Each discovered component runs as an independent child process. Closing this
@@ -39,6 +39,7 @@ import tkinter as tk
 from tkinter import filedialog, font as tkfont, messagebox, scrolledtext, ttk
 
 import runtime_update
+from telemetry_runtime import detect_lan_addresses, is_private_lan_address
 
 
 HERE = Path(__file__).resolve().parent
@@ -56,6 +57,7 @@ LATEST_RELEASE_API = (
 UPDATE_CACHE_SECONDS = 24 * 60 * 60
 UPDATE_TIMEOUT_SECONDS = 4
 MAX_RELEASE_RESPONSE_BYTES = 2 * 1024 * 1024
+LAN_WARNING_ACK_VERSION = 1
 
 
 def _default_update_state_path():
@@ -126,7 +128,10 @@ COMPONENTS = (
         "name": "feed",
         "title": "Dashboard feed (telemetry)",
         "script": "telemetry_server.py",
-        "description": "Serves the React dashboard and kRPC telemetry on local loopback.",
+        "description": (
+            "Serves the React dashboard and kRPC telemetry locally, with "
+            "optional trusted-LAN access."
+        ),
         "dashboard": True,
         "requirements": "requirements-dashboard.txt",
         "dependencies": (
@@ -1983,16 +1988,34 @@ def save_update_state(state, path=UPDATE_STATE_PATH):
 
 def load_settings(path=SETTINGS_PATH):
     """Load launcher settings, returning safe defaults on any error."""
+    defaults = {
+        "ksp_root": "",
+        "lan_access_enabled": False,
+        "lan_bind_address": "",
+        "lan_warning_ack_version": 0,
+    }
     try:
         settings = json.loads(Path(path).read_text(encoding="utf-8"))
     except (OSError, ValueError, TypeError):
-        return {"ksp_root": "", "lan_access_enabled": False}
+        return defaults
     if not isinstance(settings, dict):
-        return {"ksp_root": "", "lan_access_enabled": False}
+        return defaults
     root = settings.get("ksp_root")
+    lan_bind_address = settings.get("lan_bind_address")
+    warning_version = settings.get("lan_warning_ack_version")
     return {
         "ksp_root": root.strip() if isinstance(root, str) else "",
         "lan_access_enabled": settings.get("lan_access_enabled") is True,
+        "lan_bind_address": (
+            lan_bind_address.strip() if isinstance(lan_bind_address, str) else ""
+        ),
+        "lan_warning_ack_version": (
+            warning_version
+            if isinstance(warning_version, int)
+            and not isinstance(warning_version, bool)
+            and warning_version >= 0
+            else 0
+        ),
     }
 
 
@@ -2021,12 +2044,20 @@ def resolve_ksp_root(value):
     return None
 
 
-def telemetry_environment(ksp_root_value, lan_access_enabled=False):
+def telemetry_environment(
+    ksp_root_value,
+    lan_access_enabled=False,
+    lan_bind_address="",
+):
     """Return the child-process environment override for telemetry."""
     root = resolve_ksp_root(ksp_root_value)
     environment = {"WOOBIE_KSP_ROOT": str(root)} if root is not None else {}
-    if lan_access_enabled:
-        environment["WOOBIE_ALLOW_LAN"] = "1"
+    selected_address = str(lan_bind_address or "").strip()
+    valid_address = is_private_lan_address(selected_address)
+    environment["WOOBIE_ALLOW_LAN"] = (
+        "1" if lan_access_enabled and valid_address else "0"
+    )
+    environment["WOOBIE_LAN_BIND"] = selected_address if valid_address else ""
     return environment
 
 
@@ -2058,6 +2089,9 @@ def component_preflight(
     dashboard_port_available=local_tcp_port_available,
     version_reader=read_windows_file_version,
     hash_reader=sha256_file,
+    lan_access_enabled=False,
+    lan_bind_address="",
+    lan_address_provider=detect_lan_addresses,
 ):
     """Return actionable errors and warnings before a kRPC component starts."""
     if isinstance(ksp_root_value, os.PathLike):
@@ -2195,6 +2229,27 @@ def component_preflight(
                 f"Dashboard telemetry port {DASHBOARD_FEED_PORT} is already in "
                 "use. Stop the other dashboard feed or program using that port, "
                 "then try again."
+            )
+    if component_name == "feed" and lan_access_enabled:
+        selected_address = str(lan_bind_address or "").strip()
+        try:
+            active_addresses = tuple(lan_address_provider())
+        except OSError:
+            active_addresses = ()
+        if (
+            not is_private_lan_address(selected_address)
+            or selected_address not in active_addresses
+        ):
+            errors.append(
+                "The selected LAN address is no longer active or is not an "
+                "RFC1918 private IPv4 address. Refresh the address list and "
+                "choose an active address."
+            )
+        elif not dashboard_port_available(DASHBOARD_FEED_PORT, selected_address):
+            errors.append(
+                f"Dashboard telemetry port {DASHBOARD_FEED_PORT} cannot be bound "
+                f"on LAN address {selected_address}. Stop the program using that "
+                "endpoint or choose another active address."
             )
     return {
         "errors": errors,
@@ -2499,9 +2554,17 @@ class App:
         self.update_download_root = Path(update_download_root)
         self.settings_path = Path(settings_path)
         self.settings = load_settings(self.settings_path)
+        self.lan_addresses = detect_lan_addresses()
+        saved_lan_address = self.settings.get("lan_bind_address", "")
+        selected_lan_address = (
+            saved_lan_address
+            if saved_lan_address
+            else (self.lan_addresses[0] if self.lan_addresses else "")
+        )
         self.lan_access_var = tk.BooleanVar(
             value=self.settings.get("lan_access_enabled", False)
         )
+        self.lan_address_var = tk.StringVar(value=selected_lan_address)
         self.update_generation = 0
         self.update_checking = False
         self.update_staging = False
@@ -3016,18 +3079,53 @@ class App:
                 self._toggle_lan_access,
             )
             self.lan_access_control.pack(side="left")
+            address_row = ttk.Frame(frame)
+            address_row.pack(fill="x", padx=9, pady=(2, 4))
+            ttk.Label(address_row, text="LAN address:").pack(side="left")
+            self.lan_address_combo = ttk.Combobox(
+                address_row,
+                textvariable=self.lan_address_var,
+                values=self.lan_addresses,
+                state="readonly",
+                width=18,
+            )
+            self.lan_address_combo.pack(side="left", padx=(7, 5))
+            self.lan_address_combo.bind(
+                "<<ComboboxSelected>>", self._select_lan_address
+            )
+            ttk.Button(
+                address_row,
+                text="Refresh",
+                command=self._refresh_lan_addresses,
+            ).pack(side="left", padx=3)
+            self.copy_lan_url_button = ttk.Button(
+                address_row,
+                text="Copy LAN URL",
+                command=self._copy_lan_url,
+            )
+            self.copy_lan_url_button.pack(side="left", padx=3)
+            self.lan_address_status = ttk.Label(
+                frame,
+                text="",
+                foreground=THEME["slate_dim"],
+                anchor="w",
+                justify="left",
+            )
+            self.lan_address_status.pack(fill="x", padx=9, pady=(0, 4))
             ttk.Label(
                 frame,
                 text=(
-                    "Serves the dashboard to other devices on your local "
-                    "network instead of just this computer. Only enable on "
-                    "networks you trust -- the feed has no authentication."
+                    "Adds a command-capable listener for trusted devices while "
+                    "keeping this computer on 127.0.0.1. LAN access has no "
+                    "authentication or encryption; Windows firewall access must "
+                    "be limited to Private networks."
                 ),
                 foreground=THEME["slate_dim"],
                 anchor="w",
                 justify="left",
                 wraplength=670,
             ).pack(fill="x", padx=9, pady=(0, 8))
+            self._update_lan_address_status()
 
         self.backends.append(backend)
         self.backend_rows.append(
@@ -3124,7 +3222,9 @@ class App:
 
     def _telemetry_environment(self):
         return telemetry_environment(
-            self.ksp_root_var.get(), self.lan_access_var.get()
+            self.ksp_root_var.get(),
+            self.lan_access_var.get(),
+            self.lan_address_var.get(),
         )
 
     def _refresh_ksp_root_status(self):
@@ -4261,15 +4361,8 @@ class App:
             foreground=THEME["slate_dim"],
         )
 
-    def _toggle_lan_access(self):
-        enabled = self.lan_access_var.get()
-        self.settings["lan_access_enabled"] = enabled
-        try:
-            save_settings(self.settings, self.settings_path)
-        except OSError as exc:
-            self._enqueue("feed", f"couldn't save network setting: {exc}")
-            return
-        feed_backend = next(
+    def _feed_backend(self):
+        return next(
             (
                 row["backend"]
                 for row in self.backend_rows
@@ -4277,12 +4370,252 @@ class App:
             ),
             None,
         )
+
+    def _stop_feed_for_network_change(self):
+        feed_backend = self._feed_backend()
         if feed_backend is not None and feed_backend.running():
+            feed_backend.stop()
             self._enqueue(
                 "feed",
-                "Local network access setting changed; restart Dashboard feed "
-                "to apply.",
+                "Network access configuration changed; Dashboard feed stopped. "
+                "Click Start to apply the new listeners.",
             )
+
+    def _show_lan_access_warning(self):
+        result = {"confirmed": False, "remember": False}
+        dialog = tk.Toplevel(self.root)
+        dialog.title("Enable trusted-LAN dashboard access?")
+        dialog.transient(self.root)
+        dialog.resizable(False, False)
+        dialog.configure(background=THEME["bg"])
+
+        body = ttk.Frame(dialog, padding=(20, 18))
+        body.pack(fill="both", expand=True)
+        ttk.Label(
+            body,
+            text="ENABLE TRUSTED-LAN DASHBOARD ACCESS?",
+            style="DialogTitle.TLabel",
+            anchor="w",
+        ).pack(fill="x")
+        ttk.Label(
+            body,
+            text=(
+                "This opens Mission Control to trusted devices on your local "
+                "network. There is no authentication and traffic is not encrypted."
+            ),
+            style="DialogBody.TLabel",
+            wraplength=610,
+            justify="left",
+        ).pack(fill="x", pady=(10, 8))
+        ttk.Label(
+            body,
+            text=(
+                "Trusted peers can view telemetry, finances, contracts, notes, "
+                "and vessel information. They can also issue every dashboard "
+                "command, including vessel recovery or termination, system "
+                "controls, and maneuver-node creation."
+            ),
+            foreground=THEME["warn"],
+            style="Shell.TLabel",
+            wraplength=610,
+            justify="left",
+        ).pack(fill="x", pady=(0, 10))
+        ttk.Label(
+            body,
+            text=(
+                "Only continue on a network you trust. If Windows asks, allow "
+                "access on Private networks only; Mission Control does not create "
+                "or change firewall rules."
+            ),
+            style="DialogBody.TLabel",
+            wraplength=610,
+            justify="left",
+        ).pack(fill="x", pady=(0, 12))
+
+        remember_var = tk.BooleanVar(value=False)
+        remember_control = CheckXControl(
+            body,
+            remember_var,
+            "Remember that I understand this warning",
+            lambda: None,
+        )
+        remember_control.pack(anchor="w", pady=(0, 14))
+
+        def close(confirmed=False):
+            result["confirmed"] = confirmed
+            result["remember"] = bool(confirmed and remember_var.get())
+            dialog.destroy()
+
+        footer = ttk.Frame(body)
+        footer.pack(fill="x")
+        cancel_button = ttk.Button(
+            footer, text="Cancel", width=10, command=lambda: close(False)
+        )
+        cancel_button.pack(side="right")
+        confirm_button = ttk.Button(
+            footer,
+            text="Enable LAN access",
+            command=lambda: close(True),
+        )
+        confirm_button.pack(side="right", padx=(0, 8))
+
+        dialog.protocol("WM_DELETE_WINDOW", lambda: close(False))
+        dialog.bind("<Escape>", lambda _event: close(False))
+        confirm_button.bind("<Return>", lambda _event: close(True))
+        cancel_button.bind("<Return>", lambda _event: close(False))
+        dialog.update_idletasks()
+        x = self.root.winfo_rootx() + max(
+            0, (self.root.winfo_width() - dialog.winfo_width()) // 2
+        )
+        y = self.root.winfo_rooty() + max(
+            0, (self.root.winfo_height() - dialog.winfo_height()) // 2
+        )
+        dialog.geometry(f"+{x}+{y}")
+        dialog.grab_set()
+        dialog.lift()
+        confirm_button.focus_set()
+        self.root.wait_window(dialog)
+        return result["confirmed"], result["remember"]
+
+    def _toggle_lan_access(self):
+        enabled = bool(self.lan_access_var.get())
+        was_enabled = self.settings.get("lan_access_enabled") is True
+        if enabled == was_enabled:
+            return
+
+        selected_address = self.lan_address_var.get().strip()
+        if enabled and (
+            not is_private_lan_address(selected_address)
+            or selected_address not in self.lan_addresses
+        ):
+            self.lan_access_var.set(False)
+            messagebox.showerror(
+                "Choose an active LAN address",
+                "Refresh the address list and choose an active RFC1918 private "
+                "IPv4 address before enabling LAN access.",
+                parent=self.root,
+            )
+            self._update_lan_address_status()
+            return
+
+        remember = False
+        if (
+            enabled
+            and self.settings.get("lan_warning_ack_version", 0)
+            != LAN_WARNING_ACK_VERSION
+        ):
+            confirmed, remember = self._show_lan_access_warning()
+            if not confirmed:
+                self.lan_access_var.set(False)
+                return
+
+        candidate = dict(self.settings)
+        candidate["lan_access_enabled"] = enabled
+        candidate["lan_bind_address"] = selected_address
+        if enabled and remember:
+            candidate["lan_warning_ack_version"] = LAN_WARNING_ACK_VERSION
+
+        if not enabled:
+            self._stop_feed_for_network_change()
+        try:
+            save_settings(candidate, self.settings_path)
+        except OSError as exc:
+            self._enqueue("feed", f"couldn't save network setting: {exc}")
+            self.lan_access_var.set(was_enabled)
+            messagebox.showerror(
+                "Could not save LAN setting",
+                "LAN access was not changed because the launcher could not save "
+                f"your settings.\n\n{exc}",
+                parent=self.root,
+            )
+            return
+        self.settings = candidate
+        if enabled:
+            self._stop_feed_for_network_change()
+        self._update_lan_address_status()
+
+    def _select_lan_address(self, _event=None):
+        selected_address = self.lan_address_var.get().strip()
+        previous_address = self.settings.get("lan_bind_address", "")
+        if selected_address == previous_address:
+            self._update_lan_address_status()
+            return
+        if (
+            not is_private_lan_address(selected_address)
+            or selected_address not in self.lan_addresses
+        ):
+            self.lan_address_var.set(previous_address)
+            self._update_lan_address_status()
+            return
+
+        self._stop_feed_for_network_change()
+        candidate = dict(self.settings)
+        candidate["lan_bind_address"] = selected_address
+        try:
+            save_settings(candidate, self.settings_path)
+        except OSError as exc:
+            self.lan_address_var.set(previous_address)
+            self._enqueue("feed", f"couldn't save LAN address: {exc}")
+            messagebox.showerror(
+                "Could not save LAN address",
+                f"The selected address was not saved.\n\n{exc}",
+                parent=self.root,
+            )
+        else:
+            self.settings = candidate
+        self._update_lan_address_status()
+
+    def _refresh_lan_addresses(self):
+        self.lan_addresses = detect_lan_addresses()
+        self.lan_address_combo.configure(values=self.lan_addresses)
+        if not self.lan_address_var.get().strip() and self.lan_addresses:
+            self.lan_address_var.set(self.lan_addresses[0])
+        self._update_lan_address_status()
+
+    def _update_lan_address_status(self):
+        selected_address = self.lan_address_var.get().strip()
+        active = (
+            is_private_lan_address(selected_address)
+            and selected_address in self.lan_addresses
+        )
+        if active:
+            text = f"LAN URL: http://{selected_address}:{DASHBOARD_FEED_PORT}/"
+            color = THEME["green"] if self.lan_access_var.get() else THEME["slate_dim"]
+        elif selected_address:
+            text = (
+                "Selected address is unavailable. Refresh and choose an active address."
+            )
+            color = THEME["warn"]
+        else:
+            text = "No active RFC1918 private IPv4 address was found."
+            color = THEME["warn"]
+        self.lan_address_status.config(text=text, foreground=color)
+        self.copy_lan_url_button.config(state="normal" if active else "disabled")
+
+    def _copy_lan_url(self):
+        selected_address = self.lan_address_var.get().strip()
+        if (
+            not is_private_lan_address(selected_address)
+            or selected_address not in self.lan_addresses
+        ):
+            messagebox.showerror(
+                "LAN address unavailable",
+                "Refresh the address list and choose an active private IPv4 address.",
+                parent=self.root,
+            )
+            return
+        url = f"http://{selected_address}:{DASHBOARD_FEED_PORT}/"
+        try:
+            self.root.clipboard_clear()
+            self.root.clipboard_append(url)
+            self.root.update_idletasks()
+        except tk.TclError as exc:
+            self._enqueue("feed", f"couldn't copy LAN URL: {exc}")
+            messagebox.showerror(
+                "Could not copy LAN URL", str(exc), parent=self.root
+            )
+            return
+        self._enqueue("feed", f"copied trusted-LAN dashboard URL: {url}")
 
     def _save_update_state(self):
         try:
@@ -4459,8 +4792,14 @@ class App:
             backend.stop()
             return
 
+        preflight_options = {}
+        if backend.name == "feed":
+            preflight_options = {
+                "lan_access_enabled": self.lan_access_var.get(),
+                "lan_bind_address": self.lan_address_var.get(),
+            }
         preflight = component_preflight(
-            self.ksp_root_var.get(), backend.name
+            self.ksp_root_var.get(), backend.name, **preflight_options
         )
         for warning in preflight["warnings"]:
             self._enqueue("preflight", warning)

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -1986,11 +1986,14 @@ def load_settings(path=SETTINGS_PATH):
     try:
         settings = json.loads(Path(path).read_text(encoding="utf-8"))
     except (OSError, ValueError, TypeError):
-        return {"ksp_root": ""}
+        return {"ksp_root": "", "lan_access_enabled": False}
     if not isinstance(settings, dict):
-        return {"ksp_root": ""}
+        return {"ksp_root": "", "lan_access_enabled": False}
     root = settings.get("ksp_root")
-    return {"ksp_root": root.strip() if isinstance(root, str) else ""}
+    return {
+        "ksp_root": root.strip() if isinstance(root, str) else "",
+        "lan_access_enabled": settings.get("lan_access_enabled") is True,
+    }
 
 
 def save_settings(settings, path=SETTINGS_PATH):
@@ -2018,10 +2021,13 @@ def resolve_ksp_root(value):
     return None
 
 
-def telemetry_environment(ksp_root_value):
+def telemetry_environment(ksp_root_value, lan_access_enabled=False):
     """Return the child-process environment override for telemetry."""
     root = resolve_ksp_root(ksp_root_value)
-    return {"WOOBIE_KSP_ROOT": str(root)} if root is not None else {}
+    environment = {"WOOBIE_KSP_ROOT": str(root)} if root is not None else {}
+    if lan_access_enabled:
+        environment["WOOBIE_ALLOW_LAN"] = "1"
+    return environment
 
 
 def tcp_port_open(address, port, timeout=0.15):
@@ -2493,6 +2499,9 @@ class App:
         self.update_download_root = Path(update_download_root)
         self.settings_path = Path(settings_path)
         self.settings = load_settings(self.settings_path)
+        self.lan_access_var = tk.BooleanVar(
+            value=self.settings.get("lan_access_enabled", False)
+        )
         self.update_generation = 0
         self.update_checking = False
         self.update_staging = False
@@ -2997,6 +3006,29 @@ class App:
             justify="left",
         ).pack(fill="x", padx=9, pady=(0, 8))
 
+        if component["name"] == "feed":
+            lan_row = ttk.Frame(frame)
+            lan_row.pack(fill="x", padx=8, pady=(0, 4))
+            self.lan_access_control = CheckXControl(
+                lan_row,
+                self.lan_access_var,
+                "ALLOW LOCAL NETWORK ACCESS",
+                self._toggle_lan_access,
+            )
+            self.lan_access_control.pack(side="left")
+            ttk.Label(
+                frame,
+                text=(
+                    "Serves the dashboard to other devices on your local "
+                    "network instead of just this computer. Only enable on "
+                    "networks you trust -- the feed has no authentication."
+                ),
+                foreground=THEME["slate_dim"],
+                anchor="w",
+                justify="left",
+                wraplength=670,
+            ).pack(fill="x", padx=9, pady=(0, 8))
+
         self.backends.append(backend)
         self.backend_rows.append(
             {
@@ -3091,7 +3123,9 @@ class App:
         self.root.after(100, self._drain_component_setup_queue)
 
     def _telemetry_environment(self):
-        return telemetry_environment(self.ksp_root_var.get())
+        return telemetry_environment(
+            self.ksp_root_var.get(), self.lan_access_var.get()
+        )
 
     def _refresh_ksp_root_status(self):
         raw = self.ksp_root_var.get().strip()
@@ -4226,6 +4260,29 @@ class App:
             text="Automatic update checks are off",
             foreground=THEME["slate_dim"],
         )
+
+    def _toggle_lan_access(self):
+        enabled = self.lan_access_var.get()
+        self.settings["lan_access_enabled"] = enabled
+        try:
+            save_settings(self.settings, self.settings_path)
+        except OSError as exc:
+            self._enqueue("feed", f"couldn't save network setting: {exc}")
+            return
+        feed_backend = next(
+            (
+                row["backend"]
+                for row in self.backend_rows
+                if row["component"]["name"] == "feed"
+            ),
+            None,
+        )
+        if feed_backend is not None and feed_backend.running():
+            self._enqueue(
+                "feed",
+                "Local network access setting changed; restart Dashboard feed "
+                "to apply.",
+            )
 
     def _save_update_state(self):
         try:

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -415,8 +415,8 @@ def calculate_initial_window_size(
     """Return a roomy launcher size clamped for the current display."""
     available_width = max(640, int(screen_width) - 80)
     available_height = max(520, int(screen_height) - 120)
-    desired_width = max(960, int(requested_width) + 24)
-    desired_height = max(820, int(requested_height) + 12)
+    desired_width = max(1360, int(requested_width) + 24)
+    desired_height = max(860, int(requested_height) + 12)
     return min(desired_width, available_width), min(
         desired_height, available_height
     )
@@ -424,9 +424,9 @@ def calculate_initial_window_size(
 
 def calculate_initial_pane_sash(
     available_height,
-    controls_share=0.74,
-    minimum_controls=240,
-    minimum_log=120,
+    controls_share=0.72,
+    minimum_controls=260,
+    minimum_log=150,
 ):
     """Return the initial controls/log divider position for the launcher."""
     available_height = max(0, int(available_height))
@@ -495,6 +495,12 @@ def configure_dashboard_theme(root):
         background=THEME["panel_2"],
         foreground=THEME["cyan"],
         font=UI_FONT_BOLD,
+    )
+    style.configure(
+        "TableHeader.TLabel",
+        background=THEME["panel_2"],
+        foreground=THEME["slate_dim"],
+        font=(UI_FONT_FAMILY, 8, "bold"),
     )
     style.configure(
         "DialogTitle.TLabel",
@@ -2531,6 +2537,128 @@ class ScrollableLauncherPane(ttk.Frame):
         return True
 
 
+class ResponsiveLauncherWorkbench(ttk.Frame):
+    """Arrange launcher cards in two columns and collapse safely when narrow."""
+
+    def __init__(self, parent, breakpoint=1120, left_width=390):
+        super().__init__(parent, style="Shell.TFrame")
+        self.breakpoint = int(breakpoint)
+        self.left_width = int(left_width)
+        self.left = ttk.Frame(self, style="Shell.TFrame")
+        self.right = ttk.Frame(self, style="Shell.TFrame")
+        self._wide = None
+        self.bind("<Configure>", self._apply_layout)
+        self.after_idle(self._apply_layout)
+
+    def _apply_layout(self, event=None):
+        width = int(getattr(event, "width", 0) or self.winfo_width())
+        wide = width >= self.breakpoint
+        if self._wide is wide:
+            return
+        self._wide = wide
+        self.left.grid_forget()
+        self.right.grid_forget()
+        if wide:
+            self.columnconfigure(0, weight=0, minsize=self.left_width)
+            self.columnconfigure(1, weight=1, minsize=0)
+            self.left.grid(row=0, column=0, sticky="nsew", padx=(0, 6))
+            self.right.grid(row=0, column=1, sticky="nsew", padx=(6, 0))
+        else:
+            self.columnconfigure(0, weight=1, minsize=0)
+            self.columnconfigure(1, weight=0, minsize=0)
+            self.left.grid(row=0, column=0, sticky="nsew")
+            self.right.grid(row=1, column=0, sticky="nsew", pady=(6, 0))
+
+
+def build_paired_status_grid(parent, entries):
+    """Build a two-across status table and return its value labels by key."""
+    header = ttk.Frame(parent, style="CardInner.TFrame")
+    header.pack(fill="x", pady=(0, 4))
+    for column in range(2):
+        pair_header = ttk.Frame(header, style="CardInner.TFrame")
+        pair_header.grid(
+            row=0,
+            column=column,
+            sticky="ew",
+            padx=(0, 10) if column == 0 else (10, 0),
+        )
+        pair_header.columnconfigure(0, weight=1)
+        ttk.Label(
+            pair_header,
+            text="COMPONENT",
+            style="TableHeader.TLabel",
+        ).grid(row=0, column=0, sticky="w")
+        ttk.Label(
+            pair_header,
+            text="DETECTED",
+            style="TableHeader.TLabel",
+        ).grid(row=0, column=1, sticky="e")
+        header.columnconfigure(column, weight=1, uniform="status_header")
+
+    body = ttk.Frame(parent, style="CardInner.TFrame")
+    body.pack(fill="x")
+    body.columnconfigure(0, weight=1, uniform="status_body")
+    body.columnconfigure(1, weight=1, uniform="status_body")
+    labels = {}
+    for index, (key, title) in enumerate(entries):
+        row, column = divmod(index, 2)
+        pair = ttk.Frame(body, style="CardInner.TFrame")
+        pair.grid(
+            row=row,
+            column=column,
+            sticky="ew",
+            padx=(0, 10) if column == 0 else (10, 0),
+            pady=2,
+        )
+        pair.columnconfigure(0, weight=1)
+        ttk.Label(
+            pair,
+            text=title,
+            anchor="w",
+            style="Card.TLabel",
+        ).grid(row=0, column=0, sticky="w")
+        status = ttk.Label(
+            pair,
+            text="Checking...",
+            anchor="e",
+            style="Card.TLabel",
+        )
+        status.grid(row=0, column=1, sticky="e", padx=(8, 0))
+        labels[key] = status
+    return labels
+
+
+LOG_WARNING_TERMS = (
+    " warning",
+    " error",
+    " failed",
+    " refused",
+    " timed out",
+    " exhausted",
+    " already in use",
+    " couldn't",
+    " denied",
+    " unavailable",
+    " missing",
+)
+
+
+def is_launcher_log_warning(source, message):
+    """Return whether a structured launcher log record merits warning focus."""
+    text = f" {source} {message}".casefold()
+    return any(term in text for term in LOG_WARNING_TERMS)
+
+
+def filter_launcher_log_records(records, selected_filter):
+    """Return structured log records visible for the selected log filter."""
+    selected_filter = str(selected_filter or "all").casefold()
+    if selected_filter == "all":
+        return list(records)
+    if selected_filter == "warnings":
+        return [record for record in records if record[2]]
+    return [record for record in records if record[0].casefold() == selected_filter]
+
+
 class App:
     def __init__(
         self,
@@ -2543,6 +2671,11 @@ class App:
     ):
         self.root = root
         self.log_queue = queue.Queue()
+        self.log_records = []
+        self.log_filter_var = tk.StringVar(root, value="all")
+        self.log_follow_var = tk.BooleanVar(root, value=True)
+        self.log_warning_count_var = tk.StringVar(root, value="0 warnings")
+        self.log_filter_buttons = {}
         self.update_queue = queue.Queue()
         self.krpc_test_queue = queue.Queue()
         self.component_setup_queue = queue.Queue()
@@ -2589,23 +2722,24 @@ class App:
         root.title(f"{APP_NAME} v{APP_VERSION}")
         root.protocol("WM_DELETE_WINDOW", self._on_close)
 
-        header = ttk.Frame(root, style="Shell.TFrame")
-        header.pack(fill="x", padx=14, pady=(14, 4))
+        self.header = ttk.Frame(root, style="Shell.TFrame")
+        self.header.pack(fill="x", padx=14, pady=(12, 7))
+        title_group = ttk.Frame(self.header, style="Shell.TFrame")
+        title_group.grid(row=0, column=0, sticky="w")
         ttk.Label(
-            header,
+            title_group,
             text=APP_NAME.upper(),
             anchor="w",
             style="Title.TLabel",
         ).pack(side="left")
         ttk.Label(
-            header, text=f"  //  v{APP_VERSION}", style="Version.TLabel"
+            title_group, text=f"  //  v{APP_VERSION}", style="Version.TLabel"
         ).pack(side="left")
-        ttk.Button(header, text="ABOUT", width=9, command=self._show_about).pack(
-            side="right"
-        )
 
-        update_bar = ttk.Frame(root, style="Shell.TFrame")
-        update_bar.pack(fill="x", padx=14, pady=(2, 7))
+        update_bar = ttk.Frame(self.header, style="Shell.TFrame")
+        update_bar.grid(row=0, column=1, sticky="ew", padx=(14, 0))
+        self.header.columnconfigure(1, weight=1)
+        self.header_update_bar = update_bar
         self.update_status = ttk.Label(
             update_bar,
             text="Update status: waiting",
@@ -2653,6 +2787,14 @@ class App:
             command=self._open_latest_release,
         )
         self.view_release_button.pack(side="left", padx=(4, 0))
+        self.about_button = ttk.Button(
+            update_actions,
+            text="About",
+            command=self._show_about,
+        )
+        self.about_button.pack(side="left", padx=(4, 0))
+        self.header_wide = None
+        self.header.bind("<Configure>", self._layout_header)
 
         self.main_panes = tk.PanedWindow(
             root,
@@ -2676,8 +2818,13 @@ class App:
         self.controls_root = self.controls_pane.content
         root.bind("<MouseWheel>", self._on_launcher_mousewheel, add="+")
 
+        self.workbench = ResponsiveLauncherWorkbench(self.controls_root)
+        self.workbench.pack(fill="x", padx=14, pady=6)
+        self.component_column = self.workbench.left
+        self.installation_column = self.workbench.right
+
         settings_frame = ttk.LabelFrame(
-            self.controls_root,
+            self.installation_column,
             text="KSP INSTALLATION",
         )
         settings_controls = ttk.Frame(settings_frame)
@@ -2719,6 +2866,12 @@ class App:
             anchor="w",
             style="CardTitle.TLabel",
         ).pack(side="left")
+        self.prerequisite_refresh_button = ttk.Button(
+            prerequisite_header,
+            text="Refresh all status",
+            command=self._refresh_all_ksp_status,
+        )
+        self.prerequisite_refresh_button.pack(side="right", padx=(8, 0))
         self.prerequisite_summary = ttk.Label(
             prerequisite_header,
             text="Checking...",
@@ -2728,129 +2881,38 @@ class App:
         )
         self.prerequisite_summary.pack(side="right")
 
-        ksp_version_row = ttk.Frame(prerequisites, style="CardInner.TFrame")
-        ksp_version_row.pack(fill="x", pady=2)
-        ttk.Label(
-            ksp_version_row,
-            text="Kerbal Space Program",
-            anchor="w",
-            style="Card.TLabel",
-        ).pack(side="left", fill="x", expand=True)
-        self.ksp_version_status = ttk.Label(
-            ksp_version_row,
-            text="Checking...",
-            width=32,
-            anchor="e",
-            style="Card.TLabel",
+        compatibility_entries = [
+            ("__ksp_version", "Kerbal Space Program"),
+            ("__dll_layout", "Core DLL layout"),
+            *(
+                (definition["key"], definition["title"])
+                for definition in KSP_PREREQUISITES
+            ),
+            ("__system_heat", "System Heat thermal backend"),
+            ("__krpc_configuration", "kRPC server configuration"),
+            ("__notes", "Notes mod"),
+        ]
+        compatibility_labels = build_paired_status_grid(
+            prerequisites,
+            compatibility_entries,
         )
-        self.ksp_version_status.pack(side="right")
+        self.ksp_version_status = compatibility_labels["__ksp_version"]
+        self.dll_layout_status = compatibility_labels["__dll_layout"]
+        self.prerequisite_status_labels = {
+            definition["key"]: compatibility_labels[definition["key"]]
+            for definition in KSP_PREREQUISITES
+        }
+        self.system_heat_mod_status = compatibility_labels["__system_heat"]
+        self.krpc_configuration_status = compatibility_labels[
+            "__krpc_configuration"
+        ]
+        self.notes_mod_status = compatibility_labels["__notes"]
 
-        dll_layout_row = ttk.Frame(prerequisites, style="CardInner.TFrame")
-        dll_layout_row.pack(fill="x", pady=2)
-        ttk.Label(
-            dll_layout_row,
-            text="Core DLL layout",
-            anchor="w",
-            style="Card.TLabel",
-        ).pack(side="left", fill="x", expand=True)
-        self.dll_layout_status = ttk.Label(
-            dll_layout_row,
-            text="Checking...",
-            width=32,
-            anchor="e",
-            style="Card.TLabel",
-        )
-        self.dll_layout_status.pack(side="right")
-
-        self.prerequisite_status_labels = {}
-        for definition in KSP_PREREQUISITES:
-            row = ttk.Frame(prerequisites, style="CardInner.TFrame")
-            row.pack(fill="x", pady=2)
-            ttk.Label(
-                row,
-                text=definition["title"],
-                anchor="w",
-                style="Card.TLabel",
-            ).pack(side="left", fill="x", expand=True)
-            status = ttk.Label(
-                row,
-                text="Checking...",
-                width=32,
-                anchor="e",
-                style="Card.TLabel",
-            )
-            status.pack(side="right")
-            self.prerequisite_status_labels[definition["key"]] = status
-
-        system_heat_row = ttk.Frame(prerequisites, style="CardInner.TFrame")
-        system_heat_row.pack(fill="x", pady=2)
-        ttk.Label(
-            system_heat_row,
-            text="System Heat thermal backend",
-            anchor="w",
-            style="Card.TLabel",
-        ).pack(side="left", fill="x", expand=True)
-        self.system_heat_mod_status = ttk.Label(
-            system_heat_row,
-            text="Checking...",
-            width=32,
-            anchor="e",
-            style="Card.TLabel",
-        )
-        self.system_heat_mod_status.pack(side="right")
-
-        server_row = ttk.Frame(prerequisites, style="CardInner.TFrame")
-        server_row.pack(fill="x", pady=2)
-        ttk.Label(
-            server_row,
-            text="kRPC server configuration",
-            anchor="w",
-            style="Card.TLabel",
-        ).pack(side="left", fill="x", expand=True)
-        self.krpc_configuration_status = ttk.Label(
-            server_row,
-            text="Checking...",
-            width=32,
-            anchor="e",
-            style="Card.TLabel",
-        )
-        self.krpc_configuration_status.pack(side="right")
-
-        connection_row = ttk.Frame(prerequisites, style="CardInner.TFrame")
-        connection_row.pack(fill="x", pady=2)
-        ttk.Label(
-            connection_row,
-            text="Live kRPC connection",
-            anchor="w",
-            style="Card.TLabel",
-        ).pack(side="left", fill="x", expand=True)
-        self.krpc_test_button = ttk.Button(
-            connection_row,
-            text="Test connection",
-            command=self._start_krpc_connection_test,
-        )
-        self.krpc_test_button.pack(side="right", padx=(7, 0))
-        self.krpc_connection_status = ttk.Label(
-            connection_row,
-            text="Not tested",
-            width=32,
-            anchor="e",
-            style="Card.TLabel",
-        )
-        self.krpc_connection_status.pack(side="right")
-
-        prerequisite_buttons = ttk.Frame(
+        self.prerequisite_buttons = ttk.Frame(
             prerequisites, style="CardInner.TFrame"
         )
-        prerequisite_buttons.pack(fill="x", pady=(10, 0))
-        self.prerequisite_refresh_button = ttk.Button(
-            prerequisite_buttons,
-            text="Refresh all status",
-            command=self._refresh_all_ksp_status,
-        )
-        self.prerequisite_refresh_button.pack(side="left")
         self.prerequisite_fix_button = ttk.Button(
-            prerequisite_buttons,
+            self.prerequisite_buttons,
             text="Review fixes",
             command=self._show_prerequisite_fixes,
             style="Accent.TButton",
@@ -2868,6 +2930,12 @@ class App:
             anchor="w",
             style="CardTitle.TLabel",
         ).pack(side="left")
+        self.service_refresh_button = ttk.Button(
+            services_header,
+            text="Refresh all status",
+            command=self._refresh_all_ksp_status,
+        )
+        self.service_refresh_button.pack(side="right", padx=(8, 0))
         self.service_summary = ttk.Label(
             services_header,
             text="Checking...",
@@ -2877,22 +2945,10 @@ class App:
         )
         self.service_summary.pack(side="right")
 
-        self.service_status_labels = {}
-        for folder, title in SERVICE_DLLS:
-            row = ttk.Frame(services, style="CardInner.TFrame")
-            row.pack(fill="x", pady=2)
-            ttk.Label(row, text=title, anchor="w", style="Card.TLabel").pack(
-                side="left", fill="x", expand=True
-            )
-            status = ttk.Label(
-                row,
-                text="Checking...",
-                width=44,
-                anchor="e",
-                style="Card.TLabel",
-            )
-            status.pack(side="right")
-            self.service_status_labels[folder] = status
+        self.service_status_labels = build_paired_status_grid(
+            services,
+            [(folder, title) for folder, title in SERVICE_DLLS],
+        )
 
         service_buttons = ttk.Frame(services, style="CardInner.TFrame")
         service_buttons.pack(fill="x", pady=(10, 0))
@@ -2904,11 +2960,6 @@ class App:
             style="Accent.TButton",
         )
         self.install_services_button.pack(side="left")
-        ttk.Button(
-            service_buttons,
-            text="Refresh all status",
-            command=self._refresh_all_ksp_status,
-        ).pack(side="left", padx=(6, 0))
         self.open_gamedata_button = ttk.Button(
             service_buttons,
             text="Open GameData",
@@ -2923,27 +2974,104 @@ class App:
             command=self._open_packaged_dlls,
         )
         self.open_packaged_dlls_button.pack(side="right", padx=(0, 6))
-        self._refresh_ksp_root_status()
 
         components = discover_components()
         if components:
             for component in components:
                 self._add_component(component)
         else:
-            empty = ttk.LabelFrame(self.controls_root, text="COMPONENTS")
-            empty.pack(fill="x", padx=14, pady=6)
+            empty = ttk.LabelFrame(self.component_column, text="COMPONENTS")
+            empty.pack(fill="x", pady=(0, 6))
             ttk.Label(
                 empty,
                 text="No supported Python components were found beside this launcher.",
                 anchor="w",
             ).pack(fill="x", padx=10, pady=12)
 
-        settings_frame.pack(fill="x", padx=14, pady=6)
+        live_krpc = ttk.LabelFrame(
+            self.component_column,
+            text="LIVE KRPC CONNECTION",
+        )
+        live_krpc.pack(fill="x", pady=(6, 0))
+        live_controls = ttk.Frame(live_krpc)
+        live_controls.pack(fill="x", padx=8, pady=(8, 4))
+        self.krpc_test_button = ttk.Button(
+            live_controls,
+            text="Test connection",
+            command=self._start_krpc_connection_test,
+        )
+        self.krpc_test_button.pack(side="left")
+        self.krpc_connection_status = ttk.Label(
+            live_controls,
+            text="Not tested",
+            anchor="e",
+            style="TLabel",
+        )
+        self.krpc_connection_status.pack(side="right", fill="x", expand=True)
+        ttk.Label(
+            live_krpc,
+            text=(
+                f"127.0.0.1 · RPC {KRPC_RPC_PORT} / stream {KRPC_STREAM_PORT}. "
+                "Tests the running kRPC server and expected services."
+            ),
+            foreground=THEME["slate"],
+            anchor="w",
+            justify="left",
+            wraplength=350,
+        ).pack(fill="x", padx=9, pady=(0, 8))
+
+        settings_frame.pack(fill="x")
+        self._refresh_ksp_root_status()
 
         log_shell = ttk.Frame(self.main_panes, style="Shell.TFrame")
-        log_frame = ttk.LabelFrame(log_shell, text="MISSION LOG")
+        log_frame = ttk.Frame(log_shell, style="Card.TFrame")
         log_frame.pack(fill="both", expand=True, padx=14, pady=(6, 12))
-        self.main_panes.add(log_shell, minsize=120, stretch="always")
+        log_header = ttk.Frame(log_frame, style="CardInner.TFrame")
+        log_header.pack(fill="x", padx=8, pady=(6, 3))
+        ttk.Label(
+            log_header,
+            text="MISSION LOG",
+            style="CardTitle.TLabel",
+        ).pack(side="left")
+        ttk.Label(
+            log_header,
+            textvariable=self.log_warning_count_var,
+            foreground=THEME["amber"],
+            style="Card.TLabel",
+        ).pack(side="left", padx=(8, 0))
+        ttk.Checkbutton(
+            log_header,
+            text="follow",
+            variable=self.log_follow_var,
+            command=self._render_log,
+            style="Panel.TCheckbutton",
+        ).pack(side="right", padx=(5, 0))
+        ttk.Button(
+            log_header,
+            text="Clear",
+            width=6,
+            command=self._clear_log,
+        ).pack(side="right", padx=(4, 0))
+        ttk.Button(
+            log_header,
+            text="Copy",
+            width=6,
+            command=self._copy_log,
+        ).pack(side="right", padx=(4, 0))
+        for selected_filter in ("warnings", "preflight", "feed", "all"):
+            button = ttk.Button(
+                log_header,
+                text=selected_filter.title(),
+                command=lambda value=selected_filter: self._select_log_filter(value),
+            )
+            button.pack(side="right", padx=(4, 0))
+            self.log_filter_buttons[selected_filter] = button
+        ttk.Label(
+            log_header,
+            text="FILTER",
+            style="TableHeader.TLabel",
+        ).pack(side="right", padx=(8, 0))
+        self.main_panes.add(log_shell, minsize=150, stretch="always")
         self.logbox = scrolledtext.ScrolledText(
             log_frame,
             height=10,
@@ -2961,6 +3089,7 @@ class App:
             pady=7,
         )
         self.logbox.pack(fill="both", expand=True, padx=7, pady=7)
+        self._select_log_filter("all")
 
         self._apply_initial_window_geometry()
         self.root.after_idle(self._place_initial_pane_sash)
@@ -2990,6 +3119,31 @@ class App:
             self.update_status.config(text="Automatic update checks are off")
         self.root.after(700, self._maybe_show_changelog)
 
+    def _layout_header(self, event=None):
+        width = int(getattr(event, "width", 0) or self.header.winfo_width())
+        wide = width >= 1180
+        if self.header_wide is wide:
+            return
+        self.header_wide = wide
+        self.header_update_bar.grid_forget()
+        if wide:
+            self.header_update_bar.grid(
+                row=0,
+                column=1,
+                sticky="ew",
+                padx=(14, 0),
+                pady=0,
+            )
+        else:
+            self.header_update_bar.grid(
+                row=1,
+                column=0,
+                columnspan=2,
+                sticky="ew",
+                padx=0,
+                pady=(7, 0),
+            )
+
     def _apply_initial_window_geometry(self):
         self.root.update_idletasks()
         width, height = calculate_initial_window_size(
@@ -2998,7 +3152,7 @@ class App:
             self.root.winfo_reqwidth(),
             self.root.winfo_reqheight(),
         )
-        self.root.minsize(min(900, width), min(640, height))
+        self.root.minsize(min(1100, width), min(700, height))
         x = max(0, (self.root.winfo_screenwidth() - width) // 2)
         y = max(0, (self.root.winfo_screenheight() - height) // 3)
         self.root.geometry(f"{width}x{height}+{x}+{y}")
@@ -3027,10 +3181,10 @@ class App:
         )
 
         frame = ttk.LabelFrame(
-            self.controls_root,
+            self.component_column,
             text=component["title"].upper(),
         )
-        frame.pack(fill="x", padx=14, pady=6)
+        frame.pack(fill="x", pady=(0, 6))
 
         controls = ttk.Frame(frame)
         controls.pack(fill="x", padx=8, pady=(8, 2))
@@ -3081,13 +3235,13 @@ class App:
             self.lan_access_control.pack(side="left")
             address_row = ttk.Frame(frame)
             address_row.pack(fill="x", padx=9, pady=(2, 4))
-            ttk.Label(address_row, text="LAN address:").pack(side="left")
+            ttk.Label(address_row, text="LAN:").pack(side="left")
             self.lan_address_combo = ttk.Combobox(
                 address_row,
                 textvariable=self.lan_address_var,
                 values=self.lan_addresses,
                 state="readonly",
-                width=18,
+                width=15,
             )
             self.lan_address_combo.pack(side="left", padx=(7, 5))
             self.lan_address_combo.bind(
@@ -3123,7 +3277,7 @@ class App:
                 foreground=THEME["slate_dim"],
                 anchor="w",
                 justify="left",
-                wraplength=670,
+                wraplength=350,
             ).pack(fill="x", padx=9, pady=(0, 8))
             self._update_lan_address_status()
 
@@ -3231,16 +3385,7 @@ class App:
         raw = self.ksp_root_var.get().strip()
         root = resolve_ksp_root(raw)
         if root is not None:
-            notes_variants = (
-                root / "GameData" / "Notes" / "Plugins" / "PluginData" / "notes",
-                root / "GameData" / "notes" / "Plugins" / "PluginData" / "notes",
-            )
-            notes_installed = any(path.is_dir() for path in notes_variants)
             text = "KSP folder ready"
-            if notes_installed:
-                text += " - Notes mod detected"
-            else:
-                text += " - Notes mod not detected (optional)"
             self.ksp_root_status.config(text=text, foreground=THEME["green"])
         elif raw:
             self.ksp_root_status.config(
@@ -3250,8 +3395,8 @@ class App:
         else:
             self.ksp_root_status.config(
                 text=(
-                    "Choose the KSP folder to verify kRPC and mods, maintain "
-                    "services, and enable Notes."
+                    "Choose the KSP folder to verify kRPC, mods, and Mission "
+                    "Control services."
                 ),
                 foreground=THEME["slate_dim"],
             )
@@ -3333,6 +3478,22 @@ class App:
             heat_text, heat_color = "Not installed - stock heat (W)", THEME["cyan"]
         self.system_heat_mod_status.config(text=heat_text, foreground=heat_color)
 
+        if root is None:
+            notes_text, notes_color = "KSP folder required", THEME["slate_dim"]
+            notes_resolved = False
+        else:
+            notes_variants = (
+                root / "GameData" / "Notes" / "Plugins" / "PluginData" / "notes",
+                root / "GameData" / "notes" / "Plugins" / "PluginData" / "notes",
+            )
+            notes_installed = any(path.is_dir() for path in notes_variants)
+            if notes_installed:
+                notes_text, notes_color = "Detected", THEME["green"]
+            else:
+                notes_text, notes_color = "Not detected - optional", THEME["cyan"]
+            notes_resolved = True
+        self.notes_mod_status.config(text=notes_text, foreground=notes_color)
+
         configuration = krpc_configuration_inventory(self.ksp_root_var.get())
         config_status = configuration["status"]
         server = configuration.get("server")
@@ -3374,10 +3535,12 @@ class App:
             self.prerequisite_fix_button.config(
                 text=f"Review fixes ({len(self.prerequisite_fix_items)})"
             )
+            if not self.prerequisite_buttons.winfo_manager():
+                self.prerequisite_buttons.pack(fill="x", pady=(10, 0))
             if not self.prerequisite_fix_button.winfo_manager():
-                self.prerequisite_fix_button.pack(side="left", padx=(6, 0))
-        elif self.prerequisite_fix_button.winfo_manager():
-            self.prerequisite_fix_button.pack_forget()
+                self.prerequisite_fix_button.pack(side="left")
+        elif self.prerequisite_buttons.winfo_manager():
+            self.prerequisite_buttons.pack_forget()
 
         statuses = {item["key"]: item["status"] for item in inventory}
         optional_attention = any(
@@ -3416,6 +3579,21 @@ class App:
             summary_text, summary_color = "Manual kRPC action needed", THEME["amber"]
         else:
             summary_text, summary_color = "Prerequisites tested", THEME["green"]
+        total_checks = 5 + len(KSP_PREREQUISITES)
+        resolved_checks = sum(
+            (
+                ksp_status != "unconfigured",
+                layout_status not in {"unconfigured", "error"},
+                *(
+                    item["status"] != "unconfigured"
+                    for item in inventory
+                ),
+                system_heat["status"] != "unconfigured",
+                config_status != "unconfigured",
+                notes_resolved,
+            )
+        )
+        summary_text += f" · {resolved_checks}/{total_checks} resolved"
         self.prerequisite_summary.config(
             text=summary_text, foreground=summary_color
         )
@@ -3695,7 +3873,8 @@ class App:
             summary_color = THEME["slate_dim"]
         elif installed_issues and package_missing:
             summary_text = (
-                f"{installed_issues} installed service issue(s); package incomplete"
+                f"{installed_issues} installed issue(s) · "
+                f"{package_missing} missing from package"
             )
             summary_color = THEME["warn"]
         elif installed_issues:
@@ -3703,9 +3882,11 @@ class App:
             summary_color = THEME["warn"]
         elif package_missing:
             summary_text = (
-                "Installed services current; package incomplete"
+                f"{installed_current} current · "
+                f"{package_missing} missing from package"
                 if installed_current == len(inventory)
-                else "Installed services present; package incomplete"
+                else f"{installed_current} present · "
+                f"{package_missing} missing from package"
             )
             summary_color = THEME["amber"]
         elif counts.get("current_different", 0):
@@ -3868,12 +4049,69 @@ class App:
         self._save_ksp_root()
 
     def _enqueue(self, source, message):
-        self.log_queue.put(f"[{source}] {message}")
+        self.log_queue.put((str(source), str(message)))
+
+    def _select_log_filter(self, selected_filter):
+        selected_filter = str(selected_filter or "all").casefold()
+        self.log_filter_var.set(selected_filter)
+        for name, button in self.log_filter_buttons.items():
+            button.config(
+                style="Accent.TButton" if name == selected_filter else "TButton"
+            )
+        if hasattr(self, "logbox"):
+            self._render_log()
+
+    def _render_log(self):
+        if not hasattr(self, "logbox"):
+            return
+        previous_view = self.logbox.yview()
+        visible = filter_launcher_log_records(
+            self.log_records,
+            self.log_filter_var.get(),
+        )
+        self.logbox.configure(state="normal")
+        self.logbox.delete("1.0", "end")
+        for source, message, _warning in visible:
+            self.logbox.insert("end", f"[{source}] {message}\n")
+        self.logbox.configure(state="disabled")
+        if self.log_follow_var.get():
+            self.logbox.see("end")
+        elif previous_view:
+            self.logbox.yview_moveto(previous_view[0])
+
+    def _copy_log(self):
+        visible = filter_launcher_log_records(
+            self.log_records,
+            self.log_filter_var.get(),
+        )
+        text = "\n".join(
+            f"[{source}] {message}" for source, message, _warning in visible
+        )
+        try:
+            self.root.clipboard_clear()
+            self.root.clipboard_append(text)
+            self.root.update_idletasks()
+        except tk.TclError as exc:
+            self._enqueue("launcher", f"couldn't copy Mission Log: {exc}")
+
+    def _clear_log(self):
+        self.log_records.clear()
+        self.log_warning_count_var.set("0 warnings")
+        self._render_log()
 
     def _drain_log(self):
+        changed = False
         try:
             while True:
-                line = self.log_queue.get_nowait()
+                record = self.log_queue.get_nowait()
+                if isinstance(record, tuple) and len(record) == 2:
+                    source, message = record
+                else:
+                    line = str(record)
+                    source, separator, message = line.partition("] ")
+                    source = source.removeprefix("[") if separator else "launcher"
+                    message = message if separator else line
+                line = f"[{source}] {message}"
                 if KRPC_CONNECTED_EVENT in line:
                     self.live_krpc_state = {"status": "runtime_connected"}
                     self._refresh_prerequisite_status()
@@ -3885,12 +4123,19 @@ class App:
                     }
                     self._refresh_prerequisite_status()
                     continue
-                self.logbox.configure(state="normal")
-                self.logbox.insert("end", line + "\n")
-                self.logbox.see("end")
-                self.logbox.configure(state="disabled")
+                self.log_records.append(
+                    (source, message, is_launcher_log_warning(source, message))
+                )
+                if len(self.log_records) > 5000:
+                    del self.log_records[: len(self.log_records) - 5000]
+                changed = True
         except queue.Empty:
             pass
+        if changed:
+            warning_count = sum(record[2] for record in self.log_records)
+            suffix = "warning" if warning_count == 1 else "warnings"
+            self.log_warning_count_var.set(f"{warning_count} {suffix}")
+            self._render_log()
         self.root.after(100, self._drain_log)
 
     def _start_update_check(self, use_cache):

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -4818,7 +4818,15 @@ class App:
 
         started = backend.start()
         if started and open_dashboard and DASHBOARD.is_file():
-            self.root.after(250, self._open_dashboard_when_ready)
+            if self.lan_access_var.get():
+                self._enqueue(
+                    "launcher",
+                    "Trusted-LAN access is enabled, so the host browser was not "
+                    "opened automatically. Use Copy LAN URL for another device "
+                    "or Open dashboard for this computer.",
+                )
+            else:
+                self.root.after(250, self._open_dashboard_when_ready)
 
     def _dashboard_ready(self):
         try:

--- a/ksp_dashboard_app.py
+++ b/ksp_dashboard_app.py
@@ -323,6 +323,9 @@ KRPC_SERVICE_ATTRIBUTES = (
     ("vessel_damage", "VesselDamage"),
 )
 SYSTEM_HEAT_MOD_PATH = Path("SystemHeat") / "Plugin" / "SystemHeat.dll"
+NOTES_MOD_NAME = "zer0Kerbal's Notes (Kollege Ruled)"
+NOTES_TESTED_VERSION = "0.17.0.0"
+NOTES_MOD_DIRECTORIES = ("Notes", "notes")
 KSP_PREREQUISITES = (
     {
         "key": "krpc",
@@ -1111,6 +1114,43 @@ def system_heat_mod_inventory(ksp_root_value):
     else:
         status = "stock_fallback"
     return {"status": status, "target": target}
+
+
+def notes_mod_inventory(ksp_root_value):
+    """Report the installed Notes release used by the read-only integration."""
+    if isinstance(ksp_root_value, os.PathLike):
+        ksp_root_value = os.fspath(ksp_root_value)
+    root = resolve_ksp_root(ksp_root_value)
+    if root is None:
+        return {
+            "status": "unconfigured",
+            "target": None,
+            "installed_version": None,
+        }
+
+    for directory_name in NOTES_MOD_DIRECTORIES:
+        mod_root = root / "GameData" / directory_name
+        target = mod_root / "Plugins" / "Notes.dll"
+        if not target.is_file():
+            continue
+        installed_version = read_avc_version(mod_root / "Notes.version")
+        if installed_version is None:
+            status = "unknown_version"
+        elif versions_equivalent(installed_version, NOTES_TESTED_VERSION):
+            status = "current"
+        else:
+            status = "untested"
+        return {
+            "status": status,
+            "target": target,
+            "installed_version": installed_version,
+        }
+
+    return {
+        "status": "missing",
+        "target": root / "GameData" / "Notes" / "Plugins" / "Notes.dll",
+        "installed_version": None,
+    }
 
 
 def _parse_config_nodes(text):
@@ -2890,7 +2930,7 @@ class App:
             ),
             ("__system_heat", "System Heat thermal backend"),
             ("__krpc_configuration", "kRPC server configuration"),
-            ("__notes", "Notes mod"),
+            ("__notes", NOTES_MOD_NAME),
         ]
         compatibility_labels = build_paired_status_grid(
             prerequisites,
@@ -3478,19 +3518,23 @@ class App:
             heat_text, heat_color = "Not installed - stock heat (W)", THEME["cyan"]
         self.system_heat_mod_status.config(text=heat_text, foreground=heat_color)
 
-        if root is None:
+        notes = notes_mod_inventory(self.ksp_root_var.get())
+        notes_status = notes["status"]
+        notes_version = notes["installed_version"]
+        if notes_status == "unconfigured":
             notes_text, notes_color = "KSP folder required", THEME["slate_dim"]
             notes_resolved = False
+        elif notes_status == "current":
+            notes_text, notes_color = f"{NOTES_TESTED_VERSION} tested", THEME["green"]
+            notes_resolved = True
+        elif notes_status == "untested":
+            notes_text, notes_color = f"{notes_version} - untested", THEME["amber"]
+            notes_resolved = True
+        elif notes_status == "unknown_version":
+            notes_text, notes_color = "Installed - version unknown", THEME["amber"]
+            notes_resolved = True
         else:
-            notes_variants = (
-                root / "GameData" / "Notes" / "Plugins" / "PluginData" / "notes",
-                root / "GameData" / "notes" / "Plugins" / "PluginData" / "notes",
-            )
-            notes_installed = any(path.is_dir() for path in notes_variants)
-            if notes_installed:
-                notes_text, notes_color = "Detected", THEME["green"]
-            else:
-                notes_text, notes_color = "Not detected - optional", THEME["cyan"]
+            notes_text, notes_color = "Not detected - optional", THEME["cyan"]
             notes_resolved = True
         self.notes_mod_status.config(text=notes_text, foreground=notes_color)
 

--- a/telemetry_runtime.py
+++ b/telemetry_runtime.py
@@ -299,9 +299,6 @@ def create_telemetry_runtime(
 
         logging.getLogger("websockets.server").addFilter(_HandshakeNoiseFilter())
 
-        tconn = connect("KSP Dashboard Telemetry")
-        if tconn is None:
-            return False
         if not web_root.joinpath("index.html").is_file():
             print(
                 "[telemetry] React dashboard files are missing. Expected "
@@ -472,7 +469,7 @@ def create_telemetry_runtime(
                 sessions.pop(ws, None)
                 send_locks.pop(ws, None)
 
-        async def broadcaster():
+        async def broadcaster(tconn):
             loop = asyncio.get_running_loop()
             interval = 1.0 / telemetry_hz
             while True:
@@ -517,7 +514,18 @@ def create_telemetry_runtime(
                             max_queue=32,
                         )
                     )
-                await broadcaster()
+                # Bind both HTTP/WebSocket listeners before the blocking kRPC
+                # retry begins. The launcher and local browser can therefore
+                # load immediately while KSP is still starting or at its main
+                # menu. The existing bounded retry still stops the component
+                # if no kRPC connection becomes available.
+                loop = asyncio.get_running_loop()
+                tconn = await loop.run_in_executor(
+                    None, connect, "KSP Dashboard Telemetry"
+                )
+                if tconn is None:
+                    raise RuntimeError("kRPC connection was not available")
+                await broadcaster(tconn)
 
         try:
             asyncio.run(serve())

--- a/telemetry_runtime.py
+++ b/telemetry_runtime.py
@@ -78,7 +78,7 @@ def is_local_network_address(value):
 
 def bind_host_allowed(host):
     """Return whether *host* is safe for the dashboard server to bind to."""
-    return host == "127.0.0.1" or is_local_network_address(host)
+    return is_local_network_address(host)
 
 
 def remote_address_allowed(remote_address):
@@ -109,6 +109,30 @@ def detect_lan_address(probe_factory=lambda: socket.socket(socket.AF_INET, socke
     finally:
         probe.close()
     return candidate if is_local_network_address(candidate) else None
+
+
+def is_handshake_noise(record):
+    """Return whether a ``websockets.server`` log record is routine LAN
+    noise from a malformed/incomplete handshake, safe to drop from the log.
+
+    A LAN-facing socket routinely receives non-HTTP traffic (device
+    discovery, health-check probes, port scans), and websockets logs a full
+    traceback for each one. Filtering on the specific parse-failure
+    exception types -- rather than muting the whole logger -- keeps genuine
+    handshake and connection-handler errors visible. These connections never
+    reach process_request, so nothing is ever disclosed by them; this is
+    purely about keeping the log readable.
+    """
+    if record.getMessage() != "opening handshake failed":
+        return False
+    exc_type = record.exc_info[0] if record.exc_info else None
+    if exc_type is None:
+        return False
+    if exc_type is EOFError:
+        return True
+    from websockets.exceptions import InvalidMessage
+
+    return issubclass(exc_type, InvalidMessage)
 
 
 def planner_event(store, command):
@@ -199,11 +223,11 @@ def create_telemetry_runtime(
             print("[telemetry] Install with:  pip install websockets")
             return False
 
-        # Malformed or incomplete handshakes -- routine noise from other
-        # devices on a LAN interface -- would otherwise dump a full traceback
-        # per occurrence; they never reach process_request, so nothing is
-        # ever disclosed by them.
-        logging.getLogger("websockets.server").setLevel(logging.CRITICAL)
+        class _HandshakeNoiseFilter(logging.Filter):
+            def filter(self, record):
+                return not is_handshake_noise(record)
+
+        logging.getLogger("websockets.server").addFilter(_HandshakeNoiseFilter())
 
         tconn = connect("KSP Dashboard Telemetry")
         if tconn is None:

--- a/telemetry_runtime.py
+++ b/telemetry_runtime.py
@@ -11,6 +11,7 @@ import re
 import socket
 import urllib.parse
 import uuid
+from contextlib import AsyncExitStack
 from http import HTTPStatus
 
 from planner_persistence import PlannerPersistence
@@ -53,9 +54,10 @@ KRPC_COMMAND_TYPES = frozenset(
 MAX_COMMAND_BYTES = 2 * 1024 * 1024
 MAX_PENDING_COMMANDS = 256
 FINGERPRINTED_ASSET = re.compile(r"^.+-[A-Za-z0-9_-]{8,}\.[^.]+$")
-LOCAL_NETWORKS = tuple(
+LOOPBACK_NETWORK = ipaddress.ip_network("127.0.0.0/8")
+PRIVATE_LAN_NETWORKS = tuple(
     ipaddress.ip_network(cidr)
-    for cidr in ("127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+    for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 )
 
 
@@ -67,13 +69,38 @@ def allowed_host_header(value, host, port):
     return str(value or "").casefold() == f"{host}:{int(port)}".casefold()
 
 
-def is_local_network_address(value):
-    """Return whether *value* is a loopback or private-LAN IPv4 address."""
+def allowed_origin_header(value, host, port):
+    """Accept an absent Origin or the exact HTTP origin for one listener."""
+    return (
+        value is None
+        or str(value).casefold() == canonical_origin(host, port).casefold()
+    )
+
+
+def _ipv4_address(value):
     try:
         address = ipaddress.ip_address(str(value))
     except ValueError:
-        return False
-    return any(address in network for network in LOCAL_NETWORKS)
+        return None
+    return address if isinstance(address, ipaddress.IPv4Address) else None
+
+
+def is_loopback_address(value):
+    address = _ipv4_address(value)
+    return address is not None and address in LOOPBACK_NETWORK
+
+
+def is_private_lan_address(value):
+    """Return whether *value* is an RFC1918, non-loopback IPv4 address."""
+    address = _ipv4_address(value)
+    return address is not None and any(
+        address in network for network in PRIVATE_LAN_NETWORKS
+    )
+
+
+def is_local_network_address(value):
+    """Return whether *value* is a loopback or private-LAN IPv4 address."""
+    return is_loopback_address(value) or is_private_lan_address(value)
 
 
 def bind_host_allowed(host):
@@ -81,11 +108,22 @@ def bind_host_allowed(host):
     return is_local_network_address(host)
 
 
-def remote_address_allowed(remote_address):
-    """Return whether an inbound connection's peer address is local-network."""
+def remote_address_allowed(remote_address, listener_host=None):
+    """Validate a peer against the specific listener it reached.
+
+    Without ``listener_host`` this retains the legacy local-network predicate
+    for callers that only need a general classification.
+    """
     if not remote_address:
         return False
-    return is_local_network_address(remote_address[0])
+    peer = remote_address[0]
+    if listener_host is None:
+        return is_local_network_address(peer)
+    if is_loopback_address(listener_host):
+        return is_loopback_address(peer)
+    if is_private_lan_address(listener_host):
+        return is_private_lan_address(peer)
+    return False
 
 
 def detect_lan_address(probe_factory=lambda: socket.socket(socket.AF_INET, socket.SOCK_DGRAM)):
@@ -108,7 +146,32 @@ def detect_lan_address(probe_factory=lambda: socket.socket(socket.AF_INET, socke
         return None
     finally:
         probe.close()
-    return candidate if is_local_network_address(candidate) else None
+    return candidate if is_private_lan_address(candidate) else None
+
+
+def detect_lan_addresses(
+    route_detector=detect_lan_address,
+    hostname_factory=socket.gethostname,
+    hostname_resolver=socket.gethostbyname_ex,
+):
+    """Discover active RFC1918 IPv4 addresses, routed candidate first."""
+    candidates = []
+    try:
+        candidates.append(route_detector())
+    except OSError:
+        pass
+    try:
+        _hostname, _aliases, resolved = hostname_resolver(hostname_factory())
+        candidates.extend(resolved)
+    except (OSError, TypeError, ValueError):
+        pass
+
+    result = []
+    for candidate in candidates:
+        value = str(candidate or "").strip()
+        if is_private_lan_address(value) and value not in result:
+            result.append(value)
+    return tuple(result)
 
 
 def is_handshake_noise(record):
@@ -201,18 +264,25 @@ def create_telemetry_runtime(
             cache_policy = "no-cache"
         return status, media_type, cache_policy, body
 
-    def run_telemetry_server(host, port):
-        if not bind_host_allowed(host):
+    def run_telemetry_server(host, port, additional_hosts=()):
+        if isinstance(additional_hosts, str):
+            additional_hosts = (additional_hosts,)
+        listener_hosts = []
+        for candidate in (host, *tuple(additional_hosts or ())):
+            candidate = str(candidate or "").strip()
+            if candidate and candidate not in listener_hosts:
+                listener_hosts.append(candidate)
+
+        if (
+            not listener_hosts
+            or listener_hosts[0] != "127.0.0.1"
+            or any(not is_private_lan_address(item) for item in listener_hosts[1:])
+        ):
             print(
-                "[telemetry] Mission Control requires the canonical loopback "
-                "host 127.0.0.1 or a private local-network address."
+                "[telemetry] Mission Control requires 127.0.0.1 as its primary "
+                "listener and only RFC1918 IPv4 addresses as additional listeners."
             )
             return False
-        if host != "127.0.0.1":
-            print(
-                f"[telemetry] LAN access enabled -- reachable from your local "
-                f"network at http://{host}:{port}/. Use only on a trusted network."
-            )
 
         try:
             import websockets
@@ -239,74 +309,93 @@ def create_telemetry_runtime(
             )
             return False
 
-        origin = canonical_origin(host, port)
-        websocket_origin = origin.replace("http://", "ws://", 1)
-        content_security_policy = (
-            "default-src 'self'; "
-            f"connect-src 'self' {websocket_origin}; "
-            "img-src 'self' data:; "
-            "style-src 'self' 'unsafe-inline'; "
-            "object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
-        )
         store = PlannerPersistence()
         clients = set()
         sessions = {}
         send_locks = {}
         commands = asyncio.Queue(maxsize=MAX_PENDING_COMMANDS)
 
-        print(f"[telemetry] dashboard: {origin}/")
-        print(f"[telemetry] telemetry: {websocket_origin}/  ({telemetry_hz} Hz)")
+        for listener_host in listener_hosts:
+            origin = canonical_origin(listener_host, port)
+            websocket_origin = origin.replace("http://", "ws://", 1)
+            print(f"[telemetry] dashboard: {origin}/")
+            print(f"[telemetry] telemetry: {websocket_origin}/  ({telemetry_hz} Hz)")
+            if is_private_lan_address(listener_host):
+                print(
+                    "[telemetry] WARNING: trusted-LAN access has no authentication "
+                    "or encryption and exposes every dashboard command."
+                )
         print(f"[telemetry] planner saves: {store.path}")
 
-        def response(status, body, extra_headers=()):
-            encoded = body if isinstance(body, bytes) else str(body).encode("utf-8")
-            return Response(
-                int(status),
-                status.phrase,
-                Headers(
-                    [
-                        ("Content-Type", "text/plain; charset=utf-8"),
-                        ("Content-Length", str(len(encoded))),
-                        ("Cache-Control", "no-store"),
-                        ("X-Content-Type-Options", "nosniff"),
-                        ("Content-Security-Policy", content_security_policy),
-                        ("Referrer-Policy", "no-referrer"),
-                    ]
-                    + list(extra_headers)
-                ),
-                encoded,
+        def request_processor(listener_host):
+            origin = canonical_origin(listener_host, port)
+            websocket_origin = origin.replace("http://", "ws://", 1)
+            content_security_policy = (
+                "default-src 'self'; "
+                f"connect-src 'self' {websocket_origin}; "
+                "img-src 'self' data:; "
+                "style-src 'self' 'unsafe-inline'; "
+                "object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
             )
 
-        def process_request(_connection, request):
-            if not remote_address_allowed(getattr(_connection, "remote_address", None)):
-                return response(HTTPStatus.FORBIDDEN, "Forbidden\n")
-            if not allowed_host_header(request.headers.get("Host"), host, port):
-                if request.headers.get("Upgrade", "").casefold() == "websocket":
-                    return response(HTTPStatus.FORBIDDEN, "Forbidden\n")
-                location = f"{origin}{request.path}"
-                return response(
-                    HTTPStatus.PERMANENT_REDIRECT,
-                    "Use the canonical loopback address.\n",
-                    (("Location", location),),
+            def response(status, body, extra_headers=()):
+                encoded = body if isinstance(body, bytes) else str(body).encode("utf-8")
+                return Response(
+                    int(status),
+                    status.phrase,
+                    Headers(
+                        [
+                            ("Content-Type", "text/plain; charset=utf-8"),
+                            ("Content-Length", str(len(encoded))),
+                            ("Cache-Control", "no-store"),
+                            ("X-Content-Type-Options", "nosniff"),
+                            ("Content-Security-Policy", content_security_policy),
+                            ("Referrer-Policy", "no-referrer"),
+                        ]
+                        + list(extra_headers)
+                    ),
+                    encoded,
                 )
-            if request.headers.get("Upgrade", "").casefold() == "websocket":
-                return None
-            status, media_type, cache_policy, body = dashboard_asset(request.path)
-            return Response(
-                int(status),
-                status.phrase,
-                Headers(
-                    [
-                        ("Content-Type", media_type),
-                        ("Content-Length", str(len(body))),
-                        ("Cache-Control", cache_policy),
-                        ("X-Content-Type-Options", "nosniff"),
-                        ("Content-Security-Policy", content_security_policy),
-                        ("Referrer-Policy", "no-referrer"),
-                    ]
-                ),
-                body,
-            )
+
+            def process_request(connection, request):
+                if not remote_address_allowed(
+                    getattr(connection, "remote_address", None), listener_host
+                ):
+                    return response(HTTPStatus.FORBIDDEN, "Forbidden\n")
+                if not allowed_host_header(
+                    request.headers.get("Host"), listener_host, port
+                ):
+                    if request.headers.get("Upgrade", "").casefold() == "websocket":
+                        return response(HTTPStatus.FORBIDDEN, "Forbidden\n")
+                    return response(
+                        HTTPStatus.PERMANENT_REDIRECT,
+                        "Use the address for this dashboard listener.\n",
+                        (("Location", f"{origin}{request.path}"),),
+                    )
+                if request.headers.get("Upgrade", "").casefold() == "websocket":
+                    if not allowed_origin_header(
+                        request.headers.get("Origin"), listener_host, port
+                    ):
+                        return response(HTTPStatus.FORBIDDEN, "Forbidden\n")
+                    return None
+                status, media_type, cache_policy, body = dashboard_asset(request.path)
+                return Response(
+                    int(status),
+                    status.phrase,
+                    Headers(
+                        [
+                            ("Content-Type", media_type),
+                            ("Content-Length", str(len(body))),
+                            ("Cache-Control", cache_policy),
+                            ("X-Content-Type-Options", "nosniff"),
+                            ("Content-Security-Policy", content_security_policy),
+                            ("Referrer-Policy", "no-referrer"),
+                        ]
+                    ),
+                    body,
+                )
+
+            return process_request
 
         async def safe_send(ws, payload):
             if ws not in clients:
@@ -414,15 +503,20 @@ def create_telemetry_runtime(
                 await asyncio.sleep(interval)
 
         async def serve():
-            async with websockets.serve(
-                handler,
-                host,
-                port,
-                process_request=process_request,
-                origins=[origin, None],
-                max_size=MAX_COMMAND_BYTES,
-                max_queue=32,
-            ):
+            async with AsyncExitStack() as stack:
+                for listener_host in listener_hosts:
+                    origin = canonical_origin(listener_host, port)
+                    await stack.enter_async_context(
+                        websockets.serve(
+                            handler,
+                            listener_host,
+                            port,
+                            process_request=request_processor(listener_host),
+                            origins=[origin, None],
+                            max_size=MAX_COMMAND_BYTES,
+                            max_queue=32,
+                        )
+                    )
                 await broadcaster()
 
         try:

--- a/telemetry_runtime.py
+++ b/telemetry_runtime.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
+import logging
 import math
 import re
+import socket
 import urllib.parse
 import uuid
 from http import HTTPStatus
@@ -50,6 +53,10 @@ KRPC_COMMAND_TYPES = frozenset(
 MAX_COMMAND_BYTES = 2 * 1024 * 1024
 MAX_PENDING_COMMANDS = 256
 FINGERPRINTED_ASSET = re.compile(r"^.+-[A-Za-z0-9_-]{8,}\.[^.]+$")
+LOCAL_NETWORKS = tuple(
+    ipaddress.ip_network(cidr)
+    for cidr in ("127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+)
 
 
 def canonical_origin(host, port):
@@ -58,6 +65,50 @@ def canonical_origin(host, port):
 
 def allowed_host_header(value, host, port):
     return str(value or "").casefold() == f"{host}:{int(port)}".casefold()
+
+
+def is_local_network_address(value):
+    """Return whether *value* is a loopback or private-LAN IPv4 address."""
+    try:
+        address = ipaddress.ip_address(str(value))
+    except ValueError:
+        return False
+    return any(address in network for network in LOCAL_NETWORKS)
+
+
+def bind_host_allowed(host):
+    """Return whether *host* is safe for the dashboard server to bind to."""
+    return host == "127.0.0.1" or is_local_network_address(host)
+
+
+def remote_address_allowed(remote_address):
+    """Return whether an inbound connection's peer address is local-network."""
+    if not remote_address:
+        return False
+    return is_local_network_address(remote_address[0])
+
+
+def detect_lan_address(probe_factory=lambda: socket.socket(socket.AF_INET, socket.SOCK_DGRAM)):
+    """Best-effort discovery of this machine's LAN-facing private IPv4 address.
+
+    Opens no real connection (UDP, non-routable target) -- only asks the OS
+    which local interface it would use. Returns ``None`` if detection fails
+    or the resolved address isn't itself private, so callers can fail closed
+    to loopback-only.
+    """
+    try:
+        probe = probe_factory()
+    except OSError:
+        return None
+    try:
+        probe.settimeout(0.2)
+        probe.connect(("10.255.255.255", 1))
+        candidate = probe.getsockname()[0]
+    except OSError:
+        return None
+    finally:
+        probe.close()
+    return candidate if is_local_network_address(candidate) else None
 
 
 def planner_event(store, command):
@@ -127,12 +178,17 @@ def create_telemetry_runtime(
         return status, media_type, cache_policy, body
 
     def run_telemetry_server(host, port):
-        if host != "127.0.0.1":
+        if not bind_host_allowed(host):
             print(
-                "[telemetry] Mission Control requires the canonical "
-                "loopback host 127.0.0.1."
+                "[telemetry] Mission Control requires the canonical loopback "
+                "host 127.0.0.1 or a private local-network address."
             )
             return False
+        if host != "127.0.0.1":
+            print(
+                f"[telemetry] LAN access enabled -- reachable from your local "
+                f"network at http://{host}:{port}/. Use only on a trusted network."
+            )
 
         try:
             import websockets
@@ -142,6 +198,12 @@ def create_telemetry_runtime(
             print("[telemetry] 'websockets' not installed -- dashboard feed disabled.")
             print("[telemetry] Install with:  pip install websockets")
             return False
+
+        # Malformed or incomplete handshakes -- routine noise from other
+        # devices on a LAN interface -- would otherwise dump a full traceback
+        # per occurrence; they never reach process_request, so nothing is
+        # ever disclosed by them.
+        logging.getLogger("websockets.server").setLevel(logging.CRITICAL)
 
         tconn = connect("KSP Dashboard Telemetry")
         if tconn is None:
@@ -192,6 +254,8 @@ def create_telemetry_runtime(
             )
 
         def process_request(_connection, request):
+            if not remote_address_allowed(getattr(_connection, "remote_address", None)):
+                return response(HTTPStatus.FORBIDDEN, "Forbidden\n")
             if not allowed_host_header(request.headers.get("Host"), host, port):
                 if request.headers.get("Upgrade", "").casefold() == "websocket":
                     return response(HTTPStatus.FORBIDDEN, "Forbidden\n")

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -13,9 +13,12 @@ separate process and a separate kRPC connection.
 Requires:  pip install krpc websockets
 
 Optional args: telemetry_server.py [host] [port]
-  telemetry_server.py 0.0.0.0 8090
+  telemetry_server.py 192.168.1.50 8090
 
 Set WOOBIE_STAGE_TRACE=1 to emit opt-in StageStats lifecycle diagnostics.
+Set WOOBIE_ALLOW_LAN=1 to auto-detect this machine's private LAN address and
+serve the dashboard there instead of loopback-only. Falls back to loopback if
+no private address can be detected.
 """
 import json
 import math
@@ -55,7 +58,7 @@ from mission_planning import (
 from resource_snapshot import decode_resource_snapshot
 from stage_snapshot import decode_flight_stage_snapshot
 from staging import enrich_stage_result, flight_conditions
-from telemetry_runtime import create_telemetry_runtime
+from telemetry_runtime import create_telemetry_runtime, detect_lan_address
 
 TELEMETRY_WS_PORT = 8090  # dashboard connects here
 TELEMETRY_HZ = 4          # dashboard update rate
@@ -112,6 +115,9 @@ OVERVIEW_EDITABLE_VESSEL_TYPES = {
     "Station": KRPCVesselType.station,
 }
 STAGE_TRACE_ENABLED = os.environ.get("WOOBIE_STAGE_TRACE", "").casefold() in {
+    "1", "true", "yes", "on",
+}
+ALLOW_LAN_ENABLED = os.environ.get("WOOBIE_ALLOW_LAN", "").casefold() in {
     "1", "true", "yes", "on",
 }
 
@@ -5417,7 +5423,18 @@ def run_telemetry_server(host, port):
 
 
 def main():
-    host = sys.argv[1] if len(sys.argv) >= 2 else "127.0.0.1"
+    if len(sys.argv) >= 2:
+        host = sys.argv[1]
+    elif ALLOW_LAN_ENABLED:
+        host = detect_lan_address()
+        if host is None:
+            print(
+                "[telemetry] WOOBIE_ALLOW_LAN is set but no private LAN "
+                "address could be detected; staying on loopback."
+            )
+            host = "127.0.0.1"
+    else:
+        host = "127.0.0.1"
     port = int(sys.argv[2]) if len(sys.argv) >= 3 else TELEMETRY_WS_PORT
 
     print("KSP React dashboard and telemetry server (no ESP32 control code).")

--- a/telemetry_server.py
+++ b/telemetry_server.py
@@ -4,7 +4,7 @@ This module owns every dashboard-facing responsibility:
   * its own kRPC connection and reconnect loop
   * flight, orbit, resource, science, heat, electricity, target, and stage data
   * VAB/SPH craft stage analysis and editor-condition selection
-  * the loopback HTTP and WebSocket server consumed by the React dashboard
+  * loopback and optional trusted-LAN HTTP/WebSocket dashboard listeners
 
 It has no ESP32, serial-port, staging, abort, or panel-control dependencies.
 The physical control pad is handled exclusively by panel_bridge.py in a
@@ -12,13 +12,12 @@ separate process and a separate kRPC connection.
 
 Requires:  pip install krpc websockets
 
-Optional args: telemetry_server.py [host] [port]
+Optional args: telemetry_server.py [lan_host] [port]
   telemetry_server.py 192.168.1.50 8090
 
 Set WOOBIE_STAGE_TRACE=1 to emit opt-in StageStats lifecycle diagnostics.
-Set WOOBIE_ALLOW_LAN=1 to auto-detect this machine's private LAN address and
-serve the dashboard there instead of loopback-only. Falls back to loopback if
-no private address can be detected.
+Set WOOBIE_ALLOW_LAN=1 and WOOBIE_LAN_BIND to a selected RFC1918 IPv4 address
+to add a trusted-LAN listener. Loopback remains available in every mode.
 """
 import json
 import math
@@ -58,7 +57,7 @@ from mission_planning import (
 from resource_snapshot import decode_resource_snapshot
 from stage_snapshot import decode_flight_stage_snapshot
 from staging import enrich_stage_result, flight_conditions
-from telemetry_runtime import create_telemetry_runtime, detect_lan_address
+from telemetry_runtime import create_telemetry_runtime, is_loopback_address
 
 TELEMETRY_WS_PORT = 8090  # dashboard connects here
 TELEMETRY_HZ = 4          # dashboard update rate
@@ -120,6 +119,7 @@ STAGE_TRACE_ENABLED = os.environ.get("WOOBIE_STAGE_TRACE", "").casefold() in {
 ALLOW_LAN_ENABLED = os.environ.get("WOOBIE_ALLOW_LAN", "").casefold() in {
     "1", "true", "yes", "on",
 }
+LAN_BIND_ADDRESS = os.environ.get("WOOBIE_LAN_BIND", "").strip()
 
 # KSP Recall exposes these internal refund-bookkeeping resources through kRPC.
 # They are implementation details, not vessel consumables. Match normalized
@@ -5409,7 +5409,7 @@ def gather_telemetry(conn):
     return _finalize_telemetry(conn, payload)
 
 
-def run_telemetry_server(host, port):
+def run_telemetry_server(host, port, lan_host=None):
     """Run the hardened, session-bound production dashboard transport."""
     _asset_handler, server = create_telemetry_runtime(
         dashboard_asset,
@@ -5419,31 +5419,34 @@ def run_telemetry_server(host, port):
         DASHBOARD_WEB_ROOT,
         TELEMETRY_HZ,
     )
-    return server(host, port)
+    return server(host, port, (lan_host,) if lan_host else ())
 
 
 def main():
+    loopback_host = "127.0.0.1"
     if len(sys.argv) >= 2:
-        host = sys.argv[1]
+        requested_host = sys.argv[1]
+        lan_host = None if is_loopback_address(requested_host) else requested_host
     elif ALLOW_LAN_ENABLED:
-        host = detect_lan_address()
-        if host is None:
+        lan_host = LAN_BIND_ADDRESS
+        if not lan_host:
             print(
-                "[telemetry] WOOBIE_ALLOW_LAN is set but no private LAN "
-                "address could be detected; staying on loopback."
+                "[telemetry] WOOBIE_ALLOW_LAN=1 requires an explicit "
+                "WOOBIE_LAN_BIND private IPv4 address."
             )
-            host = "127.0.0.1"
+            return 2
     else:
-        host = "127.0.0.1"
+        lan_host = None
     port = int(sys.argv[2]) if len(sys.argv) >= 3 else TELEMETRY_WS_PORT
 
     print("KSP React dashboard and telemetry server (no ESP32 control code).")
-    print(f"Serving on http://{host}:{port}/. Ctrl+C to stop.")
-    if host not in ("127.0.0.1", "localhost", "::1"):
-        print("WARNING: this read-only telemetry feed has no authentication.")
-        print(f"Network binding is enabled on {host}; use only a trusted network.")
+    print(f"Local dashboard: http://{loopback_host}:{port}/. Ctrl+C to stop.")
+    if lan_host:
+        print(f"Trusted-LAN dashboard: http://{lan_host}:{port}/")
+        print("WARNING: LAN access has no authentication or encryption.")
+        print("Trusted peers can view private data and issue every dashboard command.")
 
-    return 0 if run_telemetry_server(host, port) else 2
+    return 0 if run_telemetry_server(loopback_host, port, lan_host) else 2
 
 
 if __name__ == "__main__":

--- a/tests/test_dashboard_loopback.py
+++ b/tests/test_dashboard_loopback.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from unittest import mock
 from http import HTTPStatus
 from pathlib import Path
 
@@ -7,6 +8,43 @@ import telemetry_server
 
 
 class DashboardLoopbackTests(unittest.TestCase):
+    def test_server_main_keeps_loopback_when_lan_is_enabled(self):
+        with (
+            mock.patch.object(telemetry_server.sys, "argv", ["telemetry_server.py"]),
+            mock.patch.object(telemetry_server, "ALLOW_LAN_ENABLED", True),
+            mock.patch.object(telemetry_server, "LAN_BIND_ADDRESS", "192.168.1.50"),
+            mock.patch.object(
+                telemetry_server, "run_telemetry_server", return_value=True
+            ) as run,
+        ):
+            self.assertEqual(telemetry_server.main(), 0)
+        run.assert_called_once_with("127.0.0.1", 8090, "192.168.1.50")
+
+    def test_server_main_fails_closed_when_enabled_without_selected_address(self):
+        with (
+            mock.patch.object(telemetry_server.sys, "argv", ["telemetry_server.py"]),
+            mock.patch.object(telemetry_server, "ALLOW_LAN_ENABLED", True),
+            mock.patch.object(telemetry_server, "LAN_BIND_ADDRESS", ""),
+            mock.patch.object(telemetry_server, "run_telemetry_server") as run,
+        ):
+            self.assertEqual(telemetry_server.main(), 2)
+        run.assert_not_called()
+
+    def test_explicit_cli_host_is_an_additional_listener(self):
+        with (
+            mock.patch.object(
+                telemetry_server.sys,
+                "argv",
+                ["telemetry_server.py", "10.0.0.5", "9000"],
+            ),
+            mock.patch.object(telemetry_server, "ALLOW_LAN_ENABLED", False),
+            mock.patch.object(
+                telemetry_server, "run_telemetry_server", return_value=True
+            ) as run,
+        ):
+            self.assertEqual(telemetry_server.main(), 0)
+        run.assert_called_once_with("127.0.0.1", 9000, "10.0.0.5")
+
     def test_serves_index_and_hashed_assets_with_expected_cache_policy(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_krpc_preflight.py
+++ b/tests/test_krpc_preflight.py
@@ -305,7 +305,10 @@ class KrpcPrerequisiteTests(unittest.TestCase):
 
             self.assertEqual(inventory["status"], "current")
             self.assertEqual(inventory["installed_version"], "0.17.0.0")
-            self.assertEqual(inventory["target"], notes / "Plugins" / "Notes.dll")
+            self.assertEqual(
+                inventory["target"].resolve(),
+                (notes / "Plugins" / "Notes.dll").resolve(),
+            )
 
     def test_notes_inventory_reports_untested_unknown_and_missing(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_krpc_preflight.py
+++ b/tests/test_krpc_preflight.py
@@ -281,6 +281,65 @@ class KrpcPrerequisiteTests(unittest.TestCase):
         self.assertTrue(app.versions_equivalent("0.8.6.0", "0.8.6"))
         self.assertFalse(app.versions_equivalent("0.8.7", "0.8.6"))
 
+    def test_notes_inventory_reports_tested_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_root(directory)
+            notes = root / "GameData" / "Notes"
+            (notes / "Plugins").mkdir(parents=True)
+            (notes / "Plugins" / "Notes.dll").write_bytes(b"notes")
+            (notes / "Notes.version").write_text(
+                json.dumps(
+                    {
+                        "VERSION": {
+                            "MAJOR": 0,
+                            "MINOR": 17,
+                            "PATCH": 0,
+                            "BUILD": 0,
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            inventory = app.notes_mod_inventory(root)
+
+            self.assertEqual(inventory["status"], "current")
+            self.assertEqual(inventory["installed_version"], "0.17.0.0")
+            self.assertEqual(inventory["target"], notes / "Plugins" / "Notes.dll")
+
+    def test_notes_inventory_reports_untested_unknown_and_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_root(directory)
+            notes = root / "GameData" / "notes"
+            (notes / "Plugins").mkdir(parents=True)
+            (notes / "Plugins" / "Notes.dll").write_bytes(b"notes")
+            version_path = notes / "Notes.version"
+            version_path.write_text(
+                json.dumps(
+                    {
+                        "VERSION": {
+                            "MAJOR": 0,
+                            "MINOR": 18,
+                            "PATCH": 0,
+                            "BUILD": 0,
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            untested = app.notes_mod_inventory(root)
+            self.assertEqual(untested["status"], "untested")
+            self.assertEqual(untested["installed_version"], "0.18.0.0")
+
+            version_path.unlink()
+            self.assertEqual(
+                app.notes_mod_inventory(root)["status"], "unknown_version"
+            )
+
+            (notes / "Plugins" / "Notes.dll").unlink()
+            self.assertEqual(app.notes_mod_inventory(root)["status"], "missing")
+
     def test_newer_mechjeb_recommends_ckan_downgrade_to_tested_version(self):
         inventory = []
         for definition in app.KSP_PREREQUISITES:

--- a/tests/test_launcher_lan_access.py
+++ b/tests/test_launcher_lan_access.py
@@ -1,0 +1,221 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ksp_dashboard_app as app_module
+
+
+class FakeVar:
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+class FakeBackend:
+    def __init__(self, running=False):
+        self.is_running = running
+        self.stop_calls = 0
+
+    def running(self):
+        return self.is_running
+
+    def stop(self):
+        self.stop_calls += 1
+        self.is_running = False
+
+
+class FakeRoot:
+    def __init__(self):
+        self.clipboard = None
+
+    def clipboard_clear(self):
+        self.clipboard = ""
+
+    def clipboard_append(self, value):
+        self.clipboard += value
+
+    def update_idletasks(self):
+        pass
+
+
+def build_app(*, enabled=False, acknowledgement=0, backend_running=False):
+    instance = app_module.App.__new__(app_module.App)
+    instance.settings = {
+        "ksp_root": "",
+        "lan_access_enabled": enabled,
+        "lan_bind_address": "192.168.1.50",
+        "lan_warning_ack_version": acknowledgement,
+    }
+    instance.settings_path = Path("unused-settings.json")
+    instance.lan_access_var = FakeVar(enabled)
+    instance.lan_address_var = FakeVar("192.168.1.50")
+    instance.lan_addresses = ("192.168.1.50", "10.0.0.5")
+    backend = FakeBackend(backend_running)
+    instance.backend_rows = [
+        {
+            "component": {"name": "feed"},
+            "backend": backend,
+        }
+    ]
+    instance._enqueue = mock.Mock()
+    instance._update_lan_address_status = mock.Mock()
+    instance.root = FakeRoot()
+    return instance, backend
+
+
+class LauncherLanAccessTests(unittest.TestCase):
+    def test_warning_copy_and_unchecked_default_are_explicit(self):
+        source = (ROOT / "ksp_dashboard_app.py").read_text(encoding="utf-8")
+        for marker in (
+            'dialog.title("Enable trusted-LAN dashboard access?")',
+            "There is no authentication and traffic is not encrypted.",
+            "finances, contracts, notes",
+            "vessel recovery or termination",
+            '"controls, and maneuver-node creation."',
+            '"Remember that I understand this warning"',
+            "remember_var = tk.BooleanVar(value=False)",
+        ):
+            self.assertIn(marker, source)
+
+    @mock.patch.object(app_module.messagebox, "showerror")
+    @mock.patch.object(app_module, "save_settings")
+    def test_cancel_reverts_toggle_without_saving(self, save, _showerror):
+        instance, backend = build_app(backend_running=True)
+        instance.lan_access_var.set(True)
+        instance._show_lan_access_warning = mock.Mock(return_value=(False, False))
+
+        instance._toggle_lan_access()
+
+        self.assertFalse(instance.lan_access_var.get())
+        self.assertFalse(instance.settings["lan_access_enabled"])
+        save.assert_not_called()
+        self.assertEqual(backend.stop_calls, 0)
+
+    @mock.patch.object(app_module.messagebox, "showerror")
+    @mock.patch.object(app_module, "save_settings")
+    def test_unremembered_warning_is_shown_on_every_enable(self, _save, _showerror):
+        instance, _backend = build_app()
+        instance._show_lan_access_warning = mock.Mock(return_value=(True, False))
+
+        instance.lan_access_var.set(True)
+        instance._toggle_lan_access()
+        instance.lan_access_var.set(False)
+        instance._toggle_lan_access()
+        instance.lan_access_var.set(True)
+        instance._toggle_lan_access()
+
+        self.assertEqual(instance._show_lan_access_warning.call_count, 2)
+        self.assertEqual(instance.settings["lan_warning_ack_version"], 0)
+        self.assertTrue(instance.settings["lan_access_enabled"])
+
+    @mock.patch.object(app_module.messagebox, "showerror")
+    @mock.patch.object(app_module, "save_settings")
+    def test_remembered_warning_suppresses_later_enable(self, _save, _showerror):
+        instance, _backend = build_app()
+        instance._show_lan_access_warning = mock.Mock(return_value=(True, True))
+
+        instance.lan_access_var.set(True)
+        instance._toggle_lan_access()
+        instance.lan_access_var.set(False)
+        instance._toggle_lan_access()
+        instance.lan_access_var.set(True)
+        instance._toggle_lan_access()
+
+        self.assertEqual(instance._show_lan_access_warning.call_count, 1)
+        self.assertEqual(
+            instance.settings["lan_warning_ack_version"],
+            app_module.LAN_WARNING_ACK_VERSION,
+        )
+
+    @mock.patch.object(app_module.messagebox, "showerror")
+    @mock.patch.object(app_module, "save_settings")
+    def test_old_acknowledgement_version_requires_warning(self, _save, _showerror):
+        instance, _backend = build_app(
+            acknowledgement=app_module.LAN_WARNING_ACK_VERSION - 1
+        )
+        instance._show_lan_access_warning = mock.Mock(return_value=(True, False))
+        instance.lan_access_var.set(True)
+
+        instance._toggle_lan_access()
+
+        instance._show_lan_access_warning.assert_called_once_with()
+
+    @mock.patch.object(app_module.messagebox, "showerror")
+    @mock.patch.object(app_module, "save_settings", side_effect=OSError("disk full"))
+    def test_persistence_failure_does_not_enable_or_remember(self, _save, showerror):
+        instance, backend = build_app(backend_running=True)
+        instance._show_lan_access_warning = mock.Mock(return_value=(True, True))
+        instance.lan_access_var.set(True)
+
+        instance._toggle_lan_access()
+
+        self.assertFalse(instance.lan_access_var.get())
+        self.assertFalse(instance.settings["lan_access_enabled"])
+        self.assertEqual(instance.settings["lan_warning_ack_version"], 0)
+        self.assertEqual(backend.stop_calls, 0)
+        showerror.assert_called_once()
+
+    @mock.patch.object(app_module.messagebox, "showerror")
+    @mock.patch.object(app_module, "save_settings")
+    def test_enabling_stops_running_feed_after_setting_is_saved(self, _save, _showerror):
+        instance, backend = build_app(backend_running=True)
+        instance._show_lan_access_warning = mock.Mock(return_value=(True, False))
+        instance.lan_access_var.set(True)
+
+        instance._toggle_lan_access()
+
+        self.assertEqual(backend.stop_calls, 1)
+        self.assertTrue(instance.settings["lan_access_enabled"])
+
+    @mock.patch.object(app_module.messagebox, "showerror")
+    @mock.patch.object(app_module, "save_settings")
+    def test_selecting_a_new_address_stops_feed_and_persists(self, _save, _showerror):
+        instance, backend = build_app(enabled=True, backend_running=True)
+        instance.lan_address_var.set("10.0.0.5")
+
+        instance._select_lan_address()
+
+        self.assertEqual(backend.stop_calls, 1)
+        self.assertEqual(instance.settings["lan_bind_address"], "10.0.0.5")
+
+    @mock.patch.object(app_module.messagebox, "showerror")
+    def test_copy_lan_url_uses_selected_active_address(self, _showerror):
+        instance, _backend = build_app()
+
+        instance._copy_lan_url()
+
+        self.assertEqual(instance.root.clipboard, "http://192.168.1.50:8090/")
+        self.assertIn("copied trusted-LAN", instance._enqueue.call_args.args[1])
+
+    def test_preflight_rejects_stale_and_unavailable_lan_endpoints(self):
+        common = {
+            "port_open": lambda *_args: True,
+            "dashboard_port_available": lambda *_args: True,
+            "lan_access_enabled": True,
+            "lan_bind_address": "192.168.1.50",
+            "lan_address_provider": lambda: ("10.0.0.5",),
+        }
+        stale = app_module.component_preflight("", "feed", **common)
+        self.assertTrue(any("no longer active" in item for item in stale["errors"]))
+
+        common["lan_address_provider"] = lambda: ("192.168.1.50",)
+        common["dashboard_port_available"] = (
+            lambda _port, address=app_module.KRPC_ADDRESS: address
+            != "192.168.1.50"
+        )
+        busy = app_module.component_preflight("", "feed", **common)
+        self.assertTrue(any("cannot be bound" in item for item in busy["errors"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_launcher_readiness.py
+++ b/tests/test_launcher_readiness.py
@@ -28,11 +28,26 @@ class FakeRoot:
 
 class FakeBackend:
     def __init__(self, running=True):
+        self.name = "feed"
         self.is_running = running
         self.startup_ready = False
+        self.start_calls = 0
 
     def running(self):
         return self.is_running
+
+    def start(self):
+        self.start_calls += 1
+        self.is_running = True
+        return True
+
+
+class FakeVar:
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
 
 
 class LauncherReadinessTests(unittest.TestCase):
@@ -89,6 +104,55 @@ class LauncherReadinessTests(unittest.TestCase):
 
         launcher._open_dashboard.assert_called_once_with()
         self.assertEqual(launcher.root.after_calls, [])
+
+    def test_start_does_not_auto_open_host_browser_when_lan_is_enabled(self):
+        backend = FakeBackend(running=False)
+        launcher = self.make_launcher(backend)
+        launcher.ksp_root_var = FakeVar("")
+        launcher.lan_access_var = FakeVar(True)
+        launcher.lan_address_var = FakeVar("192.168.1.50")
+        launcher._enqueue = mock.Mock()
+        launcher._refresh_all_ksp_status = mock.Mock()
+        dashboard = mock.Mock()
+        dashboard.is_file.return_value = True
+
+        with (
+            mock.patch.object(
+                app,
+                "component_preflight",
+                return_value={"errors": [], "warnings": []},
+            ),
+            mock.patch.object(app, "DASHBOARD", dashboard),
+        ):
+            launcher._toggle(backend, open_dashboard=True)
+
+        self.assertEqual(backend.start_calls, 1)
+        self.assertEqual(launcher.root.after_calls, [])
+        self.assertIn("host browser was not opened", launcher._enqueue.call_args.args[1])
+
+    def test_start_still_auto_opens_loopback_when_lan_is_off(self):
+        backend = FakeBackend(running=False)
+        launcher = self.make_launcher(backend)
+        launcher.ksp_root_var = FakeVar("")
+        launcher.lan_access_var = FakeVar(False)
+        launcher.lan_address_var = FakeVar("")
+        launcher._enqueue = mock.Mock()
+        launcher._refresh_all_ksp_status = mock.Mock()
+        dashboard = mock.Mock()
+        dashboard.is_file.return_value = True
+
+        with (
+            mock.patch.object(
+                app,
+                "component_preflight",
+                return_value={"errors": [], "warnings": []},
+            ),
+            mock.patch.object(app, "DASHBOARD", dashboard),
+        ):
+            launcher._toggle(backend, open_dashboard=True)
+
+        self.assertEqual(backend.start_calls, 1)
+        self.assertEqual(launcher.root.after_calls[0][0], 250)
 
 
 if __name__ == "__main__":

--- a/tests/test_launcher_readiness.py
+++ b/tests/test_launcher_readiness.py
@@ -80,6 +80,16 @@ class LauncherReadinessTests(unittest.TestCase):
         self.assertEqual(row["status"].options["text"], "\u25cb stopped")
         self.assertFalse(backend.startup_ready)
 
+    def test_loopback_ready_opens_immediately_without_retry_timeout(self):
+        launcher = self.make_launcher(FakeBackend())
+        launcher._dashboard_ready = mock.Mock(return_value=True)
+        launcher._open_dashboard = mock.Mock()
+
+        launcher._open_dashboard_when_ready()
+
+        launcher._open_dashboard.assert_called_once_with()
+        self.assertEqual(launcher.root.after_calls, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_launcher_settings.py
+++ b/tests/test_launcher_settings.py
@@ -16,11 +16,22 @@ class LauncherSettingsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             path = Path(temp) / "settings.json"
             ksp_dashboard_app.save_settings(
-                {"ksp_root": "C:/Games/KSP", "lan_access_enabled": True}, path
+                {
+                    "ksp_root": "C:/Games/KSP",
+                    "lan_access_enabled": True,
+                    "lan_bind_address": "192.168.1.50",
+                    "lan_warning_ack_version": 1,
+                },
+                path,
             )
             self.assertEqual(
                 ksp_dashboard_app.load_settings(path),
-                {"ksp_root": "C:/Games/KSP", "lan_access_enabled": True},
+                {
+                    "ksp_root": "C:/Games/KSP",
+                    "lan_access_enabled": True,
+                    "lan_bind_address": "192.168.1.50",
+                    "lan_warning_ack_version": 1,
+                },
             )
             payload = json.loads(path.read_text(encoding="utf-8"))
             self.assertEqual(payload["ksp_root"], "C:/Games/KSP")
@@ -32,8 +43,39 @@ class LauncherSettingsTests(unittest.TestCase):
             path.write_text("[]", encoding="utf-8")
             self.assertEqual(
                 ksp_dashboard_app.load_settings(path),
-                {"ksp_root": "", "lan_access_enabled": False},
+                {
+                    "ksp_root": "",
+                    "lan_access_enabled": False,
+                    "lan_bind_address": "",
+                    "lan_warning_ack_version": 0,
+                },
             )
+
+    def test_old_settings_migrate_to_safe_lan_defaults(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "settings.json"
+            path.write_text(json.dumps({"ksp_root": " C:/KSP "}), encoding="utf-8")
+            self.assertEqual(
+                ksp_dashboard_app.load_settings(path),
+                {
+                    "ksp_root": "C:/KSP",
+                    "lan_access_enabled": False,
+                    "lan_bind_address": "",
+                    "lan_warning_ack_version": 0,
+                },
+            )
+
+    def test_invalid_warning_acknowledgement_versions_are_reset(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "settings.json"
+            for value in (True, -1, "1"):
+                path.write_text(
+                    json.dumps({"lan_warning_ack_version": value}), encoding="utf-8"
+                )
+                self.assertEqual(
+                    ksp_dashboard_app.load_settings(path)["lan_warning_ack_version"],
+                    0,
+                )
 
     def test_lan_access_enabled_requires_exact_bool_true(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -58,11 +100,18 @@ class LauncherSettingsTests(unittest.TestCase):
     def test_telemetry_environment_only_includes_valid_root(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
-            self.assertEqual(ksp_dashboard_app.telemetry_environment(str(root)), {})
+            self.assertEqual(
+                ksp_dashboard_app.telemetry_environment(str(root)),
+                {"WOOBIE_ALLOW_LAN": "0", "WOOBIE_LAN_BIND": ""},
+            )
             (root / "GameData").mkdir()
             self.assertEqual(
                 ksp_dashboard_app.telemetry_environment(str(root)),
-                {"WOOBIE_KSP_ROOT": str(root.resolve())},
+                {
+                    "WOOBIE_KSP_ROOT": str(root.resolve()),
+                    "WOOBIE_ALLOW_LAN": "0",
+                    "WOOBIE_LAN_BIND": "",
+                },
             )
 
     def test_telemetry_environment_includes_lan_flag_when_enabled(self):
@@ -70,16 +119,29 @@ class LauncherSettingsTests(unittest.TestCase):
             root = Path(temp)
             (root / "GameData").mkdir()
             self.assertEqual(
-                ksp_dashboard_app.telemetry_environment(str(root), True),
+                ksp_dashboard_app.telemetry_environment(
+                    str(root), True, "192.168.1.50"
+                ),
                 {
                     "WOOBIE_KSP_ROOT": str(root.resolve()),
                     "WOOBIE_ALLOW_LAN": "1",
+                    "WOOBIE_LAN_BIND": "192.168.1.50",
                 },
             )
             self.assertEqual(
-                ksp_dashboard_app.telemetry_environment("", True),
-                {"WOOBIE_ALLOW_LAN": "1"},
+                ksp_dashboard_app.telemetry_environment("", True, "10.2.3.4"),
+                {"WOOBIE_ALLOW_LAN": "1", "WOOBIE_LAN_BIND": "10.2.3.4"},
             )
+
+    def test_telemetry_environment_neutralizes_inherited_or_invalid_lan_state(self):
+        self.assertEqual(
+            ksp_dashboard_app.telemetry_environment("", False, "192.168.1.50"),
+            {"WOOBIE_ALLOW_LAN": "0", "WOOBIE_LAN_BIND": "192.168.1.50"},
+        )
+        self.assertEqual(
+            ksp_dashboard_app.telemetry_environment("", True, "8.8.8.8"),
+            {"WOOBIE_ALLOW_LAN": "0", "WOOBIE_LAN_BIND": ""},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_launcher_settings.py
+++ b/tests/test_launcher_settings.py
@@ -15,19 +15,36 @@ class LauncherSettingsTests(unittest.TestCase):
     def test_settings_round_trip(self):
         with tempfile.TemporaryDirectory() as temp:
             path = Path(temp) / "settings.json"
-            ksp_dashboard_app.save_settings({"ksp_root": "C:/Games/KSP"}, path)
+            ksp_dashboard_app.save_settings(
+                {"ksp_root": "C:/Games/KSP", "lan_access_enabled": True}, path
+            )
             self.assertEqual(
                 ksp_dashboard_app.load_settings(path),
-                {"ksp_root": "C:/Games/KSP"},
+                {"ksp_root": "C:/Games/KSP", "lan_access_enabled": True},
             )
             payload = json.loads(path.read_text(encoding="utf-8"))
             self.assertEqual(payload["ksp_root"], "C:/Games/KSP")
+            self.assertIs(payload["lan_access_enabled"], True)
 
     def test_invalid_settings_fall_back_to_empty_root(self):
         with tempfile.TemporaryDirectory() as temp:
             path = Path(temp) / "settings.json"
             path.write_text("[]", encoding="utf-8")
-            self.assertEqual(ksp_dashboard_app.load_settings(path), {"ksp_root": ""})
+            self.assertEqual(
+                ksp_dashboard_app.load_settings(path),
+                {"ksp_root": "", "lan_access_enabled": False},
+            )
+
+    def test_lan_access_enabled_requires_exact_bool_true(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "settings.json"
+            path.write_text(
+                json.dumps({"ksp_root": "", "lan_access_enabled": "yes"}),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                ksp_dashboard_app.load_settings(path)["lan_access_enabled"], False
+            )
 
     def test_ksp_root_requires_gamedata(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -46,6 +63,22 @@ class LauncherSettingsTests(unittest.TestCase):
             self.assertEqual(
                 ksp_dashboard_app.telemetry_environment(str(root)),
                 {"WOOBIE_KSP_ROOT": str(root.resolve())},
+            )
+
+    def test_telemetry_environment_includes_lan_flag_when_enabled(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "GameData").mkdir()
+            self.assertEqual(
+                ksp_dashboard_app.telemetry_environment(str(root), True),
+                {
+                    "WOOBIE_KSP_ROOT": str(root.resolve()),
+                    "WOOBIE_ALLOW_LAN": "1",
+                },
+            )
+            self.assertEqual(
+                ksp_dashboard_app.telemetry_environment("", True),
+                {"WOOBIE_ALLOW_LAN": "1"},
             )
 
 

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -374,7 +374,7 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertNotIn("Next release candidate", readme)
         self.assertNotIn("v0.7.4 release candidate", readme)
 
-    def test_only_react_loopback_runtime_is_supported(self):
+    def test_react_runtime_keeps_loopback_and_supports_opt_in_lan(self):
         self.assertFalse((ROOT / "ksp_mission_dashboard.html").exists())
         self.assertFalse((ROOT / "Start React POC.bat").exists())
         self.assertFalse((ROOT / "Stop React POC.bat").exists())
@@ -385,7 +385,14 @@ class ReleaseContractTests(unittest.TestCase):
         telemetry = (ROOT / "telemetry_server.py").read_text(encoding="utf-8")
         self.assertIn('DASHBOARD = HERE / "web" / "index.html"', launcher)
         self.assertIn('DASHBOARD_URL = "http://127.0.0.1:8090/"', launcher)
-        self.assertIn('DASHBOARD_WEB_ROOT = Path(__file__).resolve().parent / "web"', telemetry)
+        self.assertIn('environment["WOOBIE_ALLOW_LAN"]', launcher)
+        self.assertIn('environment["WOOBIE_LAN_BIND"]', launcher)
+        self.assertIn(
+            'DASHBOARD_WEB_ROOT = Path(__file__).resolve().parent / "web"', telemetry
+        )
+        self.assertIn(
+            'run_telemetry_server(loopback_host, port, lan_host)', telemetry
+        )
 
     def test_managed_frontend_server_uses_the_configured_vite_port(self):
         dev_script = (ROOT / "scripts" / "dashboard-dev.ps1").read_text(
@@ -568,6 +575,27 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertEqual(
             publish_script.count("Sort-CanonicalManifestPaths $"),
             2,
+        )
+
+    def test_lan_launcher_server_and_frontend_ship_in_one_managed_update(self):
+        publish_script = (ROOT / "tools" / "Publish-Release.ps1").read_text(
+            encoding="utf-8"
+        )
+        update_contract = json.loads(
+            (ROOT / "runtime-update-contract.json").read_text(encoding="utf-8")
+        )
+        for source in (
+            "ksp_dashboard_app.py",
+            "telemetry_runtime.py",
+            "telemetry_server.py",
+        ):
+            self.assertIn(
+                f"@{{ Source = '{source}'; Destination = 'Dashboard/{source}' }}",
+                publish_script,
+            )
+        self.assertIn(".py", update_contract["dashboard_top_level_extensions"])
+        self.assertEqual(
+            update_contract["dashboard_web_index"], "Dashboard/web/index.html"
         )
         self.assertIn("$Left.ToLowerInvariant()", publish_script)
         self.assertIn("$Right.ToLowerInvariant()", publish_script)

--- a/tests/test_telemetry_runtime.py
+++ b/tests/test_telemetry_runtime.py
@@ -24,6 +24,81 @@ class TelemetryRuntimeTests(unittest.TestCase):
         self.assertFalse(runtime.allowed_host_header("localhost:8090", "127.0.0.1", 8090))
         self.assertFalse(runtime.allowed_host_header("attacker.example", "127.0.0.1", 8090))
 
+    def test_is_local_network_address_accepts_loopback_and_rfc1918(self):
+        for address in (
+            "127.0.0.1",
+            "10.1.2.3",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.1.1",
+        ):
+            self.assertTrue(runtime.is_local_network_address(address), address)
+
+    def test_is_local_network_address_rejects_non_private(self):
+        for address in (
+            "172.32.0.1",
+            "8.8.8.8",
+            "169.254.1.1",
+            "0.0.0.0",
+            "not-an-ip",
+            "",
+        ):
+            self.assertFalse(runtime.is_local_network_address(address), address)
+
+    def test_bind_host_allowed(self):
+        self.assertTrue(runtime.bind_host_allowed("127.0.0.1"))
+        self.assertTrue(runtime.bind_host_allowed("192.168.1.50"))
+        self.assertFalse(runtime.bind_host_allowed("0.0.0.0"))
+        self.assertFalse(runtime.bind_host_allowed("localhost"))
+        self.assertFalse(runtime.bind_host_allowed("8.8.8.8"))
+
+    def test_remote_address_allowed(self):
+        self.assertTrue(runtime.remote_address_allowed(("127.0.0.1", 54321)))
+        self.assertTrue(runtime.remote_address_allowed(("192.168.1.5", 54321)))
+        self.assertFalse(runtime.remote_address_allowed(("8.8.8.8", 54321)))
+        self.assertFalse(runtime.remote_address_allowed(None))
+        self.assertFalse(runtime.remote_address_allowed(()))
+
+    def test_detect_lan_address_returns_private_candidate(self):
+        class FakeSocket:
+            def settimeout(self, _value):
+                pass
+
+            def connect(self, _address):
+                pass
+
+            def getsockname(self):
+                return ("192.168.50.7", 0)
+
+            def close(self):
+                pass
+
+        self.assertEqual(
+            runtime.detect_lan_address(probe_factory=FakeSocket), "192.168.50.7"
+        )
+
+    def test_detect_lan_address_rejects_non_private_result(self):
+        class FakeSocket:
+            def settimeout(self, _value):
+                pass
+
+            def connect(self, _address):
+                pass
+
+            def getsockname(self):
+                return ("8.8.8.8", 0)
+
+            def close(self):
+                pass
+
+        self.assertIsNone(runtime.detect_lan_address(probe_factory=FakeSocket))
+
+    def test_detect_lan_address_returns_none_on_socket_error(self):
+        def failing_factory():
+            raise OSError("no network")
+
+        self.assertIsNone(runtime.detect_lan_address(probe_factory=failing_factory))
+
     def test_planner_wire_events_preserve_status_revision_and_request(self):
         with tempfile.TemporaryDirectory() as temporary:
             store = PlannerPersistence(Path(temporary) / "mission_planning.json")
@@ -88,6 +163,7 @@ class TelemetryRuntimeTests(unittest.TestCase):
         source = (ROOT / "telemetry_runtime.py").read_text(encoding="utf-8")
         for marker in (
             "origins=[origin, None]",
+            'logging.getLogger("websockets.server").setLevel(logging.CRITICAL)',
             "Content-Security-Policy",
             "Queue(maxsize=MAX_PENDING_COMMANDS)",
             "sessions.get(ws) != session_id",

--- a/tests/test_telemetry_runtime.py
+++ b/tests/test_telemetry_runtime.py
@@ -1,9 +1,12 @@
 import importlib.util
+import json
 import sys
 import tempfile
 import unittest
 from http import HTTPStatus
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -263,6 +266,157 @@ class TelemetryRuntimeTests(unittest.TestCase):
         self.assertFalse(server("127.0.0.1", 8090, ("0.0.0.0",)))
         self.assertFalse(server("127.0.0.1", 8090, ("8.8.8.8",)))
         self.assertEqual(connections, [])
+
+    def test_dual_listeners_bind_before_krpc_and_share_security_and_commands(self):
+        registrations = []
+        applied_commands = []
+        connection_calls = []
+        handler_exercised = False
+        real_asyncio_sleep = runtime.asyncio.sleep
+
+        class FakeSocket:
+            def __init__(self):
+                self.messages = [
+                    json.dumps(
+                        {
+                            "type": "overview.vessel.lifecycle",
+                            "requestId": "lan-command-1",
+                        }
+                    )
+                ]
+                self.release = runtime.asyncio.Event()
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.messages:
+                    return self.messages.pop(0)
+                await self.release.wait()
+                raise StopAsyncIteration
+
+            async def send(self, _payload):
+                pass
+
+        class FakeServerContext:
+            def __init__(self, registration):
+                self.registration = registration
+                self.socket = None
+                self.handler_task = None
+
+            async def __aenter__(self):
+                nonlocal handler_exercised
+                if not handler_exercised:
+                    handler_exercised = True
+                    self.socket = FakeSocket()
+                    self.handler_task = runtime.asyncio.create_task(
+                        self.registration["handler"](self.socket)
+                    )
+                    await real_asyncio_sleep(0)
+                return self
+
+            async def __aexit__(self, _exc_type, _exc, _traceback):
+                if self.handler_task is not None:
+                    self.socket.release.set()
+                    await self.handler_task
+                return False
+
+        def fake_serve(handler, host, port, **options):
+            registration = {
+                "handler": handler,
+                "host": host,
+                "port": port,
+                **options,
+            }
+            registrations.append(registration)
+            return FakeServerContext(registration)
+
+        def connect(name):
+            connection_calls.append((name, len(registrations)))
+            return "shared-krpc"
+
+        def apply_command(connection, command):
+            applied_commands.append((connection, command))
+            return {"type": "command.accepted"}
+
+        async def stop_after_first_cycle(_interval):
+            raise RuntimeError("stop integration server")
+
+        def baseline(_target, _root=None):
+            return HTTPStatus.OK, "text/html", "no-cache", b"dashboard"
+
+        class FakeStore:
+            path = Path("test-planner-store.json")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            web_root = Path(temporary)
+            (web_root / "index.html").write_text("dashboard", encoding="utf-8")
+            _asset, server = runtime.create_telemetry_runtime(
+                baseline,
+                connect,
+                lambda _conn: {},
+                apply_command,
+                web_root,
+                4,
+            )
+            with (
+                mock.patch("websockets.serve", side_effect=fake_serve),
+                mock.patch.object(runtime.asyncio, "sleep", stop_after_first_cycle),
+                mock.patch.object(runtime, "PlannerPersistence", return_value=FakeStore()),
+            ):
+                self.assertFalse(server("127.0.0.1", 8090, ("192.168.1.50",)))
+
+        self.assertEqual(
+            [(item["host"], item["port"]) for item in registrations],
+            [("127.0.0.1", 8090), ("192.168.1.50", 8090)],
+        )
+        self.assertIs(registrations[0]["handler"], registrations[1]["handler"])
+        self.assertEqual(connection_calls, [("KSP Dashboard Telemetry", 2)])
+        self.assertEqual(applied_commands[0][0], "shared-krpc")
+        self.assertEqual(
+            applied_commands[0][1]["type"], "overview.vessel.lifecycle"
+        )
+
+        loopback_policy = registrations[0]["process_request"]
+        lan_policy = registrations[1]["process_request"]
+
+        def websocket_request(host, origin):
+            return SimpleNamespace(
+                headers={"Host": host, "Upgrade": "websocket", "Origin": origin},
+                path="/",
+            )
+
+        self.assertIsNone(
+            loopback_policy(
+                SimpleNamespace(remote_address=("127.0.0.1", 5000)),
+                websocket_request(
+                    "127.0.0.1:8090", "http://127.0.0.1:8090"
+                ),
+            )
+        )
+        self.assertIsNone(
+            lan_policy(
+                SimpleNamespace(remote_address=("192.168.1.25", 5000)),
+                websocket_request(
+                    "192.168.1.50:8090", "http://192.168.1.50:8090"
+                ),
+            )
+        )
+        rejected_peer = loopback_policy(
+            SimpleNamespace(remote_address=("192.168.1.25", 5000)),
+            websocket_request("127.0.0.1:8090", "http://127.0.0.1:8090"),
+        )
+        rejected_host = lan_policy(
+            SimpleNamespace(remote_address=("192.168.1.25", 5000)),
+            websocket_request("127.0.0.1:8090", "http://192.168.1.50:8090"),
+        )
+        rejected_origin = lan_policy(
+            SimpleNamespace(remote_address=("192.168.1.25", 5000)),
+            websocket_request("192.168.1.50:8090", "http://127.0.0.1:8090"),
+        )
+        self.assertEqual(rejected_peer.status_code, HTTPStatus.FORBIDDEN)
+        self.assertEqual(rejected_host.status_code, HTTPStatus.FORBIDDEN)
+        self.assertEqual(rejected_origin.status_code, HTTPStatus.FORBIDDEN)
 
     def test_packaged_server_source_contains_origin_csp_and_session_guards(self):
         source = (ROOT / "telemetry_runtime.py").read_text(encoding="utf-8")

--- a/tests/test_telemetry_runtime.py
+++ b/tests/test_telemetry_runtime.py
@@ -18,6 +18,15 @@ spec.loader.exec_module(runtime)
 from planner_persistence import PlannerPersistence
 
 
+class FakeLogRecord:
+    def __init__(self, message, exc_info):
+        self._message = message
+        self.exc_info = exc_info
+
+    def getMessage(self):
+        return self._message
+
+
 class TelemetryRuntimeTests(unittest.TestCase):
     def test_canonical_host_validation_is_exact(self):
         self.assertTrue(runtime.allowed_host_header("127.0.0.1:8090", "127.0.0.1", 8090))
@@ -99,6 +108,33 @@ class TelemetryRuntimeTests(unittest.TestCase):
 
         self.assertIsNone(runtime.detect_lan_address(probe_factory=failing_factory))
 
+    def test_is_handshake_noise_ignores_unrelated_messages(self):
+        record = FakeLogRecord("connection handler failed", (EOFError, EOFError(), None))
+        self.assertFalse(runtime.is_handshake_noise(record))
+
+    def test_is_handshake_noise_ignores_records_without_exception(self):
+        record = FakeLogRecord("opening handshake failed", None)
+        self.assertFalse(runtime.is_handshake_noise(record))
+
+    def test_is_handshake_noise_matches_eof_during_handshake(self):
+        record = FakeLogRecord("opening handshake failed", (EOFError, EOFError(), None))
+        self.assertTrue(runtime.is_handshake_noise(record))
+
+    def test_is_handshake_noise_matches_invalid_message(self):
+        from websockets.exceptions import InvalidMessage
+
+        record = FakeLogRecord(
+            "opening handshake failed",
+            (InvalidMessage, InvalidMessage("did not receive a valid HTTP request"), None),
+        )
+        self.assertTrue(runtime.is_handshake_noise(record))
+
+    def test_is_handshake_noise_leaves_genuine_errors_visible(self):
+        record = FakeLogRecord(
+            "opening handshake failed", (ValueError, ValueError("boom"), None)
+        )
+        self.assertFalse(runtime.is_handshake_noise(record))
+
     def test_planner_wire_events_preserve_status_revision_and_request(self):
         with tempfile.TemporaryDirectory() as temporary:
             store = PlannerPersistence(Path(temporary) / "mission_planning.json")
@@ -163,7 +199,7 @@ class TelemetryRuntimeTests(unittest.TestCase):
         source = (ROOT / "telemetry_runtime.py").read_text(encoding="utf-8")
         for marker in (
             "origins=[origin, None]",
-            'logging.getLogger("websockets.server").setLevel(logging.CRITICAL)',
+            'logging.getLogger("websockets.server").addFilter(_HandshakeNoiseFilter())',
             "Content-Security-Policy",
             "Queue(maxsize=MAX_PENDING_COMMANDS)",
             "sessions.get(ws) != session_id",

--- a/tests/test_telemetry_runtime.py
+++ b/tests/test_telemetry_runtime.py
@@ -33,6 +33,19 @@ class TelemetryRuntimeTests(unittest.TestCase):
         self.assertFalse(runtime.allowed_host_header("localhost:8090", "127.0.0.1", 8090))
         self.assertFalse(runtime.allowed_host_header("attacker.example", "127.0.0.1", 8090))
 
+    def test_origin_validation_is_listener_specific(self):
+        self.assertTrue(runtime.allowed_origin_header(None, "192.168.1.50", 8090))
+        self.assertTrue(
+            runtime.allowed_origin_header(
+                "http://192.168.1.50:8090", "192.168.1.50", 8090
+            )
+        )
+        self.assertFalse(
+            runtime.allowed_origin_header(
+                "http://127.0.0.1:8090", "192.168.1.50", 8090
+            )
+        )
+
     def test_is_local_network_address_accepts_loopback_and_rfc1918(self):
         for address in (
             "127.0.0.1",
@@ -67,6 +80,23 @@ class TelemetryRuntimeTests(unittest.TestCase):
         self.assertFalse(runtime.remote_address_allowed(("8.8.8.8", 54321)))
         self.assertFalse(runtime.remote_address_allowed(None))
         self.assertFalse(runtime.remote_address_allowed(()))
+
+    def test_remote_address_must_match_listener_class(self):
+        self.assertTrue(
+            runtime.remote_address_allowed(("127.0.0.1", 5000), "127.0.0.1")
+        )
+        self.assertFalse(
+            runtime.remote_address_allowed(("192.168.1.20", 5000), "127.0.0.1")
+        )
+        self.assertTrue(
+            runtime.remote_address_allowed(("192.168.1.20", 5000), "192.168.1.50")
+        )
+        self.assertFalse(
+            runtime.remote_address_allowed(("127.0.0.1", 5000), "192.168.1.50")
+        )
+        self.assertFalse(
+            runtime.remote_address_allowed(("8.8.8.8", 5000), "192.168.1.50")
+        )
 
     def test_detect_lan_address_returns_private_candidate(self):
         class FakeSocket:
@@ -107,6 +137,25 @@ class TelemetryRuntimeTests(unittest.TestCase):
             raise OSError("no network")
 
         self.assertIsNone(runtime.detect_lan_address(probe_factory=failing_factory))
+
+    def test_detect_lan_addresses_prioritizes_route_and_deduplicates(self):
+        self.assertEqual(
+            runtime.detect_lan_addresses(
+                route_detector=lambda: "192.168.1.50",
+                hostname_factory=lambda: "host",
+                hostname_resolver=lambda _host: (
+                    "host",
+                    [],
+                    ["10.10.0.4", "192.168.1.50", "127.0.0.1", "8.8.8.8"],
+                ),
+            ),
+            ("192.168.1.50", "10.10.0.4"),
+        )
+
+    def test_private_lan_predicate_rejects_loopback_wildcard_public_and_ipv6(self):
+        self.assertTrue(runtime.is_private_lan_address("172.20.1.5"))
+        for address in ("127.0.0.1", "0.0.0.0", "8.8.8.8", "::1"):
+            self.assertFalse(runtime.is_private_lan_address(address), address)
 
     def test_is_handshake_noise_ignores_unrelated_messages(self):
         record = FakeLogRecord("connection handler failed", (EOFError, EOFError(), None))
@@ -195,10 +244,33 @@ class TelemetryRuntimeTests(unittest.TestCase):
         self.assertEqual(dashboard_asset("/assets/config.js")[2], "no-cache")
         self.assertEqual(dashboard_asset("/config.json")[2], "no-cache")
 
+    def test_server_requires_loopback_primary_and_private_additional_hosts(self):
+        connections = []
+
+        def baseline(_target, _root=None):
+            return HTTPStatus.OK, "text/html", "no-cache", b"ok"
+
+        _dashboard_asset, server = runtime.create_telemetry_runtime(
+            baseline,
+            lambda name: connections.append(name),
+            lambda _conn: {},
+            lambda _conn, _command: None,
+            ROOT / "web",
+            4,
+        )
+
+        self.assertFalse(server("192.168.1.50", 8090))
+        self.assertFalse(server("127.0.0.1", 8090, ("0.0.0.0",)))
+        self.assertFalse(server("127.0.0.1", 8090, ("8.8.8.8",)))
+        self.assertEqual(connections, [])
+
     def test_packaged_server_source_contains_origin_csp_and_session_guards(self):
         source = (ROOT / "telemetry_runtime.py").read_text(encoding="utf-8")
         for marker in (
             "origins=[origin, None]",
+            "AsyncExitStack",
+            "remote_address_allowed(",
+            "allowed_origin_header(",
             'logging.getLogger("websockets.server").addFilter(_HandshakeNoiseFilter())',
             "Content-Security-Policy",
             "Queue(maxsize=MAX_PENDING_COMMANDS)",

--- a/tests/test_update_changelog.py
+++ b/tests/test_update_changelog.py
@@ -1,3 +1,4 @@
+import queue
 import sys
 import time
 import unittest
@@ -25,11 +26,11 @@ class UpdateAndChangelogTests(unittest.TestCase):
     def test_initial_window_size_is_roomy_and_screen_bounded(self):
         self.assertEqual(
             app.calculate_initial_window_size(2560, 1440, 706, 801),
-            (960, 820),
+            (1360, 860),
         )
         self.assertEqual(
             app.calculate_initial_window_size(1366, 768, 706, 801),
-            (960, 648),
+            (1286, 648),
         )
         self.assertEqual(
             app.calculate_initial_window_size(800, 600, 706, 801),
@@ -37,10 +38,50 @@ class UpdateAndChangelogTests(unittest.TestCase):
         )
 
     def test_initial_launcher_panes_favor_controls_and_preserve_log(self):
-        self.assertEqual(app.calculate_initial_pane_sash(700), 518)
-        self.assertEqual(app.calculate_initial_pane_sash(400), 280)
-        self.assertEqual(app.calculate_initial_pane_sash(300), 180)
+        self.assertEqual(app.calculate_initial_pane_sash(700), 504)
+        self.assertEqual(app.calculate_initial_pane_sash(400), 250)
+        self.assertEqual(app.calculate_initial_pane_sash(300), 150)
         self.assertEqual(app.calculate_initial_pane_sash(100), 0)
+
+    def test_launcher_log_filters_keep_sources_and_warning_focus(self):
+        records = [
+            ("feed", "telemetry ready", False),
+            ("preflight", "kRPC port refused the connection", True),
+            ("updates", "up to date", False),
+        ]
+        self.assertEqual(
+            app.filter_launcher_log_records(records, "feed"),
+            [records[0]],
+        )
+        self.assertEqual(
+            app.filter_launcher_log_records(records, "preflight"),
+            [records[1]],
+        )
+        self.assertEqual(
+            app.filter_launcher_log_records(records, "warnings"),
+            [records[1]],
+        )
+        self.assertEqual(
+            app.filter_launcher_log_records(records, "all"),
+            records,
+        )
+        self.assertTrue(
+            app.is_launcher_log_warning(
+                "feed", "WARNING: LAN access has no authentication"
+            )
+        )
+        self.assertFalse(
+            app.is_launcher_log_warning("preflight", "live kRPC test passed")
+        )
+
+    def test_launcher_enqueue_preserves_structured_source_and_message(self):
+        launcher = app.App.__new__(app.App)
+        launcher.log_queue = queue.Queue()
+        launcher._enqueue("feed", "telemetry ready")
+        self.assertEqual(
+            launcher.log_queue.get_nowait(),
+            ("feed", "telemetry ready"),
+        )
 
     def test_mousewheel_delta_normalizes_for_tk_scrolling(self):
         self.assertEqual(app.normalize_mousewheel_units(120), -1)


### PR DESCRIPTION
## Credit

Original LAN support proposal and initial implementation by @deltwalrus. The original commits retain their contributor authorship; the subsequent security, launcher, validation, and release-path revisions were completed by @SacredWoobie.

## What changed

- Keeps `127.0.0.1:8090` available for the launcher and local browser at all times.
- Adds an opt-in second listener on a user-selected active RFC1918 IPv4 address.
- Discovers active private addresses, preselects the routed default, and provides Refresh and Copy LAN URL actions.
- Requires a detailed **Enable trusted-LAN dashboard access?** warning when LAN access transitions from off to on.
- Explains that LAN access has no authentication or encryption and exposes telemetry, finances, contracts, notes, vessel information, and every dashboard command.
- Keeps the warning's remember checkbox off by default and persists a versioned acknowledgement only after successful confirmation.
- Stops a running feed immediately when LAN enablement or address changes so visible settings cannot differ from the active listeners.
- Leaves the host browser closed when starting with LAN enabled; explicit **Open dashboard** still opens loopback.
- Uses simultaneous loopback/LAN listeners with listener-specific peer, Host, and Origin checks.
- Rejects wildcard/public/stale/unavailable binds and public peers, while preserving same-origin WebSocket resolution.
- Explicitly sets `WOOBIE_ALLOW_LAN` and `WOOBIE_LAN_BIND` so inherited environment values cannot override visible settings.
- Does not create firewall rules automatically; documentation covers Windows Private-network firewall setup and the trusted-network security boundary.

## Launcher and compatibility follow-up

The launcher was reorganized into a responsive two-column workbench with paired compatibility/service status, a compact live-kRPC card, and a larger filterable Mission Log. The optional Notes integration is now identified as **zer0Kerbal's Notes (Kollege Ruled)** and reports whether its detected version matches tested v0.17.0.0.

## Security boundary

This is intentionally full, unauthenticated LAN control for trusted private networks. Authentication, TLS, internet exposure, IPv6, automatic firewall changes, telemetry-schema changes, and service-DLL changes remain out of scope.

## Validation

- 495 Python tests pass.
- Frontend CSS contract, 516 Vitest tests, strict TypeScript checking, and production build pass.
- Independent PR-readiness audit found no code-level blocker; the subsequent commit only canonicalizes a Windows test path.
- Windows live Flight acceptance passed on the host and a second LAN device, with simultaneous local/LAN telemetry and schema parity.
- Responsive launcher screenshot accepted.
- Multi-NIC acceptance was explicitly waived for this release.

Both hosted CI jobs pass on revised head `89cc89c`. Fresh-package, managed v0.7.4 update, rollback, and final Windows firewall behavior remain release-candidate gates.